### PR TITLE
Updated site.xml and site.css to render doc just like metricshub.com

### DIFF
--- a/metricshub-doc/src/site/resources/css/site.css
+++ b/metricshub-doc/src/site/resources/css/site.css
@@ -53,8 +53,8 @@
 	font-display: swap;
 }
 
-/* MetricsHub fonts */
 :root {
+	/* MetricsHub fonts */
 	--title-font: "Poppins", sans-serif;
 	--heading-font: "Poppins", sans-serif;
 	--content-font: "Poppins", sans-serif;
@@ -62,172 +62,613 @@
 	--content-font-size: medium;
 	--banner-font-size: 40px;
 	--banner-font-weight: 800;
+	--bottom-font-size: 14px;
 
+
+	/* MetricsHub colors */
+	--metricshub-red: #e50031;
+	--metricshub-green: #45ce52;
+	--metricshub-blue: #2684ff;
+
+	--metricshub-red-dark: #ad0227;
+	--metricshub-green-dark: #088f15;
+	--metricshub-blue-dark: #166fe3;
+
+	--metricshub-red-light: #fd3c65;
+	--metricshub-green-light: #78f885;
+	--metricshub-blue-light: #5ca2ff;
 }
 
- /* MetricsHub colors */
-body {
+/* Light theme */
+body.metricshub,
+html:has(body.metricshub) {
+	--main-bgcolor: #ffffff;
 	--main-fgcolor: #212529;
-	--banner-bgcolor: #266fd0;
-	--link-color: #266fd0;
-	--alternate-bgcolor: #266fd0;
+	--medium-bgcolor: #e9ecef;
+	--light-bgcolor: #f8f9fa;
+	--link-color: var(--metricshub-blue-dark);
+	--alternate-bgcolor: var(--metricshub-blue-dark);
 	--alternate-fgcolor: #fff;
+
+	--banner-bgcolor: var(--medium-bgcolor);
+	--banner-fgcolor: #000;
+	--top-font-size: 16px;
+
+	background-color: var(--main-bgcolor);
 }
 
-body.dark {
-	--link-color: #7cb6ff;
-	--main-bgcolor: #262626;
+/* Dark theme */
+body.metricshub.dark,
+html:has(body.metricshub.dark) {
+	--main-bgcolor: #212529;
 	--main-fgcolor: #e9ecef;
+	--medium-bgcolor: #343a40;
+	--light-bgcolor: #414851;
+	--link-color: var(--metricshub-blue-light);
+	--alternate-bgcolor: var(--metricshub-blue);
+	--banner-fgcolor: #f8f9fa;
 }
 
+/**
+ * Top menu links
+ */
+body.metricshub .site-logo {
+	margin-top: 8px;
+	margin-bottom: 8px;
+	background-color: var(--main-bgcolor);
+}
+
+body.metricshub .site-logo .navbar-header>a,
+body.metricshub .site-logo ul.nav.navbar-nav>li>a {
+	letter-spacing: normal;
+	text-transform: none;
+	color: var(--main-fgcolor);
+	opacity: 1;
+	padding-left: 15px;
+	padding-right: 15px;
+}
+
+body.metricshub .site-logo .navbar-header>a:hover,
+body.metricshub .site-logo ul.nav.navbar-nav>li>a:hover {
+	color: var(--link-color);
+}
+
+body.metricshub .site-logo .navbar-header>a.navbar-brand {
+	font-size: var(--top-font-size);
+}
+
+body.metricshub .site-logo ul.nav.navbar-nav>li>a[href="https://support.metricshub.com"] {
+	background-color: var(--main-bgcolor);
+	color: var(--main-fgcolor);
+	border-radius: 20px;
+	border-style: solid;
+	border-color: var(--main-fgcolor);
+	border-width: 1px;
+	height: 40px;
+	margin-top: 5px;
+	padding-top: 10px;}
+
+body.metricshub .site-logo ul.nav.navbar-nav>li>a[href="https://support.metricshub.com"]:hover {
+	background-color: var(--main-fgcolor);
+	color: var(--main-bgcolor);
+}
+
+body.metricshub .site-logo ul.nav.navbar-nav.navbar-right>li>a
+{
+	font-size: var(--top-font-size);
+	background-color: var(--medium-bgcolor);
+	border-radius: 45px;
+	height: 44px;
+	line-height: 36px;
+	margin-right: 5px;
+}
+
+body.metricshub .site-logo ul.nav.navbar-nav.navbar-right>li>a:hover {
+	background-color: var(--alternate-bgcolor);
+	color: var(--alternate-fgcolor);
+}
+
+body.metricshub li.dark-toggle .toggle.dark-toggle {
+	width: 45px !important;
+	height: 45px !important;
+	border-radius: 22px;
+	margin: 0;
+}
+
+body.metricshub li.dark-toggle .toggle-on-pad {
+	font-size: var(--top-font-size) !important;
+	padding-top: 11px !important;
+}
+
+body.metricshub li.dark-toggle .toggle-off-pad {
+	font-size: var(--top-font-size) !important;
+	padding-top: 13px !important;
+}
+
+body.metricshub header .site-logo-xs a::before {
+	content: " ";
+	display: inline-block;
+	background-image: url(../images/metricshub-logo.png);
+	background-repeat: no-repeat;
+	background-position: center;
+	height: 30px;
+	width: 53px;
+	margin-bottom: -10px;
+}
+
+/**
+ * Banner
+ */
+body.metricshub .site-banner .navbar-brand {
+	max-width: calc(100vw - 1em - 35px);
+}
+
+body.metricshub .site-banner .header-title,
+body.metricshub .site-banner .header-subtitle {
+	overflow: clip;
+	text-overflow: ellipsis;
+}
+
+/**
+ * Left menu
+ */
+body.metricshub nav.left-menu {
+	background-color: var(--light-bgcolor);
+}
+
+body.metricshub nav.left-menu h5 {
+	color: var(--main-fgcolor);
+	margin-top: 40px;
+	margin-bottom: 10px;
+}
+
+body.metricshub nav.left-menu>ul>li:first-child {
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+body.metricshub nav.left-menu ul>li>a {
+	color: var(--main-fgcolor);
+	background-color: var(--medium-bgcolor);
+	border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+body.metricshub nav.left-menu ul>li:not(.active)>a:hover {
+	background-color: var(--main-bgcolor);
+	color: var(--main-fgcolor);
+}
+
+body.metricshub nav.left-menu ul>li.active>a,
+body.metricshub nav.left-menu ul>li.active>a:hover {
+	background-color: var(--alternate-bgcolor);
+	color: var(--alternate-fgcolor);
+}
+
+body.metricshub nav.left-menu code {
+	color: var(--main-fgcolor)
+}
+
+/**
+ * Main content
+ */
+body.metricshub .main-content .breadcrumb::after {
+	background-color: var(--light-bgcolor);
+	opacity: 1;
+}
+
+body.metricshub .toc-side-container .toc::after {
+	background-color: var(--light-bgcolor);
+	opacity: 1;
+	border-radius: 4px;
+}
+
+body.metricshub .toc-inline-container #toc::after {
+	border-left-color: var(--medium-bgcolor);
+	opacity: 1;
+}
+
+body.metricshub .main-content .document-footer .keywords .label::after {
+	background-color: var(--alternate-bgcolor);
+	opacity: 1;
+	border-radius: 14px;
+}
+
+body.metricshub .main-content .document-footer .keywords .label:hover::after {
+	background-color: var(--main-fgcolor);
+}
+
+body.metricshub .main-content .document-footer .keywords .label {
+	color: var(--alternate-fgcolor);
+	letter-spacing: normal;
+	font-weight: 400;
+	padding-left: 10px;
+	padding-right: 10px;
+}
+
+body.metricshub .main-content .document-footer .keywords .label:hover {
+	color: var(--main-bgcolor);
+}
+
+/** Various stuff in the main content */
+body.metricshub .main-content .label-default {
+	background-color: var(--medium-bgcolor);
+}
+body.metricshub .main-content .label {
+	border-radius: 1em;
+	padding-left: 1em;
+	padding-right: 1em;
+	font-weight: 400;
+}
+
+body.metricshub .main-content .label-default.metricshub-tag {
+	background-color: var(--alternate-bgcolor);
+	color: var(--alternate-fgcolor);
+	transition: background-color .2s ease-in-out, color .2s ease-in-out;
+}
+body.metricshub .main-content .label-default.metricshub-tag:hover {
+	background-color: var(--main-fgcolor);
+	color: var(--main-bgcolor);
+}
+body.metricshub .main-content .label-default.metricshub-tag a {
+	color: inherit;
+	text-decoration: none;
+}
+
+body.sentry-site.metricshub .table>tbody>tr {
+	position: unset;
+	z-index: unset;
+	background: unset;
+}
+body.sentry-site.metricshub .table>tbody>tr::after {
+	display: none;
+}
+body.sentry-site.metricshub:not(.dark) .table-striped>tbody>tr:nth-of-type(odd) {
+	background-color: var(--light-bgcolor);
+}
+body.sentry-site.metricshub.dark .table-striped>tbody>tr:nth-of-type(odd) {
+	background-color: var(--medium-bgcolor);
+}
+
+/**
+ * Footer
+ */
+body.metricshub footer {
+	background-color: var(--light-bgcolor);
+	color: var(--main-fgcolor);
+	letter-spacing: normal;
+	text-transform: none;
+}
+
+body.metricshub footer .site-logo.site-logo-xs {
+	background-color: var(--light-bgcolor);
+}
+
+body.metricshub footer .site-logo.additional-links {
+	background-color: var(--light-bgcolor);
+}
+
+body.metricshub footer .site-logo .navbar-header>a,
+body.metricshub footer .site-logo ul.nav.navbar-nav>li>a {
+	padding-left: 10px;
+	padding-right: 10px;
+	font-size: var(--bottom-font-size);
+}
+
+/* Add some spacing around the button to Support Desk in footer in mobile mode */
+body.metricshub footer .site-logo-xs li>a[href="https://support.metricshub.com"] {
+	margin-top: 15px;
+	margin-bottom: 15px;
+}
+
+body.metricshub footer .navbar.site-logo.site-logo-xs>.nav.navbar-nav>li.icons {
+	padding-top: 20px;
+}
+
+body.metricshub footer .navbar.site-logo.site-logo-xs>.nav.navbar-nav>li.icons>a {
+	font-size: 32px;
+	padding-left: 20px;
+	padding-right: 20px;
+}
+
+/* Removes the second MetricsHub item in the list, as it's duplicate with the project name */
+body.metricshub footer .site-logo-xs li:nth-child(2) {
+	display: none;
+}
+
+body.metricshub footer>.footer-copyright a {
+	color: var(--main-fgcolor)
+}
+
+/* Make the day/night toggle full width in mobile footer */
+body.metricshub footer .site-logo-xs li.dark-toggle .toggle.dark-toggle {
+	width: 100% !important;
+}
+
+/* Align the sun and moon in the toggle (eclipse? 😅) */
+body.metricshub footer .site-logo-xs .toggle-off-pad.btn {
+	padding-left: 18px;
+}
+
+/**
+ * Code
+ */
+
+body.sentry-site.metricshub code,
+body.sentry-site.metricshub pre,
+body.sentry-site.metricshub pre>code {
+	background-color: var(--medium-bgcolor);
+	color: var(--main-fgcolor);
+	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	direction: ltr;
+	text-align: left;
+	word-break: break-all;
+	font-size: .9em;
+	line-height: 1.2em;
+	tab-size: 4;
+	hyphens: none;
+	position: unset;
+}
+
+/* Code blocks */
+body.sentry-site.metricshub pre {
+	padding: .5em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+/* Remove the unnecessary background from inline code */
+body.sentry-site.metricshub :not(pre)>code {
+	background-color: var(--medium-bgcolor);
+	color: var(--main-fgcolor);
+	font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace;
+	position: unset;
+	z-index: unset;
+}
+
+body.sentry-site.metricshub :not(pre)>code::after {
+	display: none;
+}
+
+/* Selection styles */
+body.metricshub pre::selection,
+body.sentry-site.metricshub pre ::selection,
+body.sentry-site.metricshub code::selection,
+body.sentry-site.metricshub code ::selection {
+	background: var(--alternate-bgcolor);
+}
+
+/* Light theme */
+body.metricshub:not(.dark) .token.comment,
+body.metricshub:not(.dark) .token.prolog,
+body.metricshub:not(.dark) .token.doctype,
+body.metricshub:not(.dark) .token.cdata {
+	color: #999c9f;
+	font-style: italic;
+}
+
+body.metricshub:not(.dark) .token.namespace {
+	opacity: .7;
+}
+
+body.metricshub:not(.dark) .token.string,
+body.metricshub:not(.dark) .token.attr-value,
+body.metricshub:not(.dark) .token.inserted {
+	color: var(--metricshub-green-dark);
+}
+
+body.metricshub:not(.dark) .token.punctuation,
+body.metricshub:not(.dark) .token.operator {
+	color: #393a3c;
+}
+
+body.metricshub:not(.dark) .token.entity,
+body.metricshub:not(.dark) .token.url,
+body.metricshub:not(.dark) .token.symbol,
+body.metricshub:not(.dark) .token.number,
+body.metricshub:not(.dark) .token.boolean,
+body.metricshub:not(.dark) .token.variable,
+body.metricshub:not(.dark) .token.constant,
+body.metricshub:not(.dark) .token.property,
+body.metricshub:not(.dark) .token.regex {
+	color: var(--metricshub-red-dark);
+}
+
+body.metricshub:not(.dark) .token.atrule,
+body.metricshub:not(.dark) .token.keyword,
+body.metricshub:not(.dark) .token.attr-name,
+body.metricshub:not(.dark) .token.class-name {
+	color: var(--metricshub-blue-dark);
+}
+
+body.metricshub:not(.dark) .token.function,
+body.metricshub:not(.dark) .token.deleted {
+	color: var(--metricshub-red);
+}
+
+body.metricshub:not(.dark) .token.tag,
+body.metricshub:not(.dark) .token.selector {
+	color: var(--metricshub-blue);
+}
+
+body.metricshub:not(.dark) .token.important,
+body.metricshub:not(.dark) .token.function,
+body.metricshub:not(.dark) .token.bold {
+	font-weight: bold;
+}
+
+body.metricshub:not(.dark) .token.italic {
+	font-style: italic;
+}
+
+/* Dark theme */
+body.metricshub.dark .token.comment,
+body.metricshub.dark .token.prolog,
+body.metricshub.dark .token.doctype,
+body.metricshub.dark .token.cdata {
+	color: #999c9f;
+	font-style: italic;
+}
+
+body.metricshub.dark .token.namespace {
+	opacity: .7;
+}
+
+body.metricshub.dark .token.string,
+body.metricshub.dark .token.attr-value,
+body.metricshub.dark .token.inserted {
+	color: var(--metricshub-green);
+}
+
+body.metricshub.dark .token.punctuation,
+body.metricshub.dark .token.operator {
+	color: #a9acb3;
+}
+
+body.metricshub.dark .token.entity,
+body.metricshub.dark .token.url,
+body.metricshub.dark .token.symbol,
+body.metricshub.dark .token.number,
+body.metricshub.dark .token.boolean,
+body.metricshub.dark .token.variable,
+body.metricshub.dark .token.constant,
+body.metricshub.dark .token.property,
+body.metricshub.dark .token.regex {
+	color: var(--metricshub-green);
+}
+
+body.metricshub.dark .token.atrule,
+body.metricshub.dark .token.keyword,
+body.metricshub.dark .token.attr-name,
+body.metricshub.dark .token.class-name {
+	color: var(--metricshub-blue-light);
+}
+
+body.metricshub.dark .token.function,
+body.metricshub.dark .token.deleted {
+	color: var(--metricshub-red-light);
+}
+
+body.metricshub.dark .token.tag,
+body.metricshub.dark .token.selector {
+	color: var(--metricshub-green-light);
+}
+
+body.metricshub.dark .token.important,
+body.metricshub.dark .token.function,
+body.metricshub.dark .token.bold {
+	font-weight: bold;
+}
+
+body.metricshub.dark .token.italic {
+	font-style: italic;
+}
+
+/* Platform tiles */
 body.metricshub.dark .platform-tile {
-    background: #333;
-    color: #ffffff;
-    box-shadow: none;
+	background: var(--light-bgcolor);
+	color: var(--main-fgcolor);
+	box-shadow: none;
 }
 
 body.metricshub.dark .platform-tile:hover {
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+	box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
 }
 
 body.metricshub.dark .platform-tile .platform-title {
-    color: #fff;
-}
-
-/* Special PrismJS colors for <code> element containing JSON */
-body.metricshub code[class*=language-js] {
-	color: #606060;
-}
-body.metricshub.dark code[class*=language-js] {
-	color: #d9d9d9;
-}
-
-body.metricshub code[class*=language-js] .token.punctuation {
-	color: #0046a4;
-}
-body.metricshub.dark code[class*=language-js] .token.punctuation {
-	color: #1bdbf3
-}
-
-.metricshub code[class*=language-js] .token.operator {
-	color: #00660b;
-}
-.metricshub.dark code[class*=language-js] .token.operator {
-	color: #5ffc6f;
-}
-.metricshub code[class*=language-js] .token.string {
-	color: #a40627;
-}
-.metricshub.dark code[class*=language-js] .token.string {
-	color: #ff9e9e;
-}
-
-.metricshub code[class*=language-js]::selection,
-.metricshub code[class*=language-js] ::selection
-{
-	text-shadow: none;
-	background: var(--banner-bgcolor);
-	color: var(--banner-fgcolor);
-}
-
-.metricshub .metricshub-tag a {
-	color: white;
-	text-decoration: none;
-	font-size: small;
+	color: var(--main-fgcolor);
 }
 
 .metricshub .platform-tile-container {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 20px;
-    padding: 10px;
-    width: 100%;
+	display: grid;
+	grid-template-columns: repeat(4, 1fr);
+	gap: 20px;
+	padding: 10px;
+	width: 100%;
 }
 
 .metricshub .platform-tile {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    background: rgb(230 230 230);
-    border-radius: 8px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    text-align: center;
-    padding: 20px;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    text-decoration: none;
-    color: inherit;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	align-items: center;
+	background-color: var(--medium-bgcolor);
+	border-radius: 8px;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+	text-align: center;
+	padding: 20px;
+	transition: transform 0.3s ease, box-shadow 0.3s ease;
+	text-decoration: none;
+	color: var(--main-fgcolor);
 }
 
 .metricshub .platform-tile:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
-    cursor: pointer;
+	transform: translateY(-5px);
+	box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
+	cursor: pointer;
 }
 
 .metricshub .platform-tile .platform-title {
-    font-size: 18px;
-    color: #333;
-    text-align: center;
-    min-height: 50px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	font-size: 18px;
+	color: var(--main-fgcolor);
+	text-align: center;
+	min-height: 50px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .metricshub .platform-tile .platform-title .connectors-badge {
-    margin-top: 0px;
-    padding-left: 10px;
-    padding-bottom: 5px;
+	margin-top: 0px;
+	padding-left: 10px;
+	padding-bottom: 5px;
 }
 
 .metricshub .platform-tile .platform-icon {
-    width: 140px;
-    height: 140px;
-    background-size: cover;
-    background-position: center;
-    margin-bottom: 15px;
+	width: 140px;
+	height: 140px;
+	background-size: cover;
+	background-position: center;
+	margin-bottom: 15px;
 }
 
 .metricshub .platform-tile .platform-labels {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 10px;
-    width: 100%;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 10px;
+	margin-top: 10px;
+	width: 100%;
 }
 
 .metricshub .platform-tile .badge,
 .metricshub .platform-tile .label {
-    font-size: 10px;
-    padding: 5px 10px;
-    text-align: center;
-    white-space: nowrap;
+	font-size: 10px;
+	padding: 5px 10px;
+	text-align: center;
+	white-space: nowrap;
 }
 
 .metricshub .platform-tile div:last-child {
-    margin-top: auto;
+	margin-top: auto;
 }
 
 @media (max-width: 1200px) and (min-width: 993px) {
-    .metricshub .platform-tile-container {
-        grid-template-columns: repeat(3, 1fr);
-    }
+	.metricshub .platform-tile-container {
+		grid-template-columns: repeat(3, 1fr);
+	}
 }
 
 @media (max-width: 992px) and (min-width: 769px) {
-    .metricshub .platform-tile-container {
-        grid-template-columns: repeat(2, 1fr);
-    }
+	.metricshub .platform-tile-container {
+		grid-template-columns: repeat(2, 1fr);
+	}
 }
 
 @media (max-width: 768px) {
-    .metricshub .platform-tile-container {
-        grid-template-columns: repeat(1, 1fr);
-    }
+	.metricshub .platform-tile-container {
+		grid-template-columns: repeat(1, 1fr);
+	}
 
-    .metricshub .platform-tile {
-        padding: 40px;
-    }
+	.metricshub .platform-tile {
+		padding: 40px;
+	}
 }

--- a/metricshub-doc/src/site/resources/css/site.css
+++ b/metricshub-doc/src/site/resources/css/site.css
@@ -146,11 +146,14 @@ body.metricshub .site-logo ul.nav.navbar-nav>li>a[href="https://support.metricsh
 	border-width: 1px;
 	height: 40px;
 	margin-top: 5px;
-	padding-top: 10px;}
+	padding-top: 10px;
+	transition: background-color .2s ease-in-out, color .2s ease-in-out, border-color .2s ease-in-out;
+}
 
 body.metricshub .site-logo ul.nav.navbar-nav>li>a[href="https://support.metricshub.com"]:hover {
-	background-color: var(--main-fgcolor);
-	color: var(--main-bgcolor);
+	background-color: var(--alternate-bgcolor);
+	color: var(--alternate-fgcolor);
+	border-color: var(--alternate-bgcolor);
 }
 
 body.metricshub .site-logo ul.nav.navbar-nav.navbar-right>li>a
@@ -267,52 +270,53 @@ body.metricshub .toc-inline-container #toc::after {
 }
 
 body.metricshub .main-content .document-footer .keywords .label::after {
-	background-color: var(--alternate-bgcolor);
-	opacity: 1;
-	border-radius: 14px;
-}
-
-body.metricshub .main-content .document-footer .keywords .label:hover::after {
-	background-color: var(--main-fgcolor);
+	display: none;
 }
 
 body.metricshub .main-content .document-footer .keywords .label {
-	color: var(--alternate-fgcolor);
+	background-color: inherit;
+	color: inherit;
 	letter-spacing: normal;
 	font-weight: 400;
-	padding-left: 10px;
-	padding-right: 10px;
 }
 
 body.metricshub .main-content .document-footer .keywords .label:hover {
-	color: var(--main-bgcolor);
+	color: inherit;
 }
 
 /** Various stuff in the main content */
+
+/* Labels */
 body.metricshub .main-content .label-default {
-	background-color: var(--medium-bgcolor);
+	background-color: inherit;
 }
 body.metricshub .main-content .label {
-	border-radius: 1em;
+	color: var(--main-fgcolor);
 	padding-left: 1em;
 	padding-right: 1em;
 	font-weight: 400;
-}
-
-body.metricshub .main-content .label-default.metricshub-tag {
-	background-color: var(--alternate-bgcolor);
-	color: var(--alternate-fgcolor);
+	border-radius: 1em;
+	border-style: solid;
+	border-color: var(--main-fgcolor);
+	border-width: 1px;
 	transition: background-color .2s ease-in-out, color .2s ease-in-out;
 }
+
+/* Tags (produced by the MetricsHub connectors report)*/
+body.metricshub .main-content .label-default.metricshub-tag {
+	transition: background-color .2s ease-in-out, color .2s ease-in-out, border-color .2s ease-in-out;
+}
 body.metricshub .main-content .label-default.metricshub-tag:hover {
-	background-color: var(--main-fgcolor);
-	color: var(--main-bgcolor);
+	background-color: var(--alternate-bgcolor);
+	color: var(--alternate-fgcolor);
+	border-color: var(--alternate-bgcolor);
 }
 body.metricshub .main-content .label-default.metricshub-tag a {
 	color: inherit;
 	text-decoration: none;
 }
 
+/* Tables */
 body.sentry-site.metricshub .table>tbody>tr {
 	position: unset;
 	z-index: unset;
@@ -326,6 +330,11 @@ body.sentry-site.metricshub:not(.dark) .table-striped>tbody>tr:nth-of-type(odd) 
 }
 body.sentry-site.metricshub.dark .table-striped>tbody>tr:nth-of-type(odd) {
 	background-color: var(--medium-bgcolor);
+}
+
+/* Bullets in metrics tables */
+body.metricshub #metrics+table ul {
+	padding-left: 20px;
 }
 
 /**
@@ -434,6 +443,34 @@ body.sentry-site.metricshub pre ::selection,
 body.sentry-site.metricshub code::selection,
 body.sentry-site.metricshub code ::selection {
 	background: var(--alternate-bgcolor);
+}
+
+/* Fix an issue with token "label", which inherits Bootstrap's "label" properties! */
+body.metricshub .token.label {
+	display: inherit;
+	padding: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+	text-align: inherit;
+	white-space: inherit;
+	vertical-align: inherit;
+	border-radius: inherit;
+}
+
+/* Copy-paste button */
+body.metricshub .copy-to-clipboard>button {
+	border-radius: 20px;
+	top: -17px;
+	right: 5px;
+}
+body.metricshub .copy-to-clipboard>button.btn-default {
+	background-color: var(--main-bgcolor);
+	border-color: var(--main-fgcolor);
+}
+body.metricshub .copy-to-clipboard>button:hover.btn-default {
+	background-color: var(--main-fgcolor);
+	color: var(--main-bgcolor);
 }
 
 /* Light theme */
@@ -585,7 +622,7 @@ body.metricshub.dark .platform-tile .platform-title {
 	width: 100%;
 }
 
-.metricshub .platform-tile {
+.metricshub a.platform-tile {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -600,13 +637,13 @@ body.metricshub.dark .platform-tile .platform-title {
 	color: var(--main-fgcolor);
 }
 
-.metricshub .platform-tile:hover {
+.metricshub a.platform-tile:hover {
 	transform: translateY(-5px);
 	box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
 	cursor: pointer;
 }
 
-.metricshub .platform-tile .platform-title {
+.metricshub a.platform-tile .platform-title {
 	font-size: 18px;
 	color: var(--main-fgcolor);
 	text-align: center;
@@ -616,7 +653,7 @@ body.metricshub.dark .platform-tile .platform-title {
 	justify-content: center;
 }
 
-.metricshub .platform-tile .platform-title .connectors-badge {
+.metricshub a.platform-tile .platform-title .connectors-badge {
 	margin-top: 0px;
 	padding-left: 10px;
 	padding-bottom: 5px;
@@ -639,12 +676,20 @@ body.metricshub.dark .platform-tile .platform-title {
 	width: 100%;
 }
 
+.metricshub .platform-tile .badge {
+	background-color: var(--main-fgcolor);
+	color: var(--main-bgcolor);
+}
+
 .metricshub .platform-tile .badge,
 .metricshub .platform-tile .label {
-	font-size: 10px;
 	padding: 5px 10px;
-	text-align: center;
+	margin-bottom: -4px;
 	white-space: nowrap;
+}
+
+.metricshub .platform-tile .technology-label {
+	width: 100%;
 }
 
 .metricshub .platform-tile div:last-child {

--- a/metricshub-doc/src/site/site.xml
+++ b/metricshub-doc/src/site/site.xml
@@ -8,7 +8,7 @@
 	</skin>
 
 	<bannerLeft>
-		<name>MetricsHub</name>
+		<name>MetricsHub&reg;</name>
 		<src>images/metricshub-logo.png</src>
 		<href>https://metricshub.com</href>
 		<alt>MetricsHub Official Website</alt>
@@ -21,6 +21,11 @@
 		<keywords>monitoring, observability, opentelemetry, otel</keywords>
 
 		<social>
+			<custom>
+				<title>Contribute on GitHub</title>
+				<href>https://github.com/metricshub</href>
+				<icon>fa-brands fa-github</icon>
+			</custom>
 			<linkedin>metricshub</linkedin>
 			<custom>
 				<title>Join us on Slack!</title>
@@ -61,14 +66,11 @@
 	<body>
 
 		<links>
-			<item name="Open MetricsHub" href="https://metricshub.org" />
-			<item name="&lt;i class='fa-brands fa-github'&gt;&lt;/i&gt; GitHub" href="https://github.com/metricshub/metricshub-community" />
-			<item name="OpenTelemetry" href="https://opentelemetry.io" />
+			<item name="MetricsHub" href="https://metricshub.com" />
+			<item name="Pricing" href="https://metricshub.com/pricing" />
+			<item name="Download" href="https://metricshub.com/download" />
+			<item name="Support Desk" href="https://support.metricshub.com" />
 		</links>
-
-		<breadcrumbs>
-			<item name="MetricsHub&lt;sup&gt;&reg;&lt;/sup&gt;" href="https://metricshub.com" />
-		</breadcrumbs>
 
 		<menu name="Introduction">
 			<item name="Overview" href="index.html" />


### PR DESCRIPTION
Massive changes in `site.css` to make the documentation render just like metricshub.com.

## Before:

<img width="1444" height="857" alt="image" src="https://github.com/user-attachments/assets/c7e278cd-d1e5-4dfd-a7f6-ee12bcb14258" />


## After:

<img width="1460" height="861" alt="image" src="https://github.com/user-attachments/assets/3c5ffbf0-cb53-4493-b87a-0ab6d0e71be9" />

<img width="1452" height="835" alt="image" src="https://github.com/user-attachments/assets/6c55f79b-764e-4fbe-8977-ee36e63bc68b" />

<img width="1488" height="903" alt="image" src="https://github.com/user-attachments/assets/6a1bd0ab-d7b7-442f-ba6e-c5371eb07ab6" />

<img width="1474" height="879" alt="image" src="https://github.com/user-attachments/assets/fa0be9e5-2360-46ed-8c21-3127e00bddb5" />
