### PR TITLE
Issue #357: MetricsHub CLI: Added the ability to specify connector variables

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/AdditionalConnectorConfigCli.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/AdditionalConnectorConfigCli.java
@@ -1,0 +1,49 @@
+package org.metricshub.cli.service;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.Map;
+import lombok.Data;
+import org.metricshub.engine.configuration.AdditionalConnector;
+import picocli.CommandLine.Option;
+
+@Data
+public class AdditionalConnectorConfigCli {
+
+	@Option(names = { "--additionalConnector", "--additional-connector" }, required = true)
+	String connectorId;
+
+	@Option(names = "--uses")
+	String uses;
+
+	@Option(names = { "-F", "--variable" }, description = "Connector variable in key=value format")
+	Map<String, String> variables;
+
+	AdditionalConnector toAdditionalConnector() {
+		return AdditionalConnector
+			.builder()
+			.force(true)
+			.uses(uses != null ? uses : connectorId)
+			.variables(variables)
+			.build();
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/MetricsHubCliService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/MetricsHubCliService.java
@@ -403,10 +403,16 @@ public class MetricsHubCliService implements Callable<Integer> {
 				return CommandLine.ExitCode.SOFTWARE;
 			}
 
-			int connectorCount = telemetryManager.findMonitorsByType(KnownMonitorType.CONNECTOR.getKey()).size();
+			final Map<String, Monitor> connectors = telemetryManager.findMonitorsByType(KnownMonitorType.CONNECTOR.getKey());
+			int connectorCount = connectors.size();
 			printWriter.print("Performing discovery with ");
 			printWriter.print(Ansi.ansi().bold().a(connectorCount).boldOff().toString());
 			printWriter.println(connectorCount > 1 ? " connectors..." : " connector...");
+			connectors.forEach((connectorId, monitor) ->
+				printWriter.println(
+					Ansi.ansi().a("- ").fgCyan().a(new PrettyPrinterService().getMonitorDisplayName(monitor)).reset()
+				)
+			);
 			printWriter.flush();
 		}
 		telemetryManager.run(

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/MetricsHubCliService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/MetricsHubCliService.java
@@ -23,6 +23,9 @@ package org.metricshub.cli.service;
 
 import java.io.PrintWriter;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -55,11 +58,18 @@ import org.metricshub.cli.service.protocol.WmiConfigCli;
 import org.metricshub.engine.client.ClientsExecutor;
 import org.metricshub.engine.common.exception.InvalidConfigurationException;
 import org.metricshub.engine.common.helpers.KnownMonitorType;
+import org.metricshub.engine.configuration.AdditionalConnector;
 import org.metricshub.engine.configuration.HostConfiguration;
 import org.metricshub.engine.configuration.IConfiguration;
+import org.metricshub.engine.connector.deserializer.ConnectorDeserializer;
 import org.metricshub.engine.connector.model.Connector;
 import org.metricshub.engine.connector.model.ConnectorStore;
+import org.metricshub.engine.connector.model.RawConnector;
+import org.metricshub.engine.connector.model.RawConnectorStore;
 import org.metricshub.engine.connector.model.common.DeviceKind;
+import org.metricshub.engine.connector.parser.AdditionalConnectorsParsingResult;
+import org.metricshub.engine.connector.parser.ConnectorParser;
+import org.metricshub.engine.connector.parser.ConnectorStoreComposer;
 import org.metricshub.engine.strategy.collect.CollectStrategy;
 import org.metricshub.engine.strategy.collect.PrepareCollectStrategy;
 import org.metricshub.engine.strategy.collect.ProtocolHealthCheckStrategy;
@@ -171,6 +181,9 @@ public class MetricsHubCliService implements Callable<Integer> {
 	@ArgGroup(exclusive = false, heading = "%n@|bold,underline JDBC Options|@:%n")
 	JdbcConfigCli jdbcConfigCli;
 
+	@ArgGroup(exclusive = false, heading = "%n@|bold,underline Additional Connectors Options|@:%n", multiplicity = "0..*")
+	List<AdditionalConnectorConfigCli> additionalConnectors;
+
 	@Option(names = { "-u", "--username" }, order = 2, paramLabel = "USER", description = "Username for authentication")
 	String username;
 
@@ -274,10 +287,13 @@ public class MetricsHubCliService implements Callable<Integer> {
 
 		// First, process special "list" option
 		if (listConnectors) {
-			return listAllConnectors(
-				ConfigHelper.buildConnectorStore(CliExtensionManager.getExtensionManagerSingleton(), patchDirectory),
-				spec.commandLine().getOut()
-			);
+			// Build a connector store
+			final ConnectorStore connectorStore = buildConnectorStore();
+
+			// Add configured and default connectors with variables
+			connectorStore.addMany(resolveConnectorVariables(connectorStore).getCustomConnectorsMap());
+
+			return listAllConnectors(connectorStore, spec.commandLine().getOut());
 		}
 
 		// Validate inputs
@@ -305,12 +321,32 @@ public class MetricsHubCliService implements Callable<Integer> {
 		final Map<Class<? extends IConfiguration>, IConfiguration> configurations = buildConfigurations();
 		hostConfiguration.setConfigurations(configurations);
 
+		// Create a connector store
+		// This store will not contain connectors having variables
+		final ConnectorStore connectorStore = buildConnectorStore();
+
+		// resolve connectors with variables.
+		final AdditionalConnectorsParsingResult connectorsParsingResult = resolveConnectorVariables(connectorStore);
+
+		// Add the configured additional connectors with variables
+		connectorStore.addMany(connectorsParsingResult.getCustomConnectorsMap());
+
+		// Retrieve the set of connectors from the host
+		Set<String> hostConnectors = hostConfiguration.getConnectors();
+
+		// Create a new HashSet if the host connectors set is null
+		if (hostConfiguration.getConnectors() == null) {
+			hostConnectors = new HashSet<>();
+			hostConfiguration.setConnectors(hostConnectors);
+		}
+
+		// Add the connectors with variables connectors to the host.
+		hostConnectors.addAll(connectorsParsingResult.getResourceConnectors());
+
 		// Create the TelemetryManager using the connector store and the host configuration created above.
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()
-			.connectorStore(
-				ConfigHelper.buildConnectorStore(CliExtensionManager.getExtensionManagerSingleton(), patchDirectory)
-			)
+			.connectorStore(connectorStore)
 			.hostConfiguration(hostConfiguration)
 			.build();
 
@@ -476,6 +512,53 @@ public class MetricsHubCliService implements Callable<Integer> {
 		}
 	}
 
+	private AdditionalConnectorsParsingResult resolveConnectorVariables(final ConnectorStore connectorStore) {
+		final RawConnectorStore rawConnectorStore = connectorStore.getRawConnectorStore();
+		final Map<String, RawConnector> rawConnectors = rawConnectorStore.getStore();
+
+		final Map<String, AdditionalConnector> additionalConnectorsConfiguration = getAdditionalConnectorsConfiguration();
+		final PrintWriter printWriter = spec.commandLine().getErr();
+
+		additionalConnectorsConfiguration
+			.values()
+			.forEach(additionalConnector -> {
+				final String uses = additionalConnector.getUses();
+				if (!rawConnectors.containsKey(uses)) {
+					printWriter.println(
+						Ansi
+							.ansi()
+							.fgRed()
+							.a(
+								String.format(
+									"Error: Connector '%s' specified in --uses does not exist in the connector store.%n" +
+									"You can view the list of available connectors using: metricshub --list%n",
+									uses
+								)
+							)
+							.fgBrightBlack()
+							.a("https://metricshub.com/docs/latest/metricshub-connectors-full-listing.html")
+							.reset()
+							.toString()
+					);
+					rawConnectors.remove(uses);
+				}
+			});
+
+		printWriter.flush();
+		return ConnectorStoreComposer
+			.builder()
+			.withRawConnectorStore(rawConnectorStore)
+			.withUpdateChain(ConnectorParser.createUpdateChain())
+			.withDeserializer(new ConnectorDeserializer(rawConnectorStore.getMapperFromSubtypes()))
+			.withAdditionalConnectors(additionalConnectorsConfiguration)
+			.build()
+			.resolveConnectorStoreVariables(connectorStore);
+	}
+
+	private ConnectorStore buildConnectorStore() {
+		return ConfigHelper.buildConnectorStore(CliExtensionManager.getExtensionManagerSingleton(), patchDirectory);
+	}
+
 	/**
 	 * @return A {@link Map} associating the input protocol type to its input credentials.
 	 */
@@ -542,6 +625,32 @@ public class MetricsHubCliService implements Callable<Integer> {
 				"At least one protocol must be specified: --http[s], --ipmi, --jdbc, --snmp, --snmpv3, --ssh, --wbem, --winrm, --wmi."
 			);
 		}
+
+		if (additionalConnectors != null) {
+			final boolean connectorIdNotFound = additionalConnectors
+				.stream()
+				.anyMatch(additionalConnector -> additionalConnector.getConnectorId() == null);
+			if (connectorIdNotFound) {
+				throw new ParameterException(
+					spec.commandLine(),
+					"Invalid additional connectors configuration: connectorId is mandatory."
+				);
+			}
+		}
+	}
+
+	public Map<String, AdditionalConnector> getAdditionalConnectorsConfiguration() {
+		if (additionalConnectors != null) {
+			return additionalConnectors
+				.stream()
+				.collect(
+					Collectors.toMap(
+						AdditionalConnectorConfigCli::getConnectorId,
+						AdditionalConnectorConfigCli::toAdditionalConnector
+					)
+				);
+		}
+		return new HashMap<>();
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/PrettyPrinterService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/PrettyPrinterService.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.fusesource.jansi.Ansi;
@@ -66,6 +67,7 @@ import org.metricshub.engine.telemetry.metric.StateSetMetric;
  * </p>
  */
 @Data
+@NoArgsConstructor
 public class PrettyPrinterService {
 
 	/**
@@ -348,7 +350,7 @@ public class PrettyPrinterService {
 	 * @param monitor Monitor instance as defined by the core engine
 	 * @return String value
 	 */
-	private String getMonitorDisplayName(final Monitor monitor) {
+	public String getMonitorDisplayName(final Monitor monitor) {
 		String displayName = monitor.getAttribute(MONITOR_ATTRIBUTE_NAME);
 		displayName = displayName != null ? displayName : monitor.formatIdentifyingAttributes();
 		return displayName != null ? displayName : monitor.getId();

--- a/metricshub-agent/src/test/java/org/metricshub/cli/service/AdditionalConnectorConfigCliTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/cli/service/AdditionalConnectorConfigCliTest.java
@@ -1,0 +1,33 @@
+package org.metricshub.cli.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.metricshub.engine.configuration.AdditionalConnector;
+
+class AdditionalConnectorConfigCliTest {
+
+	@Test
+	void testToAdditionalConnector() {
+		final AdditionalConnectorConfigCli additionalConnectorConfigCli = new AdditionalConnectorConfigCli();
+		additionalConnectorConfigCli.setConnectorId("id");
+		additionalConnectorConfigCli.setUses("usedConnectorId");
+		additionalConnectorConfigCli.setVariables(Map.of("var1", "value1", "var2", "value2"));
+
+		final AdditionalConnector additionalConnector = AdditionalConnector
+			.builder()
+			.force(true)
+			.uses("usedConnectorId")
+			.variables(Map.of("var1", "value1", "var2", "value2"))
+			.build();
+
+		assertEquals(additionalConnectorConfigCli.toAdditionalConnector(), additionalConnector);
+
+		additionalConnectorConfigCli.setConnectorId("id");
+		additionalConnectorConfigCli.setUses(null);
+
+		additionalConnector.setUses("id");
+		assertEquals(additionalConnectorConfigCli.toAdditionalConnector(), additionalConnector);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/cli/service/MetricsHubCliServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/cli/service/MetricsHubCliServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.metricshub.cli.service.protocol.SshConfigCli;
 import org.metricshub.cli.service.protocol.WbemConfigCli;
 import org.metricshub.cli.service.protocol.WinRmConfigCli;
 import org.metricshub.cli.service.protocol.WmiConfigCli;
+import org.metricshub.engine.configuration.AdditionalConnector;
 import org.metricshub.engine.connector.model.Connector;
 import org.metricshub.engine.connector.model.ConnectorStore;
 import org.metricshub.engine.connector.model.common.DeviceKind;
@@ -451,5 +453,47 @@ class MetricsHubCliServiceTest {
 		// This confirms that tryInteractiveWbemPassword hasn't triggered the password reader
 		// because both username and password are already present in wbemConfigCli
 		assertTrue(builder.isEmpty());
+	}
+
+	@Test
+	void testGetAdditionalConnectors() {
+		final AdditionalConnectorConfigCli connector1 = new AdditionalConnectorConfigCli();
+		connector1.setConnectorId("id1");
+		connector1.setUses("usedConnector1");
+		connector1.setVariables(Map.of("var11", "val11", "var12", "val12"));
+
+		final AdditionalConnectorConfigCli connector2 = new AdditionalConnectorConfigCli();
+		connector2.setConnectorId("id2");
+		connector2.setUses("usedConnector2");
+		connector2.setVariables(Map.of("var21", "val21", "var22", "val22"));
+
+		//
+		final Map<String, AdditionalConnector> expectedAdditionalConnectors = Map.of(
+			"id1",
+			AdditionalConnector
+				.builder()
+				.force(true)
+				.uses("usedConnector1")
+				.variables(Map.of("var11", "val11", "var12", "val12"))
+				.build(),
+			"id2",
+			AdditionalConnector
+				.builder()
+				.force(true)
+				.uses("usedConnector2")
+				.variables(Map.of("var21", "val21", "var22", "val22"))
+				.build()
+		);
+
+		final MetricsHubCliService cli = new MetricsHubCliService();
+		cli.setAdditionalConnectors(List.of(connector1, connector2));
+		assertEquals(expectedAdditionalConnectors, cli.getAdditionalConnectorsConfiguration());
+
+		connector1.setUses(null);
+		connector2.setUses(null);
+
+		expectedAdditionalConnectors.get("id1").setUses("id1");
+		expectedAdditionalConnectors.get("id2").setUses("id2");
+		assertEquals(expectedAdditionalConnectors, cli.getAdditionalConnectorsConfiguration());
 	}
 }


### PR DESCRIPTION

* Added the ability to specify connector variables
* Added unit tests for additionalConnectorsCli.
* Added the list of discovered connectors in the CLI.
* Functionally tested on the CLI.

# Tests
## Configure additional connector without variables
![image](https://github.com/user-attachments/assets/91253c1a-fdce-4927-8b0b-a0e3d752249f)

Default variables values are then used.

![image](https://github.com/user-attachments/assets/a56bc182-9bfa-47eb-b93c-50e0e18fc3ed)

## Configure multiple additional connectors with variables
![image](https://github.com/user-attachments/assets/63719705-a52e-494a-84fc-28ccebc9704f)
![image](https://github.com/user-attachments/assets/fff7a20e-5bbd-450f-a145-89d03b48b3df)

## Use a non-existing connectorId
![image](https://github.com/user-attachments/assets/c9c1e93a-d4a0-4319-85df-771d8061b326)

## Force a default connector with variables using -c
![image](https://github.com/user-attachments/assets/f3803d5d-4b46-4122-a1c0-b3171e52268b)


