### PR TITLE
Issue #662: WMI unsigned 32-bit integers incorrectly converted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
 			<dependency>
 				<groupId>org.metricshub</groupId>
 				<artifactId>wmi-java</artifactId>
-				<version>1.0.03</version>
+				<version>1.0.05</version>
 			</dependency>
 			<dependency>
 				<groupId>org.metricshub</groupId>


### PR DESCRIPTION
- Bump `wmi-java` version from 1.0.03 to 1.0.05
---
Tests
**before fix**
![image](https://github.com/user-attachments/assets/e308d0a3-da79-475a-b166-f250b3c0ca81)
**after fix**
![image](https://github.com/user-attachments/assets/027b7982-8c24-49b7-a897-0c6311c503ee)

Thanks for the library fix @bertysentry! 