### PR TITLE
Issue #734: Fixed false positive error for missing `connector_id`

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/KnownMonitorType.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/KnownMonitorType.java
@@ -144,4 +144,14 @@ public enum KnownMonitorType {
 	public static Optional<KnownMonitorType> fromString(final String monitorType) {
 		return Stream.of(KnownMonitorType.values()).filter(type -> type.key.equalsIgnoreCase(monitorType)).findFirst();
 	}
+
+	/**
+	 * Checks if the given monitor type is a connector type.
+	 *
+	 * @param monitorType the monitor type to check
+	 * @return true if the monitor type is a connector, false otherwise
+	 */
+	public static boolean isConnector(final String monitorType) {
+		return CONNECTOR.key.equalsIgnoreCase(monitorType);
+	}
 }

--- a/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/Monitor.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/Monitor.java
@@ -197,4 +197,13 @@ public class Monitor {
 			.map(key -> Optional.ofNullable(attributes.get(key)).orElse(""))
 			.collect(Collectors.joining("_"));
 	}
+
+	/**
+	 * Checks if the monitor is a connector type.
+	 *
+	 * @return {@code true} if the monitor type is a connector, {@code false} otherwise.
+	 */
+	public boolean isConnector() {
+		return KnownMonitorType.isConnector(type);
+	}
 }

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/KnownMonitorTypeTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/KnownMonitorTypeTest.java
@@ -13,29 +13,43 @@ class KnownMonitorTypeTest {
 	void testFromString() {
 		// Test with a valid monitor type string
 		Optional<KnownMonitorType> result = KnownMonitorType.fromString("cpu");
-		assertTrue(result.isPresent());
-		assertEquals(KnownMonitorType.CPU, result.get());
+		assertTrue(result.isPresent(), "Expected 'cpu' to be a valid monitor type");
+		assertEquals(KnownMonitorType.CPU, result.get(), "Expected 'cpu' to match KnownMonitorType.CPU");
 
 		// Test with a valid monitor type string in different case
 		result = KnownMonitorType.fromString("MeMoRy");
-		assertTrue(result.isPresent());
-		assertEquals(KnownMonitorType.MEMORY, result.get());
+		assertTrue(result.isPresent(), "Expected 'MeMoRy' to be a known monitor type");
+		assertEquals(KnownMonitorType.MEMORY, result.get(), "Expected 'MeMoRy' to match KnownMonitorType.MEMORY");
 
 		// Test with an invalid monitor type string
 		result = KnownMonitorType.fromString("net");
-		assertFalse(result.isPresent());
+		assertFalse(result.isPresent(), "Expected 'net' to not be a known monitor type");
 
 		// Test with a valid monitor type string in upper case
 		result = KnownMonitorType.fromString("PHYSICAL_DISK");
-		assertTrue(result.isPresent());
-		assertEquals(KnownMonitorType.PHYSICAL_DISK, result.get());
+		assertTrue(result.isPresent(), "Expected 'PHYSICAL_DISK' to be a known monitor type");
+		assertEquals(
+			KnownMonitorType.PHYSICAL_DISK,
+			result.get(),
+			"Expected 'PHYSICAL_DISK' to match KnownMonitorType.PHYSICAL_DISK"
+		);
 
 		// Test with null input
 		result = KnownMonitorType.fromString(null);
-		assertFalse(result.isPresent());
+		assertFalse(result.isPresent(), "Expected null to not be a known monitor type");
 
 		// Test with empty string input
 		result = KnownMonitorType.fromString("");
-		assertFalse(result.isPresent());
+		assertFalse(result.isPresent(), "Expected empty string to not be a known monitor type");
+	}
+
+	@Test
+	void testIsConnector() {
+		// Test with a connector type
+		assertTrue(KnownMonitorType.isConnector("connector"), "Expected 'connector' to be a connector type");
+
+		// Test with a non-connector type
+		assertFalse(KnownMonitorType.isConnector("cpu"), "Expected 'cpu' to not be a connector type");
+		assertFalse(KnownMonitorType.isConnector("memory"), "Expected 'memory' to not be a connector type");
 	}
 }


### PR DESCRIPTION

- Add `isConnector` method to `KnownMonitorType` and `Monitor` classes
- Update `HardwareMonitorNameGenerationStrategy` to filter endpoints
- Update `HardwareMonitorNameGenerationStrategy` to filter connector
- Enhance `KnownMonitorTypeTest` with `isConnector` test cases
- Refactor test assertions for better readability and clarity
- Use `var` for local variables in `computeIdCount` for conciseness
- Fix typos in comments for consistency and accuracy
---
This pull request introduces functionality to identify and handle "connector" monitor types, improves test coverage, and includes minor code refactoring for readability and consistency. The most significant changes are grouped below by theme.

### New functionality for "connector" monitor types:
* Added `isConnector` method to `KnownMonitorType` to determine if a given monitor type is a "connector" (`metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/KnownMonitorType.java`).
* Introduced `isConnector` method in the `Monitor` class, leveraging the new `KnownMonitorType.isConnector` method (`metricshub-engine/src/main/java/org/metricshub/engine/telemetry/Monitor.java`).
* Updated `setMonitorsNames` method to filter out monitors that are "connectors" (`metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java`).

### Test coverage improvements:
* Enhanced existing tests in `KnownMonitorTypeTest` to include more descriptive failure messages (`metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/KnownMonitorTypeTest.java`).
* Added new test cases for the `isConnector` method in `KnownMonitorTypeTest` to validate behavior for both "connector" and non-connector types (`metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/KnownMonitorTypeTest.java`).

### Code refactoring:
* Made `computeIdCount` method in `HardwareMonitorNameGenerationStrategy` static and replaced explicit types with `var` for improved readability (`metricshub-hardware/src/main/java/org/metricshub/hardware/strategy/HardwareMonitorNameGenerationStrategy.java`).
---
### Testing

![image](https://github.com/user-attachments/assets/f6f7cb7c-e6e8-41be-9cbb-064c2503622a)
