### PR TITLE
Issue #693: Fix monitor names that are generated for non-Hardware monitors

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/task/MonitoringTask.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/task/MonitoringTask.java
@@ -130,7 +130,7 @@ public class MonitoringTask implements Runnable {
 			new CollectStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
 			new SimpleStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
 			new HardwarePostCollectStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
-			new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager)
+			new HardwareMonitorNameGenerationStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager)
 		);
 
 		// Run the hardware strategy

--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/task/MonitoringTask.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/task/MonitoringTask.java
@@ -55,6 +55,7 @@ import org.metricshub.engine.telemetry.MetricFactory;
 import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.engine.telemetry.metric.AbstractMetric;
+import org.metricshub.hardware.strategy.HardwareMonitorNameGenerationStrategy;
 import org.metricshub.hardware.strategy.HardwarePostCollectStrategy;
 import org.metricshub.hardware.strategy.HardwarePostDiscoveryStrategy;
 import org.metricshub.hardware.strategy.HardwareStrategy;
@@ -100,7 +101,8 @@ public class MonitoringTask implements Runnable {
 				new DetectionStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager),
 				new DiscoveryStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager),
 				new SimpleStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager),
-				new HardwarePostDiscoveryStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager)
+				new HardwarePostDiscoveryStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager),
+				new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager)
 			);
 
 			/*
@@ -127,7 +129,8 @@ public class MonitoringTask implements Runnable {
 			new ProtocolHealthCheckStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
 			new CollectStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
 			new SimpleStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
-			new HardwarePostCollectStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager)
+			new HardwarePostCollectStrategy(telemetryManager, collectTime, clientsExecutor, extensionManager),
+			new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager)
 		);
 
 		// Run the hardware strategy

--- a/metricshub-agent/src/test/java/org/metricshub/agent/service/task/MonitoringTaskTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/service/task/MonitoringTaskTest.java
@@ -60,6 +60,7 @@ import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.MonitorFactory;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.extension.snmp.SnmpConfiguration;
+import org.metricshub.hardware.strategy.HardwareMonitorNameGenerationStrategy;
 import org.metricshub.hardware.strategy.HardwarePostCollectStrategy;
 import org.metricshub.hardware.strategy.HardwarePostDiscoveryStrategy;
 import org.mockito.InjectMocks;
@@ -145,7 +146,8 @@ class MonitoringTaskTest {
 				any(DetectionStrategy.class),
 				any(DiscoveryStrategy.class),
 				any(SimpleStrategy.class),
-				any(HardwarePostDiscoveryStrategy.class)
+				any(HardwarePostDiscoveryStrategy.class),
+				any(HardwareMonitorNameGenerationStrategy.class)
 			);
 		verify(telemetryManagerMock, times(4))
 			.run(
@@ -153,7 +155,8 @@ class MonitoringTaskTest {
 				any(ProtocolHealthCheckStrategy.class),
 				any(CollectStrategy.class),
 				any(SimpleStrategy.class),
-				any(HardwarePostCollectStrategy.class)
+				any(HardwarePostCollectStrategy.class),
+				any(HardwareMonitorNameGenerationStrategy.class)
 			);
 	}
 

--- a/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java
+++ b/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java
@@ -48,6 +48,9 @@ import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.hardware.util.MonitorNameBuilder;
 
+/**
+ * Strategy responsible for executing monitor name generation for hardware monitors.
+ */
 @Slf4j
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)

--- a/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java
+++ b/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java
@@ -21,75 +21,48 @@ package org.metricshub.hardware.strategy;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
-import static org.metricshub.hardware.constants.CommonConstants.PRESENT_STATUS;
+import static org.metricshub.hardware.constants.CommonConstants.ID_COUNT;
 import static org.metricshub.hardware.util.HwCollectHelper.connectorHasHardwareTag;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.metricshub.engine.client.ClientsExecutor;
-import org.metricshub.engine.common.helpers.KnownMonitorType;
+import org.metricshub.engine.common.helpers.MetricsHubConstants;
 import org.metricshub.engine.extension.ExtensionManager;
 import org.metricshub.engine.strategy.AbstractStrategy;
-import org.metricshub.engine.telemetry.MetricFactory;
 import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.hardware.util.MonitorNameBuilder;
 
-/**
- * Strategy responsible for executing post-discovery actions for hardware monitors.<br>
- * This strategy is responsible for checking the presence of hardware monitors in the {@link TelemetryManager} and should be executed after the discovery phase.
- */
 @Slf4j
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class HardwarePostDiscoveryStrategy extends AbstractStrategy {
+public class HardwareMonitorNameGenerationStrategy extends AbstractStrategy {
 
 	/**
-	 * Set of monitor types that should be excluded from hardware missing device detection.
-	 */
-	private static final Set<String> EXCLUDED_MONITOR_TYPES = Stream
-		.of(
-			KnownMonitorType.HOST.getKey(),
-			KnownMonitorType.CONNECTOR.getKey(),
-			KnownMonitorType.LUN.getKey(),
-			KnownMonitorType.LOGICAL_DISK.getKey(),
-			KnownMonitorType.VOLTAGE.getKey(),
-			KnownMonitorType.TEMPERATURE.getKey(),
-			KnownMonitorType.VM.getKey(),
-			KnownMonitorType.LED.getKey()
-		)
-		.collect(Collectors.toSet());
-
-	/**
-	 * Set of monitor types that are candidates for hardware missing device.
-	 */
-	private static final Set<String> MONITOR_TYPE_CANDIDATES = KnownMonitorType.KEYS
-		.stream()
-		.filter(type -> !EXCLUDED_MONITOR_TYPES.contains(type))
-		.collect(Collectors.toSet());
-
-	/**
-	 * Create a new instance of {@link HardwarePostDiscoveryStrategy}.<br>
-	 * This strategy is responsible for checking the presence of hardware monitors in the {@link TelemetryManager} and should be executed after the discovery phase.
+	 * Create a new instance of {@link HardwareMonitorNameGenerationStrategy}.<br>
+	 * This strategy is responsible for monitor name attribute generation.
 	 *
 	 * @param telemetryManager The {@link TelemetryManager} instance wrapping the connector monitors.
 	 * @param strategyTime     The strategy time (Discovery time).
 	 * @param clientsExecutor  The {@link ClientsExecutor} instance.
 	 * @param extensionManager The {@link ExtensionManager} instance.
 	 */
-	public HardwarePostDiscoveryStrategy(
+	public HardwareMonitorNameGenerationStrategy(
 		@NonNull final TelemetryManager telemetryManager,
 		@NonNull final Long strategyTime,
 		@NonNull final ClientsExecutor clientsExecutor,
@@ -98,56 +71,73 @@ public class HardwarePostDiscoveryStrategy extends AbstractStrategy {
 		super(telemetryManager, strategyTime, clientsExecutor, extensionManager);
 	}
 
-	/**
-	 * Sets the current monitor as missing.
-	 *
-	 * @param monitor A given monitor
-	 * @param hostname The host's name
-	 * @param metricName The collected metric name
-	 */
-	public void setAsMissing(final Monitor monitor, final String hostname, final String metricName) {
-		new MetricFactory(hostname).collectNumberMetric(monitor, metricName, 0.0, strategyTime);
-	}
-
-	/**
-	 * Sets the current monitor as present
-	 * @param monitor A given monitor
-	 * @param hostname The host's name
-	 * @param metricName The collected metric name
-	 */
-	public void setAsPresent(final Monitor monitor, final String hostname, final String metricName) {
-		new MetricFactory(hostname).collectNumberMetric(monitor, metricName, 1.0, strategyTime);
-	}
-
-	/**
-	 * Checks whether a monitor is a candidate for hardware missing device detection.
-	 *
-	 * @param monitorType A given monitor's type
-	 * @return boolean Whether the monitor is a candidate for hardware missing device detection.
-	 */
-	private boolean isCandidateMonitorType(final String monitorType) {
-		return MONITOR_TYPE_CANDIDATES.contains(monitorType);
-	}
-
 	@Override
-	public final void run() {
-		// Filter monitors, set present/missing metrics
+	public void run() {
+		setMonitorsNames();
+	}
+
+	/**
+	 * Iterates all monitors from the telemetry manager, groups them by connector ID and type,
+	 * computes a hash-based sequence number (idCount) within each group, and assigns it as an attribute.
+	 * If a monitor has no name, generates one via buildMonitorNameUsingType method.
+	 */
+	private void setMonitorsNames() {
+		// Prepare hash storage per connector and type
+		final Map<String, Map<String, Map<String, Monitor>>> hashesByConnector = new HashMap<>();
+
 		telemetryManager
 			.getMonitors()
 			.values()
 			.stream()
 			.map(Map::values)
 			.flatMap(Collection::stream)
-			.filter(monitor -> isCandidateMonitorType(monitor.getType()))
 			.filter(telemetryManager::isConnectorStatusOk)
 			.filter(monitor -> connectorHasHardwareTag(monitor, telemetryManager))
-			.forEach(monitor -> {
-				if (!strategyTime.equals(monitor.getDiscoveryTime())) {
-					setAsMissing(monitor, telemetryManager.getHostname(), String.format(PRESENT_STATUS, monitor.getType()));
-				} else {
-					setAsPresent(monitor, telemetryManager.getHostname(), String.format(PRESENT_STATUS, monitor.getType()));
+			.forEach((Monitor monitor) -> {
+				// Look up the true connectorId on the monitor
+				final String connectorId = monitor.getAttribute(MetricsHubConstants.MONITOR_ATTRIBUTE_CONNECTOR_ID);
+
+				// Get or create the per‑connector map<type, map<hash,monitor>>
+				if (connectorId != null) {
+					final Map<String, Map<String, Monitor>> hashesPerType = hashesByConnector.computeIfAbsent(
+						connectorId,
+						k -> new HashMap<>()
+					);
+
+					// Get or create—the per‑type map<hash,monitor>
+					final Map<String, Monitor> hashMap = hashesPerType.computeIfAbsent(monitor.getType(), t -> new HashMap<>());
+
+					// Compute & store
+					final String hash = computeIdCount(monitor);
+					hashMap.put(hash, monitor);
 				}
 			});
+
+		for (Map.Entry<String, Map<String, Map<String, Monitor>>> connectorEntry : hashesByConnector.entrySet()) {
+			final Map<String, Map<String, Monitor>> perTypeMap = connectorEntry.getValue();
+
+			for (Map.Entry<String, Map<String, Monitor>> typeEntry : perTypeMap.entrySet()) {
+				final Map<String, Monitor> hashMap = typeEntry.getValue();
+
+				final List<String> sortedHashes = new ArrayList<>(hashMap.keySet());
+				Collections.sort(sortedHashes);
+
+				for (int i = 0; i < sortedHashes.size(); i++) {
+					final String hash = sortedHashes.get(i);
+					final Monitor monitor = hashMap.get(hash);
+					monitor.addAttribute(ID_COUNT, String.valueOf(i + 1));
+
+					if (
+						monitor.getAttribute(MetricsHubConstants.MONITOR_ATTRIBUTE_NAME) == null ||
+						monitor.getAttribute(MetricsHubConstants.MONITOR_ATTRIBUTE_NAME).isBlank()
+					) {
+						final String generatedName = new MonitorNameBuilder(telemetryManager.getHostname())
+							.buildMonitorNameUsingType(monitor, telemetryManager);
+						monitor.addAttribute(MetricsHubConstants.MONITOR_ATTRIBUTE_NAME, generatedName);
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
+++ b/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
@@ -149,23 +149,4 @@ public class HardwarePostDiscoveryStrategy extends AbstractStrategy {
 				}
 			});
 	}
-
-	/**
-	 * Computes an MD5-based identifier from a monitor’s sorted attributes.
-	 *
-	 * @param monitor the monitor whose attributes will be hashed
-	 * @return lowercase hex MD5 digest of the monitor’s attributes
-	 */
-	private String computeIdCount(final Monitor monitor) {
-		final SortedMap<String, String> sortedAttrs = new TreeMap<>(monitor.getAttributes());
-		final StringBuilder sb = new StringBuilder();
-		sortedAttrs.forEach((k, v) -> sb.append(k).append("=").append(v).append(";"));
-		try {
-			final MessageDigest md = MessageDigest.getInstance("MD5");
-			final byte[] digest = md.digest(sb.toString().getBytes(StandardCharsets.UTF_8));
-			return HexFormat.of().formatHex(digest);
-		} catch (NoSuchAlgorithmException e) {
-			throw new RuntimeException("MD5 not supported", e);
-		}
-	}
 }

--- a/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
+++ b/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
@@ -24,15 +24,9 @@ package org.metricshub.hardware.strategy;
 import static org.metricshub.hardware.constants.CommonConstants.PRESENT_STATUS;
 import static org.metricshub.hardware.util.HwCollectHelper.connectorHasHardwareTag;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
-import java.util.HexFormat;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;

--- a/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
+++ b/metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwarePostDiscoveryStrategy.java
@@ -175,6 +175,8 @@ public class HardwarePostDiscoveryStrategy extends AbstractStrategy {
 			.stream()
 			.map(Map::values)
 			.flatMap(Collection::stream)
+			.filter(telemetryManager::isConnectorStatusOk)
+			.filter(monitor -> connectorHasHardwareTag(monitor, telemetryManager))
 			.forEach((Monitor monitor) -> {
 				// Look up the true connectorId on the monitor
 				final String connectorId = monitor.getAttribute(MetricsHubConstants.MONITOR_ATTRIBUTE_CONNECTOR_ID);

--- a/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
+++ b/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
@@ -1,5 +1,20 @@
 package org.metricshub.hardware.strategy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_KEYS;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_NAME;
+import static org.metricshub.hardware.constants.CommonConstants.DISPLAY_ID;
+import static org.metricshub.hardware.constants.CommonConstants.ID_COUNT;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.metricshub.engine.client.ClientsExecutor;
@@ -15,22 +30,6 @@ import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.MonitorFactory;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.hardware.util.MonitorNameBuilder;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_KEYS;
-import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
-import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_NAME;
-import static org.metricshub.hardware.constants.CommonConstants.DISPLAY_ID;
-import static org.metricshub.hardware.constants.CommonConstants.ID_COUNT;
 
 /**
  * Test class for {@link HardwareMonitorNameGenerationStrategy}.
@@ -58,26 +57,20 @@ class HardwareMonitorNameGenerationStrategyTest {
 		final ConnectorStore connectorStore = new ConnectorStore();
 		final Connector connector = new Connector();
 		connector.setConnectorIdentity(
-				ConnectorIdentity
-						.builder()
-						.detection(Detection.builder().tags(Set.of("hardware")).appliesTo(Set.of(DeviceKind.WINDOWS)).build())
-						.build()
+			ConnectorIdentity
+				.builder()
+				.detection(Detection.builder().tags(Set.of("hardware")).appliesTo(Set.of(DeviceKind.WINDOWS)).build())
+				.build()
 		);
 		connectorStore.setStore(Map.of(CONNECTOR_ID, connector));
 
 		// 2. Build TelemetryManager with the connector store and a HostConfiguration:
 		telemetryManager =
-				TelemetryManager
-						.builder()
-						.hostConfiguration(
-								HostConfiguration.builder()
-										.hostId(HOST_NAME)
-										.hostname(HOST_NAME)
-										.sequential(false)
-										.build()
-						)
-						.connectorStore(connectorStore)
-						.build();
+			TelemetryManager
+				.builder()
+				.hostConfiguration(HostConfiguration.builder().hostId(HOST_NAME).hostname(HOST_NAME).sequential(false).build())
+				.connectorStore(connectorStore)
+				.build();
 
 		// 3. Mark the connector status as OK so that isConnectorStatusOk(...) returns true:
 		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
@@ -101,25 +94,25 @@ class HardwareMonitorNameGenerationStrategyTest {
 		secondMonitorAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
 
 		final MonitorFactory factory1 = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(firstMonitorAttributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(firstMonitorAttributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor monitor1 = factory1.createOrUpdateMonitor();
 
 		final MonitorFactory factory2 = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(secondMonitorAttributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(secondMonitorAttributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor monitor2 = factory2.createOrUpdateMonitor();
 
 		// Both monitors start with blank MONITOR_ATTRIBUTE_NAME:
@@ -165,14 +158,14 @@ class HardwareMonitorNameGenerationStrategyTest {
 		attributes.put(MONITOR_ATTRIBUTE_NAME, "my-custom-name");
 
 		final MonitorFactory factory = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(attributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(attributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor monitor = factory.createOrUpdateMonitor();
 
 		// Confirm initial name is what we set:
@@ -183,9 +176,9 @@ class HardwareMonitorNameGenerationStrategyTest {
 
 		// Since it already had a non-blank name, the MONITOR_ATTRIBUTE_NAME should remain unchanged:
 		assertEquals(
-				"my-custom-name",
-				monitor.getAttribute(MONITOR_ATTRIBUTE_NAME),
-				"Existing non-blank name should not be overwritten by the strategy"
+			"my-custom-name",
+			monitor.getAttribute(MONITOR_ATTRIBUTE_NAME),
+			"Existing non-blank name should not be overwritten by the strategy"
 		);
 
 		// It should still receive an ID_COUNT attribute based on its only member in the group (i.e., "1"):
@@ -201,21 +194,21 @@ class HardwareMonitorNameGenerationStrategyTest {
 		// 1. Create a CPU monitor with blank name but with DISPLAY_ID, DEVICE_ID, VENDOR, MODEL:
 		final Map<String, String> cpuAttributes = new HashMap<>();
 		cpuAttributes.put(MONITOR_ATTRIBUTE_ID, "cpu-1");
-		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, "");                   // blank name so builder runs
-		cpuAttributes.put(DISPLAY_ID, "Core i7");    // displayId to be used as base
-		cpuAttributes.put("device_id", "cpu0");                           // fallback if displayId missing
+		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name so builder runs
+		cpuAttributes.put(DISPLAY_ID, "Core i7"); // displayId to be used as base
+		cpuAttributes.put("device_id", "cpu0"); // fallback if displayId missing
 		cpuAttributes.put("vendor", "Intel");
 		cpuAttributes.put("model", "Xeon");
 
 		final MonitorFactory cpuFactory = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(cpuAttributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.CPU.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(cpuAttributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.CPU.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
 
 		// 2. Run the naming strategy:
@@ -239,21 +232,21 @@ class HardwareMonitorNameGenerationStrategyTest {
 		// 1. Create a PhysicalDisk monitor with blank name, type, DISPLAY_ID, VENDOR:
 		final Map<String, String> diskAttributes = new HashMap<>();
 		diskAttributes.put(MONITOR_ATTRIBUTE_ID, "disk-1");
-		diskAttributes.put(MONITOR_ATTRIBUTE_NAME, "");                             // blank name
-		diskAttributes.put("physical_disk_device_type", "SSD");                      // prefix type
-		diskAttributes.put(DISPLAY_ID, "Disk1");                 // displayId to use
-		diskAttributes.put("device_id", "pd0");                                       // fallback
+		diskAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
+		diskAttributes.put("physical_disk_device_type", "SSD"); // prefix type
+		diskAttributes.put(DISPLAY_ID, "Disk1"); // displayId to use
+		diskAttributes.put("device_id", "pd0"); // fallback
 		diskAttributes.put("vendor", "Seagate");
 
 		final MonitorFactory diskFactory = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(diskAttributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.PHYSICAL_DISK.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(diskAttributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.PHYSICAL_DISK.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor diskMonitor = diskFactory.createOrUpdateMonitor();
 
 		// 2. Run the naming strategy:
@@ -276,47 +269,45 @@ class HardwareMonitorNameGenerationStrategyTest {
 		final ConnectorStore connectorStore = new ConnectorStore();
 		final Connector connector = new Connector();
 		connector.setConnectorIdentity(
-				ConnectorIdentity
+			ConnectorIdentity
+				.builder()
+				.detection(
+					Detection
 						.builder()
-						.detection(Detection.builder()
-								// no "hardware" tag here
-								.tags(Set.of())
-								.appliesTo(Set.of(DeviceKind.WINDOWS))
-								.build())
+						// no "hardware" tag here
+						.tags(Set.of())
+						.appliesTo(Set.of(DeviceKind.WINDOWS))
 						.build()
+				)
+				.build()
 		);
 		connectorStore.setStore(Map.of(CONNECTOR_ID, connector));
 
 		// 2. Build TelemetryManager
 		telemetryManager =
-				TelemetryManager
-						.builder()
-						.hostConfiguration(
-								HostConfiguration.builder()
-										.hostId(HOST_NAME)
-										.hostname(HOST_NAME)
-										.sequential(false)
-										.build())
-						.connectorStore(connectorStore)
-						.build();
+			TelemetryManager
+				.builder()
+				.hostConfiguration(HostConfiguration.builder().hostId(HOST_NAME).hostname(HOST_NAME).sequential(false).build())
+				.connectorStore(connectorStore)
+				.build();
 		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
 
 		// 3. Create a CPU monitor (type=CPU) under that connector
 		final Map<String, String> cpuAttributes = new HashMap<>();
 		cpuAttributes.put(MONITOR_ATTRIBUTE_ID, "cpu-ignored");
-		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, "");            // blank name
+		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
 		cpuAttributes.put("vendor", "Intel");
 		cpuAttributes.put("model", "Xeon");
 
 		final MonitorFactory cpuFactory = MonitorFactory
-				.builder()
-				.attributes(new HashMap<>(cpuAttributes))
-				.discoveryTime(discoveryTime)
-				.connectorId(CONNECTOR_ID)
-				.telemetryManager(telemetryManager)
-				.monitorType(KnownMonitorType.CPU.getKey())
-				.keys(DEFAULT_KEYS)
-				.build();
+			.builder()
+			.attributes(new HashMap<>(cpuAttributes))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.CPU.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
 		final Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
 
 		// Sanity check: name is blank initially

--- a/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
+++ b/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
@@ -1,0 +1,329 @@
+package org.metricshub.hardware.strategy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metricshub.engine.client.ClientsExecutor;
+import org.metricshub.engine.common.helpers.KnownMonitorType;
+import org.metricshub.engine.configuration.HostConfiguration;
+import org.metricshub.engine.connector.model.Connector;
+import org.metricshub.engine.connector.model.ConnectorStore;
+import org.metricshub.engine.connector.model.common.DeviceKind;
+import org.metricshub.engine.connector.model.identity.ConnectorIdentity;
+import org.metricshub.engine.connector.model.identity.Detection;
+import org.metricshub.engine.extension.ExtensionManager;
+import org.metricshub.engine.telemetry.Monitor;
+import org.metricshub.engine.telemetry.MonitorFactory;
+import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.hardware.util.MonitorNameBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_KEYS;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
+import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_NAME;
+import static org.metricshub.hardware.constants.CommonConstants.DISPLAY_ID;
+import static org.metricshub.hardware.constants.CommonConstants.ID_COUNT;
+
+/**
+ * Test class for {@link HardwareMonitorNameGenerationStrategy}.
+ * <p>
+ * Verifies that:
+ * <ul>
+ *   <li>Monitors are grouped by connector ID and type, then assigned sequential ID_COUNT values
+ *       according to the lexicographically sorted MD5 of their attributes.</li>
+ *   <li>Monitors with a blank or missing name receive a generated name via {@link MonitorNameBuilder}.</li>
+ *   <li>Monitors that already have a non-blank name are not overwritten.</li>
+ * </ul>
+ */
+class HardwareMonitorNameGenerationStrategyTest {
+
+	private static final String HOST_NAME = "test-host";
+	private static final String CONNECTOR_ID = "connector-1";
+
+	private TelemetryManager telemetryManager;
+	private ClientsExecutor clientsExecutor;
+	private ExtensionManager extensionManager;
+
+	@BeforeEach
+	void setUp() {
+		// 1. Create a ConnectorStore with one connector that has the "hardware" tag:
+		ConnectorStore connectorStore = new ConnectorStore();
+		Connector connector = new Connector();
+		connector.setConnectorIdentity(
+			ConnectorIdentity
+				.builder()
+				.detection(Detection.builder().tags(Set.of("hardware")).appliesTo(Set.of(DeviceKind.WINDOWS)).build())
+				.build()
+		);
+		connectorStore.setStore(Map.of(CONNECTOR_ID, connector));
+
+		// 2. Build TelemetryManager with the connector store and a HostConfiguration:
+		telemetryManager =
+			TelemetryManager
+				.builder()
+				.hostConfiguration(HostConfiguration.builder().hostId(HOST_NAME).hostname(HOST_NAME).sequential(false).build())
+				.connectorStore(connectorStore)
+				.build();
+
+		// 3. Mark the connector status as OK so that isConnectorStatusOk(...) returns true:
+		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
+
+		clientsExecutor = new ClientsExecutor(telemetryManager);
+		extensionManager = ExtensionManager.builder().build();
+	}
+
+	@Test
+	void testIdCountAssignmentAndNameGenerationForBlankNames() {
+		long discoveryTime = System.currentTimeMillis();
+
+		// Create two monitors of the same type and connector, both with blank names,
+		// but different MONITOR_ATTRIBUTE_ID so that their MD5 hashes are distinct.
+		Map<String, String> attrs1 = new HashMap<>();
+		attrs1.put(MONITOR_ATTRIBUTE_ID, "a"); // ID 'a'
+		attrs1.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
+
+		Map<String, String> attrs2 = new HashMap<>();
+		attrs2.put(MONITOR_ATTRIBUTE_ID, "b"); // ID 'b'
+		attrs2.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
+
+		MonitorFactory factory1 = MonitorFactory
+			.builder()
+			.attributes(new HashMap<>(attrs1))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
+		Monitor monitor1 = factory1.createOrUpdateMonitor();
+
+		MonitorFactory factory2 = MonitorFactory
+			.builder()
+			.attributes(new HashMap<>(attrs2))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
+		Monitor monitor2 = factory2.createOrUpdateMonitor();
+
+		// Both monitors start with blank MONITOR_ATTRIBUTE_NAME:
+		assertTrue(monitor1.getAttribute(MONITOR_ATTRIBUTE_NAME).isBlank());
+		assertTrue(monitor2.getAttribute(MONITOR_ATTRIBUTE_NAME).isBlank());
+
+		// Run the naming strategy:
+		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
+
+		// After running, each monitor should have an ID_COUNT attribute:
+		String idCount1 = monitor1.getAttribute(ID_COUNT);
+		String idCount2 = monitor2.getAttribute(ID_COUNT);
+		assertNotNull(idCount1, "Monitor1 should have an ID_COUNT attribute");
+		assertNotNull(idCount2, "Monitor2 should have an ID_COUNT attribute");
+
+		// Compute expected ordering by MD5 of "id=<value>;name=;"
+		// We know MD5("id=a;name=;") = "76df5b970f97d60766196c4c34cf1117"
+		// and MD5("id=b;name=;") = "50fd33a232f6a90691880b6a6e8ee448"
+		// "50fd..." < "76df...", so the "b" monitor should receive ID_COUNT = "1",
+		// and the "a" monitor should receive ID_COUNT = "2".
+		assertEquals("2", idCount1, "Monitor with MONITOR_ATTRIBUTE_ID='a' should get sequence '2'");
+		assertEquals("1", idCount2, "Monitor with MONITOR_ATTRIBUTE_ID='b' should get sequence '1'");
+
+		// Each monitor had a blank name, so the strategy should generate one via MonitorNameBuilder.
+		String generatedName1 = monitor1.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		String generatedName2 = monitor2.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		assertNotNull(generatedName1);
+		assertNotNull(generatedName2);
+		assertFalse(generatedName1.isBlank(), "Monitor1 should receive a non-blank generated name");
+		assertFalse(generatedName2.isBlank(), "Monitor2 should receive a non-blank generated name");
+
+		// The generated names must differ (because ID_COUNT differs and hashing order differs):
+		assertNotEquals(generatedName1, generatedName2, "Generated names should be distinct when ID_COUNT differs");
+	}
+
+	@Test
+	void testExistingNameIsNotOverwritten() {
+		long discoveryTime = System.currentTimeMillis();
+
+		// Create a single monitor with a pre-set non-blank name:
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put(MONITOR_ATTRIBUTE_ID, "fixed-id");
+		attrs.put(MONITOR_ATTRIBUTE_NAME, "my-custom-name");
+
+		MonitorFactory factory = MonitorFactory
+			.builder()
+			.attributes(new HashMap<>(attrs))
+			.discoveryTime(discoveryTime)
+			.connectorId(CONNECTOR_ID)
+			.telemetryManager(telemetryManager)
+			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+			.keys(DEFAULT_KEYS)
+			.build();
+		Monitor monitor = factory.createOrUpdateMonitor();
+
+		// Confirm initial name is what we set:
+		assertEquals("my-custom-name", monitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
+
+		// Run the naming strategy:
+		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
+
+		// Since it already had a non-blank name, the MONITOR_ATTRIBUTE_NAME should remain unchanged:
+		assertEquals(
+			"my-custom-name",
+			monitor.getAttribute(MONITOR_ATTRIBUTE_NAME),
+			"Existing non-blank name should not be overwritten by the strategy"
+		);
+
+		// It should still receive an ID_COUNT attribute based on its only member in the group (i.e., "1"):
+		String idCount = monitor.getAttribute(ID_COUNT);
+		assertNotNull(idCount, "Monitor should have an ID_COUNT attribute even if name was preset");
+		assertEquals("1", idCount, "With only one monitor in its group, ID_COUNT must be '1'");
+	}
+	@Test
+	void testCpuNameGeneratedInSetMonitorsNames() {
+		long discoveryTime = System.currentTimeMillis();
+
+		// 1. Create a CPU monitor with blank name but with DISPLAY_ID, DEVICE_ID, VENDOR, MODEL:
+		Map<String, String> cpuAttrs = new HashMap<>();
+		cpuAttrs.put(MONITOR_ATTRIBUTE_ID, "cpu-1");
+		cpuAttrs.put(MONITOR_ATTRIBUTE_NAME, "");                   // blank name so builder runs
+		cpuAttrs.put(DISPLAY_ID, "Core i7");    // displayId to be used as base
+		cpuAttrs.put("device_id", "cpu0");                           // fallback if displayId missing
+		cpuAttrs.put("vendor", "Intel");
+		cpuAttrs.put("model", "Xeon");
+
+		MonitorFactory cpuFactory = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(cpuAttrs))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.CPU.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
+
+		// 2. Run the naming strategy:
+		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
+
+		// 3. After running, CPU monitor should have ID_COUNT set and a generated name:
+		String idCountCpu = cpuMonitor.getAttribute(ID_COUNT);
+		assertNotNull(idCountCpu, "CPU monitor should have an ID_COUNT attribute");
+
+		String cpuName = cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		assertNotNull(cpuName, "CPU monitor should have a generated name");
+		// Since we provided DISPLAY_ID="Core i7", VENDOR="Intel", MODEL="Xeon", expect:
+		// "Core i7 (Intel Xeon)"
+		assertEquals("Core i7 (Intel - Xeon)", cpuName);
+	}
+
+	@Test
+	void testPhysicalDiskNameGeneratedInSetMonitorsNames() {
+		long discoveryTime = System.currentTimeMillis();
+
+		// 1. Create a PhysicalDisk monitor with blank name, type, DISPLAY_ID, VENDOR:
+		Map<String, String> diskAttrs = new HashMap<>();
+		diskAttrs.put(MONITOR_ATTRIBUTE_ID, "disk-1");
+		diskAttrs.put(MONITOR_ATTRIBUTE_NAME, "");                             // blank name
+		diskAttrs.put("physical_disk_device_type", "SSD");                      // prefix type
+		diskAttrs.put(DISPLAY_ID, "Disk1");                 // displayId to use
+		diskAttrs.put("device_id", "pd0");                                       // fallback
+		diskAttrs.put("vendor", "Seagate");
+
+		MonitorFactory diskFactory = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(diskAttrs))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.PHYSICAL_DISK.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		Monitor diskMonitor = diskFactory.createOrUpdateMonitor();
+
+		// 2. Run the naming strategy:
+		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
+
+		// 3. After running, PhysicalDisk monitor should have ID_COUNT set and a generated name:
+		String idCountDisk = diskMonitor.getAttribute(ID_COUNT);
+		assertNotNull(idCountDisk, "PhysicalDisk monitor should have an ID_COUNT attribute");
+
+		String diskName = diskMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		assertNotNull(diskName, "PhysicalDisk monitor should have a generated name");
+		// Expect: "SSD: Disk1 (Seagate)"
+		assertEquals("Disk1 (Seagate)", diskName);
+	}
+
+	@Test
+	void testMonitorWithoutHardwareTagIsIgnored() {
+		long discoveryTime = System.currentTimeMillis();
+
+		// 1. Create a ConnectorStore with one connector that does NOT have the "hardware" tag:
+		ConnectorStore connectorStore = new ConnectorStore();
+		Connector connector = new Connector();
+		connector.setConnectorIdentity(
+				ConnectorIdentity
+						.builder()
+						.detection(Detection.builder()
+								// no "hardware" tag here
+								.tags(Set.of())
+								.appliesTo(Set.of(DeviceKind.WINDOWS))
+								.build())
+						.build()
+		);
+		connectorStore.setStore(Map.of(CONNECTOR_ID, connector));
+
+		// 2. Build TelemetryManager
+		telemetryManager =
+				TelemetryManager
+						.builder()
+						.hostConfiguration(
+								HostConfiguration.builder()
+										.hostId(HOST_NAME)
+										.hostname(HOST_NAME)
+										.sequential(false)
+										.build())
+						.connectorStore(connectorStore)
+						.build();
+		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
+
+		// 3. Create a CPU monitor (type=CPU) under that connector
+		Map<String, String> cpuAttrs = new HashMap<>();
+		cpuAttrs.put(MONITOR_ATTRIBUTE_ID, "cpu-ignored");
+		cpuAttrs.put(MONITOR_ATTRIBUTE_NAME, "");            // blank name
+		cpuAttrs.put("vendor", "Intel");
+		cpuAttrs.put("model", "Xeon");
+
+		MonitorFactory cpuFactory = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(cpuAttrs))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.CPU.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
+
+		// Sanity check: name is blank initially
+		assertEquals("", cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
+
+		// 4. Run the naming strategy
+		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
+
+		// 5. Since connector lacks "hardware" tag, strategy should ignore cpuMonitor:
+		//    - No ID_COUNT attribute
+		//    - Name remains blank
+		assertNull(cpuMonitor.getAttribute(ID_COUNT));
+		assertEquals("", cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
+	}
+
+}

--- a/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
+++ b/metricshub-hardware/src/test/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategyTest.java
@@ -55,23 +55,29 @@ class HardwareMonitorNameGenerationStrategyTest {
 	@BeforeEach
 	void setUp() {
 		// 1. Create a ConnectorStore with one connector that has the "hardware" tag:
-		ConnectorStore connectorStore = new ConnectorStore();
-		Connector connector = new Connector();
+		final ConnectorStore connectorStore = new ConnectorStore();
+		final Connector connector = new Connector();
 		connector.setConnectorIdentity(
-			ConnectorIdentity
-				.builder()
-				.detection(Detection.builder().tags(Set.of("hardware")).appliesTo(Set.of(DeviceKind.WINDOWS)).build())
-				.build()
+				ConnectorIdentity
+						.builder()
+						.detection(Detection.builder().tags(Set.of("hardware")).appliesTo(Set.of(DeviceKind.WINDOWS)).build())
+						.build()
 		);
 		connectorStore.setStore(Map.of(CONNECTOR_ID, connector));
 
 		// 2. Build TelemetryManager with the connector store and a HostConfiguration:
 		telemetryManager =
-			TelemetryManager
-				.builder()
-				.hostConfiguration(HostConfiguration.builder().hostId(HOST_NAME).hostname(HOST_NAME).sequential(false).build())
-				.connectorStore(connectorStore)
-				.build();
+				TelemetryManager
+						.builder()
+						.hostConfiguration(
+								HostConfiguration.builder()
+										.hostId(HOST_NAME)
+										.hostname(HOST_NAME)
+										.sequential(false)
+										.build()
+						)
+						.connectorStore(connectorStore)
+						.build();
 
 		// 3. Mark the connector status as OK so that isConnectorStatusOk(...) returns true:
 		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
@@ -82,39 +88,39 @@ class HardwareMonitorNameGenerationStrategyTest {
 
 	@Test
 	void testIdCountAssignmentAndNameGenerationForBlankNames() {
-		long discoveryTime = System.currentTimeMillis();
+		final long discoveryTime = System.currentTimeMillis();
 
 		// Create two monitors of the same type and connector, both with blank names,
 		// but different MONITOR_ATTRIBUTE_ID so that their MD5 hashes are distinct.
-		Map<String, String> attrs1 = new HashMap<>();
-		attrs1.put(MONITOR_ATTRIBUTE_ID, "a"); // ID 'a'
-		attrs1.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
+		final Map<String, String> firstMonitorAttributes = new HashMap<>();
+		firstMonitorAttributes.put(MONITOR_ATTRIBUTE_ID, "a"); // ID 'a'
+		firstMonitorAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
 
-		Map<String, String> attrs2 = new HashMap<>();
-		attrs2.put(MONITOR_ATTRIBUTE_ID, "b"); // ID 'b'
-		attrs2.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
+		final Map<String, String> secondMonitorAttributes = new HashMap<>();
+		secondMonitorAttributes.put(MONITOR_ATTRIBUTE_ID, "b"); // ID 'b'
+		secondMonitorAttributes.put(MONITOR_ATTRIBUTE_NAME, ""); // blank name
 
-		MonitorFactory factory1 = MonitorFactory
-			.builder()
-			.attributes(new HashMap<>(attrs1))
-			.discoveryTime(discoveryTime)
-			.connectorId(CONNECTOR_ID)
-			.telemetryManager(telemetryManager)
-			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-			.keys(DEFAULT_KEYS)
-			.build();
-		Monitor monitor1 = factory1.createOrUpdateMonitor();
+		final MonitorFactory factory1 = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(firstMonitorAttributes))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		final Monitor monitor1 = factory1.createOrUpdateMonitor();
 
-		MonitorFactory factory2 = MonitorFactory
-			.builder()
-			.attributes(new HashMap<>(attrs2))
-			.discoveryTime(discoveryTime)
-			.connectorId(CONNECTOR_ID)
-			.telemetryManager(telemetryManager)
-			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-			.keys(DEFAULT_KEYS)
-			.build();
-		Monitor monitor2 = factory2.createOrUpdateMonitor();
+		final MonitorFactory factory2 = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(secondMonitorAttributes))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		final Monitor monitor2 = factory2.createOrUpdateMonitor();
 
 		// Both monitors start with blank MONITOR_ATTRIBUTE_NAME:
 		assertTrue(monitor1.getAttribute(MONITOR_ATTRIBUTE_NAME).isBlank());
@@ -124,8 +130,8 @@ class HardwareMonitorNameGenerationStrategyTest {
 		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
 
 		// After running, each monitor should have an ID_COUNT attribute:
-		String idCount1 = monitor1.getAttribute(ID_COUNT);
-		String idCount2 = monitor2.getAttribute(ID_COUNT);
+		final String idCount1 = monitor1.getAttribute(ID_COUNT);
+		final String idCount2 = monitor2.getAttribute(ID_COUNT);
 		assertNotNull(idCount1, "Monitor1 should have an ID_COUNT attribute");
 		assertNotNull(idCount2, "Monitor2 should have an ID_COUNT attribute");
 
@@ -138,8 +144,8 @@ class HardwareMonitorNameGenerationStrategyTest {
 		assertEquals("1", idCount2, "Monitor with MONITOR_ATTRIBUTE_ID='b' should get sequence '1'");
 
 		// Each monitor had a blank name, so the strategy should generate one via MonitorNameBuilder.
-		String generatedName1 = monitor1.getAttribute(MONITOR_ATTRIBUTE_NAME);
-		String generatedName2 = monitor2.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		final String generatedName1 = monitor1.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		final String generatedName2 = monitor2.getAttribute(MONITOR_ATTRIBUTE_NAME);
 		assertNotNull(generatedName1);
 		assertNotNull(generatedName2);
 		assertFalse(generatedName1.isBlank(), "Monitor1 should receive a non-blank generated name");
@@ -151,23 +157,23 @@ class HardwareMonitorNameGenerationStrategyTest {
 
 	@Test
 	void testExistingNameIsNotOverwritten() {
-		long discoveryTime = System.currentTimeMillis();
+		final long discoveryTime = System.currentTimeMillis();
 
 		// Create a single monitor with a pre-set non-blank name:
-		Map<String, String> attrs = new HashMap<>();
-		attrs.put(MONITOR_ATTRIBUTE_ID, "fixed-id");
-		attrs.put(MONITOR_ATTRIBUTE_NAME, "my-custom-name");
+		final Map<String, String> attributes = new HashMap<>();
+		attributes.put(MONITOR_ATTRIBUTE_ID, "fixed-id");
+		attributes.put(MONITOR_ATTRIBUTE_NAME, "my-custom-name");
 
-		MonitorFactory factory = MonitorFactory
-			.builder()
-			.attributes(new HashMap<>(attrs))
-			.discoveryTime(discoveryTime)
-			.connectorId(CONNECTOR_ID)
-			.telemetryManager(telemetryManager)
-			.monitorType(KnownMonitorType.ENCLOSURE.getKey())
-			.keys(DEFAULT_KEYS)
-			.build();
-		Monitor monitor = factory.createOrUpdateMonitor();
+		final MonitorFactory factory = MonitorFactory
+				.builder()
+				.attributes(new HashMap<>(attributes))
+				.discoveryTime(discoveryTime)
+				.connectorId(CONNECTOR_ID)
+				.telemetryManager(telemetryManager)
+				.monitorType(KnownMonitorType.ENCLOSURE.getKey())
+				.keys(DEFAULT_KEYS)
+				.build();
+		final Monitor monitor = factory.createOrUpdateMonitor();
 
 		// Confirm initial name is what we set:
 		assertEquals("my-custom-name", monitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
@@ -177,98 +183,98 @@ class HardwareMonitorNameGenerationStrategyTest {
 
 		// Since it already had a non-blank name, the MONITOR_ATTRIBUTE_NAME should remain unchanged:
 		assertEquals(
-			"my-custom-name",
-			monitor.getAttribute(MONITOR_ATTRIBUTE_NAME),
-			"Existing non-blank name should not be overwritten by the strategy"
+				"my-custom-name",
+				monitor.getAttribute(MONITOR_ATTRIBUTE_NAME),
+				"Existing non-blank name should not be overwritten by the strategy"
 		);
 
 		// It should still receive an ID_COUNT attribute based on its only member in the group (i.e., "1"):
-		String idCount = monitor.getAttribute(ID_COUNT);
+		final String idCount = monitor.getAttribute(ID_COUNT);
 		assertNotNull(idCount, "Monitor should have an ID_COUNT attribute even if name was preset");
 		assertEquals("1", idCount, "With only one monitor in its group, ID_COUNT must be '1'");
 	}
+
 	@Test
 	void testCpuNameGeneratedInSetMonitorsNames() {
-		long discoveryTime = System.currentTimeMillis();
+		final long discoveryTime = System.currentTimeMillis();
 
 		// 1. Create a CPU monitor with blank name but with DISPLAY_ID, DEVICE_ID, VENDOR, MODEL:
-		Map<String, String> cpuAttrs = new HashMap<>();
-		cpuAttrs.put(MONITOR_ATTRIBUTE_ID, "cpu-1");
-		cpuAttrs.put(MONITOR_ATTRIBUTE_NAME, "");                   // blank name so builder runs
-		cpuAttrs.put(DISPLAY_ID, "Core i7");    // displayId to be used as base
-		cpuAttrs.put("device_id", "cpu0");                           // fallback if displayId missing
-		cpuAttrs.put("vendor", "Intel");
-		cpuAttrs.put("model", "Xeon");
+		final Map<String, String> cpuAttributes = new HashMap<>();
+		cpuAttributes.put(MONITOR_ATTRIBUTE_ID, "cpu-1");
+		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, "");                   // blank name so builder runs
+		cpuAttributes.put(DISPLAY_ID, "Core i7");    // displayId to be used as base
+		cpuAttributes.put("device_id", "cpu0");                           // fallback if displayId missing
+		cpuAttributes.put("vendor", "Intel");
+		cpuAttributes.put("model", "Xeon");
 
-		MonitorFactory cpuFactory = MonitorFactory
+		final MonitorFactory cpuFactory = MonitorFactory
 				.builder()
-				.attributes(new HashMap<>(cpuAttrs))
+				.attributes(new HashMap<>(cpuAttributes))
 				.discoveryTime(discoveryTime)
 				.connectorId(CONNECTOR_ID)
 				.telemetryManager(telemetryManager)
 				.monitorType(KnownMonitorType.CPU.getKey())
 				.keys(DEFAULT_KEYS)
 				.build();
-		Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
+		final Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
 
 		// 2. Run the naming strategy:
 		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
 
 		// 3. After running, CPU monitor should have ID_COUNT set and a generated name:
-		String idCountCpu = cpuMonitor.getAttribute(ID_COUNT);
+		final String idCountCpu = cpuMonitor.getAttribute(ID_COUNT);
 		assertNotNull(idCountCpu, "CPU monitor should have an ID_COUNT attribute");
 
-		String cpuName = cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		final String cpuName = cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
 		assertNotNull(cpuName, "CPU monitor should have a generated name");
 		// Since we provided DISPLAY_ID="Core i7", VENDOR="Intel", MODEL="Xeon", expect:
-		// "Core i7 (Intel Xeon)"
+		// "Core i7 (Intel - Xeon)"
 		assertEquals("Core i7 (Intel - Xeon)", cpuName);
 	}
 
 	@Test
 	void testPhysicalDiskNameGeneratedInSetMonitorsNames() {
-		long discoveryTime = System.currentTimeMillis();
+		final long discoveryTime = System.currentTimeMillis();
 
 		// 1. Create a PhysicalDisk monitor with blank name, type, DISPLAY_ID, VENDOR:
-		Map<String, String> diskAttrs = new HashMap<>();
-		diskAttrs.put(MONITOR_ATTRIBUTE_ID, "disk-1");
-		diskAttrs.put(MONITOR_ATTRIBUTE_NAME, "");                             // blank name
-		diskAttrs.put("physical_disk_device_type", "SSD");                      // prefix type
-		diskAttrs.put(DISPLAY_ID, "Disk1");                 // displayId to use
-		diskAttrs.put("device_id", "pd0");                                       // fallback
-		diskAttrs.put("vendor", "Seagate");
+		final Map<String, String> diskAttributes = new HashMap<>();
+		diskAttributes.put(MONITOR_ATTRIBUTE_ID, "disk-1");
+		diskAttributes.put(MONITOR_ATTRIBUTE_NAME, "");                             // blank name
+		diskAttributes.put("physical_disk_device_type", "SSD");                      // prefix type
+		diskAttributes.put(DISPLAY_ID, "Disk1");                 // displayId to use
+		diskAttributes.put("device_id", "pd0");                                       // fallback
+		diskAttributes.put("vendor", "Seagate");
 
-		MonitorFactory diskFactory = MonitorFactory
+		final MonitorFactory diskFactory = MonitorFactory
 				.builder()
-				.attributes(new HashMap<>(diskAttrs))
+				.attributes(new HashMap<>(diskAttributes))
 				.discoveryTime(discoveryTime)
 				.connectorId(CONNECTOR_ID)
 				.telemetryManager(telemetryManager)
 				.monitorType(KnownMonitorType.PHYSICAL_DISK.getKey())
 				.keys(DEFAULT_KEYS)
 				.build();
-		Monitor diskMonitor = diskFactory.createOrUpdateMonitor();
+		final Monitor diskMonitor = diskFactory.createOrUpdateMonitor();
 
 		// 2. Run the naming strategy:
 		new HardwareMonitorNameGenerationStrategy(telemetryManager, discoveryTime, clientsExecutor, extensionManager).run();
 
 		// 3. After running, PhysicalDisk monitor should have ID_COUNT set and a generated name:
-		String idCountDisk = diskMonitor.getAttribute(ID_COUNT);
+		final String idCountDisk = diskMonitor.getAttribute(ID_COUNT);
 		assertNotNull(idCountDisk, "PhysicalDisk monitor should have an ID_COUNT attribute");
 
-		String diskName = diskMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
+		final String diskName = diskMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
 		assertNotNull(diskName, "PhysicalDisk monitor should have a generated name");
-		// Expect: "SSD: Disk1 (Seagate)"
 		assertEquals("Disk1 (Seagate)", diskName);
 	}
 
 	@Test
 	void testMonitorWithoutHardwareTagIsIgnored() {
-		long discoveryTime = System.currentTimeMillis();
+		final long discoveryTime = System.currentTimeMillis();
 
 		// 1. Create a ConnectorStore with one connector that does NOT have the "hardware" tag:
-		ConnectorStore connectorStore = new ConnectorStore();
-		Connector connector = new Connector();
+		final ConnectorStore connectorStore = new ConnectorStore();
+		final Connector connector = new Connector();
 		connector.setConnectorIdentity(
 				ConnectorIdentity
 						.builder()
@@ -296,22 +302,22 @@ class HardwareMonitorNameGenerationStrategyTest {
 		StrategyTestHelper.setConnectorStatusInNamespace(true, CONNECTOR_ID, telemetryManager);
 
 		// 3. Create a CPU monitor (type=CPU) under that connector
-		Map<String, String> cpuAttrs = new HashMap<>();
-		cpuAttrs.put(MONITOR_ATTRIBUTE_ID, "cpu-ignored");
-		cpuAttrs.put(MONITOR_ATTRIBUTE_NAME, "");            // blank name
-		cpuAttrs.put("vendor", "Intel");
-		cpuAttrs.put("model", "Xeon");
+		final Map<String, String> cpuAttributes = new HashMap<>();
+		cpuAttributes.put(MONITOR_ATTRIBUTE_ID, "cpu-ignored");
+		cpuAttributes.put(MONITOR_ATTRIBUTE_NAME, "");            // blank name
+		cpuAttributes.put("vendor", "Intel");
+		cpuAttributes.put("model", "Xeon");
 
-		MonitorFactory cpuFactory = MonitorFactory
+		final MonitorFactory cpuFactory = MonitorFactory
 				.builder()
-				.attributes(new HashMap<>(cpuAttrs))
+				.attributes(new HashMap<>(cpuAttributes))
 				.discoveryTime(discoveryTime)
 				.connectorId(CONNECTOR_ID)
 				.telemetryManager(telemetryManager)
 				.monitorType(KnownMonitorType.CPU.getKey())
 				.keys(DEFAULT_KEYS)
 				.build();
-		Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
+		final Monitor cpuMonitor = cpuFactory.createOrUpdateMonitor();
 
 		// Sanity check: name is blank initially
 		assertEquals("", cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
@@ -325,5 +331,4 @@ class HardwareMonitorNameGenerationStrategyTest {
 		assertNull(cpuMonitor.getAttribute(ID_COUNT));
 		assertEquals("", cpuMonitor.getAttribute(MONITOR_ATTRIBUTE_NAME));
 	}
-
 }


### PR DESCRIPTION
* Add hardware tag and connectorStatusOk filtering to monitors while setting their names