### PR TITLE
Issue #717: Release notes for MetricsHub v2.1.00

### DIFF
--- a/metricshub-doc/pom.xml
+++ b/metricshub-doc/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<communityVersion>${project.version}</communityVersion>
-		<enterpriseVersion>2.0.00</enterpriseVersion>
-		<otelVersion>0.116.0</otelVersion>
+		<enterpriseVersion>2.1.00</enterpriseVersion>
+		<otelVersion>0.127.0</otelVersion>
 	</properties>
 
 	<dependencies>

--- a/metricshub-doc/src/site/markdown/custom/index.md
+++ b/metricshub-doc/src/site/markdown/custom/index.md
@@ -10,6 +10,8 @@ description: Examples of custom monitoring.
 To help you get started and make the most out of **MetricsHub**, this section provides practical, ready-to-use examples across a variety of scenarios:
 
 * **Cross-platform use cases**:
+  * [Database Query](./database-query.md)
+  * [JMX Query](./jmx-query.md)
   * [SNMP Polling](./snmp-polling.md)
   * [Web Request](./web-request.md)
 * **Linux-related use cases**:

--- a/metricshub-doc/src/site/markdown/release-notes.md
+++ b/metricshub-doc/src/site/markdown/release-notes.md
@@ -42,10 +42,10 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                         | Description                                                                              |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | MetricsHub Server now supports [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
-| [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)                                       |
+| ID                                                                         | Description                                                                 |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | Added support for [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
+| [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)                          |
 
 #### Changes and Improvements
 

--- a/metricshub-doc/src/site/markdown/release-notes.md
+++ b/metricshub-doc/src/site/markdown/release-notes.md
@@ -11,11 +11,11 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                        | Description                                       |
-| ------------------------------------------------------------------------- | ------------------------------------------------- |
-| [**\#60**](https://github.com/MetricsHub/metricshub-enterprise/issues/60) | Included the **IBM Informix** JDBC driver         |
-| [**\#68**](https://github.com/MetricsHub/metricshub-enterprise/issues/68) | Added support for Java Management Extension (JMX) |
-| [**\#69**](https://github.com/MetricsHub/metricshub-enterprise/issues/69) | Added support for REST API and remote MCP         |
+| ID                                                                        | Description                                                                 |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [**\#60**](https://github.com/MetricsHub/metricshub-enterprise/issues/60) | Included the **IBM Informix** JDBC driver                                   |
+| [**\#68**](https://github.com/MetricsHub/metricshub-enterprise/issues/68) | Added support for Java Management Extension (JMX)                           |
+| [**\#69**](https://github.com/MetricsHub/metricshub-enterprise/issues/69) | Added support for [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
 
 #### Changes and Improvements
 
@@ -27,10 +27,10 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                        | Description                                           |
-| ------------------------------------------------------------------------- | ----------------------------------------------------- |
-| [**\#27**](https://github.com/MetricsHub/enterprise-connectors/issues/27) | Added support for **IBM Informix** databases via JDBC |
-| [**\#32**](https://github.com/MetricsHub/enterprise-connectors/issues/32) | Added support for **Palo Alto** firewalls via SNMP    |
+| ID                                                                        | Description                                                                              |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [**\#27**](https://github.com/MetricsHub/enterprise-connectors/issues/27) | Added support for [**IBM Informix**](./connectors/informix.html) databases via JDBC      |
+| [**\#32**](https://github.com/MetricsHub/enterprise-connectors/issues/32) | Added support for [**Palo Alto**](./connectors/paloaltofirewall.html) firewalls via SNMP |
 
 #### Changes and Improvements
 
@@ -42,19 +42,19 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### What's New
 
-| ID                                                                         | Description                                            |
-| -------------------------------------------------------------------------- | ------------------------------------------------------ |
-| [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | MetricsHub Server now supports REST API and Remote MCP |
-| [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)     |
+| ID                                                                         | Description                                                                              |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | MetricsHub Server now supports [REST API and remote MCP](./integrations/ai-agent-mcp.md) |
+| [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)                                       |
 
 #### Changes and Improvements
 
-| ID                                                                         | Description                                                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| [**\#357**](https://github.com/MetricsHub/metricshub-community/issues/357) | MetricsHub CLI: Added the ability to specify connector variables               |
-| [**\#658**](https://github.com/MetricsHub/metricshub-community/issues/658) | The `database` property is no longer required under the `jdbc` configuration   |
-| [**\#698**](https://github.com/MetricsHub/metricshub-community/issues/698) | Updated Prometheus Alert Rules                                                 |
-| [**\#726**](https://github.com/MetricsHub/metricshub-community/issues/726) | MetricsHub CLI: The `--list` option now shows connectors that define variables |
+| ID                                                                         | Description                                                                                                                                                                                                                |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**\#357**](https://github.com/MetricsHub/metricshub-community/issues/357) | **MetricsHub CLI**: Added the ability to specify connector variables                                                                                                                                                       |
+| [**\#658**](https://github.com/MetricsHub/metricshub-community/issues/658) | The `database` property is no longer required under the `jdbc` configuration                                                                                                                                               |
+| [**\#698**](https://github.com/MetricsHub/metricshub-community/issues/698) | **Prometheus Alert Rules**: Three categories of [alert rules](./prometheus/alertmanager.md#prometheus-alertmanager) are provided to inform you of MetricsHub issues, hardware failures, and system performance degradation |
+| [**\#726**](https://github.com/MetricsHub/metricshub-community/issues/726) | **MetricsHub CLI**: The `--list` option now shows connectors that define variables                                                                                                                                         |
 
 #### Fixed Issues
 
@@ -66,20 +66,20 @@ description: Learn more about the new features, changes and improvements, and bu
 
 #### Documentation Updates
 
-| ID                                                                         | Description                                                      |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [**\#684**](https://github.com/MetricsHub/metricshub-community/issues/684) | Documented custom monitoring examples                            |
-| [**\#702**](https://github.com/MetricsHub/metricshub-community/issues/702) | Explained how to implement custom monitoring through SQL queries |
-| [**\#704**](https://github.com/MetricsHub/metricshub-community/issues/704) | Documented Prometheus Alert Rules                                |
-| [**\#705**](https://github.com/MetricsHub/metricshub-community/issues/705) | Documented BMC Helix integration                                 |
+| ID                                                                         | Description                                                                                    |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [**\#684**](https://github.com/MetricsHub/metricshub-community/issues/684) | Documented [custom monitoring](./custom/index.md) examples                                     |
+| [**\#702**](https://github.com/MetricsHub/metricshub-community/issues/702) | Explained how to implement [custom monitoring through SQL queries](./custom/database-query.md) |
+| [**\#704**](https://github.com/MetricsHub/metricshub-community/issues/704) | Documented [Prometheus Alert Rules](./prometheus/alertmanager.md)                              |
+| [**\#705**](https://github.com/MetricsHub/metricshub-community/issues/705) | Documented [BMC Helix integration](./integrations/bmc-helix.md)                                |
 
 ### MetricsHub Community Connectors v1.0.12
 
 #### What's New
 
-| ID                                                                         | Description                                              |
-| -------------------------------------------------------------------------- | -------------------------------------------------------- |
-| [**\#162**](https://github.com/MetricsHub/community-connectors/issues/162) | Added support for **Apache Cassandra** databases via JMX |
+| ID                                                                         | Description                                                                             |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [**\#162**](https://github.com/MetricsHub/community-connectors/issues/162) | Added support for [**Apache Cassandra**](./connectors/cassandra.html) databases via JMX |
 
 #### Changes and Improvements
 

--- a/metricshub-doc/src/site/markdown/release-notes.md
+++ b/metricshub-doc/src/site/markdown/release-notes.md
@@ -5,6 +5,88 @@ description: Learn more about the new features, changes and improvements, and bu
 
 <!-- MACRO{toc|fromDepth=1|toDepth=1|id=toc} -->
 
+## MetricsHub Enterprise Edition v2.1.00
+
+### MetricsHub Enterprise Edition v2.1.00
+
+#### What's New
+
+| ID                                                                        | Description                                       |
+| ------------------------------------------------------------------------- | ------------------------------------------------- |
+| [**\#60**](https://github.com/MetricsHub/metricshub-enterprise/issues/60) | Included the **IBM Informix** JDBC driver         |
+| [**\#68**](https://github.com/MetricsHub/metricshub-enterprise/issues/68) | Added support for Java Management Extension (JMX) |
+| [**\#69**](https://github.com/MetricsHub/metricshub-enterprise/issues/69) | Added support for REST API and remote MCP         |
+
+#### Changes and Improvements
+
+| ID                                                                        | Description                                         |
+| ------------------------------------------------------------------------- | --------------------------------------------------- |
+| [**\#57**](https://github.com/MetricsHub/metricshub-enterprise/issues/57) | Upgraded OpenTelemetry Collector Contrib to 0.127.0 |
+
+### MetricsHub Enterprise Connectors v107
+
+#### What's New
+
+| ID                                                                        | Description                                           |
+| ------------------------------------------------------------------------- | ----------------------------------------------------- |
+| [**\#27**](https://github.com/MetricsHub/enterprise-connectors/issues/27) | Added support for **IBM Informix** databases via JDBC |
+| [**\#32**](https://github.com/MetricsHub/enterprise-connectors/issues/32) | Added support for **Palo Alto** firewalls via SNMP    |
+
+#### Changes and Improvements
+
+| ID                                                                        | Description                                                                     |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [**\#57**](https://github.com/MetricsHub/enterprise-connectors/issues/57) | **Nvidia DGX Server (REST)**: Improved HTTP requests initiated by the connector |
+
+### MetricsHub Community Edition v1.0.04
+
+#### What's New
+
+| ID                                                                         | Description                                            |
+| -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [**\#692**](https://github.com/MetricsHub/metricshub-community/issues/692) | MetricsHub Server now supports REST API and Remote MCP |
+| [**\#694**](https://github.com/MetricsHub/metricshub-community/issues/694) | Added support for Java Management Extensions (JMX)     |
+
+#### Changes and Improvements
+
+| ID                                                                         | Description                                                                    |
+| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [**\#357**](https://github.com/MetricsHub/metricshub-community/issues/357) | MetricsHub CLI: Added the ability to specify connector variables               |
+| [**\#658**](https://github.com/MetricsHub/metricshub-community/issues/658) | The `database` property is no longer required under the `jdbc` configuration   |
+| [**\#698**](https://github.com/MetricsHub/metricshub-community/issues/698) | Updated Prometheus Alert Rules                                                 |
+| [**\#726**](https://github.com/MetricsHub/metricshub-community/issues/726) | MetricsHub CLI: The `--list` option now shows connectors that define variables |
+
+#### Fixed Issues
+
+| ID                                                                         | Description                                               |
+| -------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [**\#693**](https://github.com/MetricsHub/metricshub-community/issues/693) | Monitor names are generated for non-hardware monitors     |
+| [**\#703**](https://github.com/MetricsHub/metricshub-community/issues/703) | Metrics processing failure due to `NumberFormatException` |
+| [**\#708**](https://github.com/MetricsHub/metricshub-community/issues/708) | Incorrect SchemaStore link in the documentation           |
+
+#### Documentation Updates
+
+| ID                                                                         | Description                                                      |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [**\#684**](https://github.com/MetricsHub/metricshub-community/issues/684) | Documented custom monitoring examples                            |
+| [**\#702**](https://github.com/MetricsHub/metricshub-community/issues/702) | Explained how to implement custom monitoring through SQL queries |
+| [**\#704**](https://github.com/MetricsHub/metricshub-community/issues/704) | Documented Prometheus Alert Rules                                |
+| [**\#705**](https://github.com/MetricsHub/metricshub-community/issues/705) | Documented BMC Helix integration                                 |
+
+### MetricsHub Community Connectors v1.0.12
+
+#### What's New
+
+| ID                                                                         | Description                                              |
+| -------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [**\#162**](https://github.com/MetricsHub/community-connectors/issues/162) | Added support for **Apache Cassandra** databases via JMX |
+
+#### Changes and Improvements
+
+| ID                                                                         | Description                                                                                              |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [**\#233**](https://github.com/MetricsHub/community-connectors/issues/233) | **MIB-2 Standard SNMP Agent - Network Interfaces**: Added discarded inbound and outbound packets metrics |
+
 ## MetricsHub Enterprise Edition v2.0.00
 
 ### MetricsHub Enterprise Edition v2.0.00

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 	</developers>
 
 	<properties>
-		<community-connectors.version>1.0.11</community-connectors.version>
+		<community-connectors.version>1.0.12-SNAPSHOT</community-connectors.version>
 		<maven.compiler.release>17</maven.compiler.release>
 		<metricshub-jre.version>17.0.15_6</metricshub-jre.version>
 		<project.build.outputTimestamp>2025-05-22T12:35:55Z</project.build.outputTimestamp>


### PR DESCRIPTION
- Bump enterprise version to 2.1.00 and otel to 0.127.0 in `pom.xml`
- Add release notes for MetricsHub Enterprise v2.1.00
- Document new features like JMX, REST API, and Informix JDBC driver
- Include updates for MetricsHub Community v1.0.04 and connectors
- Fix issues and update documentation for community edition
- Add support for Apache Cassandra and Palo Alto firewalls


This pull request introduces updates to the `metricshub-doc` project, including version upgrades and detailed release notes for various editions of MetricsHub. The most significant changes involve version updates in the `pom.xml` file and extensive documentation of new features, improvements, and fixes across different editions.

### Version Updates:
* [`metricshub-doc/pom.xml`](diffhunk://#diff-77ee4fa86779ba8e7a1d78405285cd8eafedbfc46b476339cb8c7d2d6a40b23aL19-R20): Upgraded `enterpriseVersion` to `2.1.00` and `otelVersion` to `0.127.0` to reflect the latest dependencies.

### Documentation Enhancements:
* `metricshub-doc/src/site/markdown/release-notes.md`: Added comprehensive release notes for:
  - **MetricsHub Enterprise Edition v2.1.00**: Introduced support for IBM Informix JDBC driver, JMX, REST API, and remote MCP. Upgraded OpenTelemetry Collector Contrib to `0.127.0`.
  - **MetricsHub Enterprise Connectors v107**: Added support for IBM Informix databases via JDBC and Palo Alto firewalls via SNMP. Improved Nvidia DGX Server connector.
  - **MetricsHub Community Edition v1.0.04**: Added REST API and JMX support, CLI enhancements, Prometheus Alert Rules updates, and several bug fixes.
  - **MetricsHub Community Connectors v1.0.12**: Added JMX support for Apache Cassandra and new SNMP metrics for network interfaces.
  
  ---
Testing
  
![image](https://github.com/user-attachments/assets/7dc6582a-9e27-4136-bbed-e8e3059af10a)
