### PR TITLE
Issue #722: Updated Connector Maven Plugin version to 1.0.12

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.metricshub.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.11</version>
+				<version>1.0.12</version>
 				<configuration>
 					<sourceDirectory>${project.basedir}/../metricshub-agent/target/connectors</sourceDirectory>
 					<defaultPlatformIconFilename>default.png</defaultPlatformIconFilename>


### PR DESCRIPTION
This pull request updates the Maven plugin version in the `metricshub-doc/pom.xml` file.

* Updated the `metricshub-connector-maven-plugin` version from `1.0.11` to `1.0.12` to ensure the project uses the latest plugin version. (`metricshub-doc/pom.xml`, [metricshub-doc/pom.xmlL122-R122](diffhunk://#diff-77ee4fa86779ba8e7a1d78405285cd8eafedbfc46b476339cb8c7d2d6a40b23aL122-R122))