### PR TITLE
Issue #749: Added api key based authentication

### DIFF
--- a/metricshub-agent/pom.xml
+++ b/metricshub-agent/pom.xml
@@ -101,7 +101,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+			<version>3.4.5</version>
+		</dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/AgentConstants.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/AgentConstants.java
@@ -149,4 +149,9 @@ public class AgentConstants {
 	 * Jackson Databind ObjectMapper
 	 */
 	public static final ObjectMapper OBJECT_MAPPER = ConfigHelper.newObjectMapper();
+
+	/**
+	 * Prefix for API keys stored in the KeyStore.
+	 */
+	public static final String API_KEY_PREFIX = "api_key:";
 }

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/ApiKeyCliService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/ApiKeyCliService.java
@@ -21,6 +21,8 @@ package org.metricshub.cli.service;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import static org.metricshub.agent.helper.AgentConstants.API_KEY_PREFIX;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -67,8 +69,6 @@ public class ApiKeyCliService {
 
 	@Spec
 	static CommandSpec spec;
-
-	private static final String API_KEY_PREFIX = "api_key:";
 
 	@Command(name = "create", description = "Generate a new API key for a given alias.")
 	public static class CreateCommand implements Callable<Integer> {

--- a/metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java
@@ -97,7 +97,7 @@ public class MetricsHubAgentServer {
 	/**
 	 * Resolves API keys from the KeyStore.
 	 *
-	 * @return a map of API key names to their corresponding IDs
+	 * @return a map of API key names to their corresponding {@link ApiKey} objects
 	 */
 	private static Map<String, ApiKey> resolveApiKeys() {
 		final Map<String, ApiKey> apiKeys = new HashMap<>();

--- a/metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java
@@ -21,11 +21,19 @@ package org.metricshub.web;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.KeyStore.PasswordProtection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.metricshub.agent.context.AgentContext;
+import org.metricshub.agent.helper.AgentConstants;
+import org.metricshub.agent.security.PasswordEncrypt;
+import org.metricshub.engine.security.SecurityManager;
+import org.metricshub.web.security.ApiKeyRegistry;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -64,17 +72,54 @@ public class MetricsHubAgentServer {
 			context =
 				new SpringApplicationBuilder()
 					.sources(MetricsHubAgentServer.class)
-					.initializers((ConfigurableApplicationContext applicationContext) ->
+					.initializers((ConfigurableApplicationContext applicationContext) -> {
 						applicationContext
 							.getBeanFactory()
-							.registerSingleton("agentContextHolder", new AgentContextHolder(agentContext))
-					)
+							.registerSingleton("agentContextHolder", new AgentContextHolder(agentContext));
+						applicationContext
+							.getBeanFactory()
+							.registerSingleton("apiKeyRegistry", new ApiKeyRegistry(resolveApiKeys()));
+					})
 					.run(args.toArray(String[]::new));
 
 			log.info("Started Spring application - Tomcat started on port: {}", applicationPort);
 		} catch (Exception e) {
 			log.error("Failed to start REST API server", e);
 		}
+	}
+
+	/**
+	 * Resolves API keys from the KeyStore.
+	 *
+	 * @return a map of API key names to their corresponding IDs
+	 */
+	private static Map<String, String> resolveApiKeys() {
+		final Map<String, String> apiKeys = new HashMap<>();
+		try {
+			final var keyStoreFile = PasswordEncrypt.getKeyStoreFile(true);
+			final var ks = SecurityManager.loadKeyStore(keyStoreFile);
+
+			final var aliases = ks.aliases();
+			while (aliases.hasMoreElements()) {
+				final var alias = aliases.nextElement();
+				if (!alias.startsWith(AgentConstants.API_KEY_PREFIX)) {
+					continue;
+				}
+
+				final var entry = ks.getEntry(alias, new PasswordProtection(new char[] { 's', 'e', 'c', 'r', 'e', 't' }));
+				if (entry instanceof KeyStore.SecretKeyEntry secreKeyEntry) {
+					final var secretKey = secreKeyEntry.getSecretKey();
+					final var apiKeyId = new String(secretKey.getEncoded(), StandardCharsets.UTF_8);
+					final var apiKeyName = alias.substring(AgentConstants.API_KEY_PREFIX.length());
+					apiKeys.put(apiKeyName, apiKeyId);
+				}
+			}
+		} catch (Exception e) {
+			log.error("Failed to resolve API keys from KeyStore");
+			log.debug("Exception details: ", e);
+		}
+
+		return apiKeys;
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package org.metricshub.web.config;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.metricshub.web.security.ApiKeyAuthFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Security configuration class for the MetricsHub web application.
+ */
+@Configuration
+public class SecurityConfig {
+
+	private ApiKeyAuthFilter apiKeyAuthFilter;
+
+	@Autowired
+	public SecurityConfig(ApiKeyAuthFilter apiKeyAuthFilter) {
+		this.apiKeyAuthFilter = apiKeyAuthFilter;
+	}
+
+	/**
+	 * Configures the security filter chain for the web application.
+	 *
+	 * @param http the HttpSecurity object to configure security settings
+	 * @return the configured SecurityFilterChain
+	 * @throws Exception if an error occurs during configuration
+	 */
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(csrf -> csrf.disable())
+			.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class)
+			.authorizeHttpRequests(authz -> authz.anyRequest().authenticated());
+		return http.build();
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
@@ -51,10 +51,10 @@ public class SecurityConfig {
 	 */
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
+		return http
 			.csrf(csrf -> csrf.disable())
 			.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class)
-			.authorizeHttpRequests(authz -> authz.anyRequest().authenticated());
-		return http.build();
+			.authorizeHttpRequests(authz -> authz.anyRequest().authenticated())
+			.build();
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
@@ -75,6 +75,6 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
 			}
 		}
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		response.getWriter().write("Unauthorized - Invalid API Key");
+		response.getWriter().write("Unauthorized");
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
@@ -1,0 +1,80 @@
+package org.metricshub.web.security;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter to authenticate requests using an API key.
+ */
+@Component
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+	/**
+	 * The header name for the API key in the request.
+	 */
+	private static final String API_KEY_HEADER = "Authorization";
+
+	private ApiKeyRegistry apiKeyRegistry;
+
+	@Autowired
+	public ApiKeyAuthFilter(ApiKeyRegistry apiKeyRegistry) {
+		this.apiKeyRegistry = apiKeyRegistry;
+	}
+
+	/**
+	 * Processes the incoming request to check for a valid API key.
+	 */
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		final var requestApiKey = request.getHeader(API_KEY_HEADER);
+
+		if (requestApiKey != null) {
+			final var token = requestApiKey.replace("Bearer ", "");
+			if (apiKeyRegistry.isValid(token)) {
+				final var authentication = new UsernamePasswordAuthenticationToken(
+					apiKeyRegistry.getPrincipal(token),
+					token,
+					Collections.emptyList()
+				);
+
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+
+				filterChain.doFilter(request, response);
+				return;
+			}
+		}
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.getWriter().write("Unauthorized - Invalid API Key");
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java
@@ -26,7 +26,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -64,14 +63,6 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
 			final var token = requestApiKey.replace("Bearer ", "");
 			if (apiKeyRegistry.isValid(token)) {
 				final var apiKey = apiKeyRegistry.getApiKeyByToken(token);
-				final var expirationDateTime = apiKey.expiresOn();
-				// Expired API keys are not allowed
-				if (expirationDateTime != null && expirationDateTime.isBefore(LocalDateTime.now())) {
-					response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-					response.getWriter().write("Unauthorized - API key expired");
-					return;
-				}
-
 				final var authentication = new UsernamePasswordAuthenticationToken(
 					apiKey.alias(),
 					token,

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
@@ -1,0 +1,67 @@
+package org.metricshub.web.security;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.Map;
+
+/**
+ * Registry for API keys used for authentication. This class provides a method
+ * to validate API keys against a predefined set of keys.
+ */
+public class ApiKeyRegistry {
+
+	private final Map<String, String> apiKeys;
+
+	/**
+	 * Constructor for ApiKeyRegistry.
+	 * @param apiKeys a map of API keys where the key is the identifier and the value is the actual API key.
+	 */
+	public ApiKeyRegistry(Map<String, String> apiKeys) {
+		this.apiKeys = apiKeys;
+	}
+
+	/**
+	 * Validates the provided API key against the registered keys.
+	 *
+	 * @param token the API key to validate.
+	 * @return true if the API key is valid, false otherwise.
+	 */
+	public boolean isValid(final String token) {
+		return apiKeys.containsValue(token);
+	}
+
+	/**
+	 * Retrieves the principal (key) associated with the provided API token.
+	 *
+	 * @param token the API token to look up.
+	 * @return the principal associated with the token, or null if not found.
+	 */
+	public String getPrincipal(final String token) {
+		return apiKeys
+			.entrySet()
+			.stream()
+			.filter(entry -> entry.getValue().equals(token))
+			.map(Map.Entry::getKey)
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
@@ -48,7 +48,12 @@ public class ApiKeyRegistry {
 	 * @return true if the API key is valid, false otherwise.
 	 */
 	public boolean isValid(final String token) {
-		return apiKeys.values().stream().anyMatch(apiKey -> apiKey.key.equals(token));
+		return apiKeys
+			.values()
+			.stream()
+			.anyMatch(apiKey ->
+				apiKey.key.equals(token) && (apiKey.expiresOn == null || apiKey.expiresOn.isAfter(LocalDateTime.now()))
+			);
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java
@@ -21,6 +21,7 @@ package org.metricshub.web.security;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 /**
@@ -29,13 +30,14 @@ import java.util.Map;
  */
 public class ApiKeyRegistry {
 
-	private final Map<String, String> apiKeys;
+	private final Map<String, ApiKey> apiKeys;
 
 	/**
 	 * Constructor for ApiKeyRegistry.
+	 *
 	 * @param apiKeys a map of API keys where the key is the identifier and the value is the actual API key.
 	 */
-	public ApiKeyRegistry(Map<String, String> apiKeys) {
+	public ApiKeyRegistry(Map<String, ApiKey> apiKeys) {
 		this.apiKeys = apiKeys;
 	}
 
@@ -46,7 +48,7 @@ public class ApiKeyRegistry {
 	 * @return true if the API key is valid, false otherwise.
 	 */
 	public boolean isValid(final String token) {
-		return apiKeys.containsValue(token);
+		return apiKeys.values().stream().anyMatch(apiKey -> apiKey.key.equals(token));
 	}
 
 	/**
@@ -55,13 +57,18 @@ public class ApiKeyRegistry {
 	 * @param token the API token to look up.
 	 * @return the principal associated with the token, or null if not found.
 	 */
-	public String getPrincipal(final String token) {
+	public ApiKey getApiKeyByToken(final String token) {
 		return apiKeys
 			.entrySet()
 			.stream()
-			.filter(entry -> entry.getValue().equals(token))
-			.map(Map.Entry::getKey)
+			.filter(entry -> entry.getValue().key.equals(token))
+			.map(Map.Entry::getValue)
 			.findFirst()
 			.orElse(null);
 	}
+
+	/**
+	 * Represents an API key with its associated properties.
+	 */
+	public record ApiKey(String alias, String key, LocalDateTime expiresOn) {}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
@@ -71,10 +71,7 @@ class ApiKeyAuthFilterTest {
 		filter.doFilterInternal(request, response, filterChain);
 
 		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		assertTrue(
-			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
-			"Response should indicate unauthorized access"
-		);
+		assertTrue(responseWriter.toString().contains("Unauthorized"), "Response should indicate unauthorized access");
 
 		verify(filterChain, never()).doFilter(request, response);
 		assertNull(
@@ -94,10 +91,7 @@ class ApiKeyAuthFilterTest {
 		filter.doFilterInternal(request, response, filterChain);
 
 		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		assertTrue(
-			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
-			"Response should indicate unauthorized access"
-		);
+		assertTrue(responseWriter.toString().contains("Unauthorized"), "Response should indicate unauthorized access");
 		verify(filterChain, never()).doFilter(request, response);
 		assertNull(
 			SecurityContextHolder.getContext().getAuthentication(),
@@ -117,10 +111,7 @@ class ApiKeyAuthFilterTest {
 		filter.doFilterInternal(request, response, filterChain);
 
 		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		assertTrue(
-			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
-			"Response should indicate unauthorized access"
-		);
+		assertTrue(responseWriter.toString().contains("Unauthorized"), "Response should indicate unauthorized access");
 		verify(filterChain, never()).doFilter(request, response);
 		assertNull(
 			SecurityContextHolder.getContext().getAuthentication(),

--- a/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
@@ -1,0 +1,130 @@
+package org.metricshub.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class ApiKeyAuthFilterTest {
+
+	private ApiKeyRegistry apiKeyRegistry;
+	private ApiKeyAuthFilter filter;
+	private HttpServletRequest request;
+	private HttpServletResponse response;
+	private FilterChain filterChain;
+
+	private final String validToken = "valid-token";
+	private final String principalName = "principal";
+
+	@BeforeEach
+	void setUp() {
+		apiKeyRegistry = mock(ApiKeyRegistry.class);
+		filter = new ApiKeyAuthFilter(apiKeyRegistry);
+		request = mock(HttpServletRequest.class);
+		response = mock(HttpServletResponse.class);
+		filterChain = mock(FilterChain.class);
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void testValidApiKey() throws ServletException, IOException {
+		when(request.getHeader("Authorization")).thenReturn("Bearer " + validToken);
+		when(apiKeyRegistry.isValid(validToken)).thenReturn(true);
+		when(apiKeyRegistry.getPrincipal(validToken)).thenReturn(principalName);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertNotNull(authentication, "Authentication should not be null");
+		assertEquals(principalName, authentication.getPrincipal(), "Principal should match");
+		assertEquals(validToken, authentication.getCredentials(), "Credentials should match");
+
+		verify(filterChain).doFilter(request, response);
+		verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+
+	@Test
+	void testInvalidApiKey() throws ServletException, IOException {
+		when(request.getHeader("Authorization")).thenReturn("Bearer invalid-token");
+		when(apiKeyRegistry.isValid("invalid-token")).thenReturn(false);
+
+		StringWriter responseWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(responseWriter);
+		when(response.getWriter()).thenReturn(printWriter);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		assertTrue(
+			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
+			"Response should indicate unauthorized access"
+		);
+
+		verify(filterChain, never()).doFilter(request, response);
+		assertNull(
+			SecurityContextHolder.getContext().getAuthentication(),
+			"Authentication should be null for invalid API key"
+		);
+	}
+
+	@Test
+	void testMissingAuthorizationHeader() throws ServletException, IOException {
+		when(request.getHeader("Authorization")).thenReturn(null);
+
+		StringWriter responseWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(responseWriter);
+		when(response.getWriter()).thenReturn(printWriter);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		assertTrue(
+			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
+			"Response should indicate unauthorized access"
+		);
+		verify(filterChain, never()).doFilter(request, response);
+		assertNull(
+			SecurityContextHolder.getContext().getAuthentication(),
+			"Authentication should be null when no Authorization header is present"
+		);
+	}
+
+	@Test
+	void testApiKeyWithoutBearerPrefix() throws ServletException, IOException {
+		when(request.getHeader("Authorization")).thenReturn(validToken); // No "Bearer " prefix
+		when(apiKeyRegistry.isValid(validToken)).thenReturn(false); // Should still fail
+
+		StringWriter responseWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(responseWriter);
+		when(response.getWriter()).thenReturn(printWriter);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		assertTrue(
+			responseWriter.toString().contains("Unauthorized - Invalid API Key"),
+			"Response should indicate unauthorized access"
+		);
+		verify(filterChain, never()).doFilter(request, response);
+		assertNull(
+			SecurityContextHolder.getContext().getAuthentication(),
+			"Authentication should be null when API key is not prefixed with 'Bearer '"
+		);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java
@@ -16,8 +16,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.metricshub.web.security.ApiKeyRegistry.ApiKey;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -46,7 +48,8 @@ class ApiKeyAuthFilterTest {
 	void testValidApiKey() throws ServletException, IOException {
 		when(request.getHeader("Authorization")).thenReturn("Bearer " + validToken);
 		when(apiKeyRegistry.isValid(validToken)).thenReturn(true);
-		when(apiKeyRegistry.getPrincipal(validToken)).thenReturn(principalName);
+		final ApiKey apiKey = new ApiKeyRegistry.ApiKey(principalName, validToken, LocalDateTime.now().plusDays(1));
+		when(apiKeyRegistry.getApiKeyByToken(validToken)).thenReturn(apiKey);
 
 		filter.doFilterInternal(request, response, filterChain);
 

--- a/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyRegistryTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyRegistryTest.java
@@ -1,0 +1,60 @@
+package org.metricshub.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiKeyRegistryTest {
+
+	private ApiKeyRegistry registry;
+
+	private static final String PRINCIPAL_1 = "client-openai-1";
+	private static final String TOKEN_1 = "token-123";
+
+	private static final String PRINCIPAL_2 = "client-openai-2";
+	private static final String TOKEN_2 = "token-456";
+
+	@BeforeEach
+	void setUp() {
+		registry = new ApiKeyRegistry(Map.of(PRINCIPAL_1, TOKEN_1, PRINCIPAL_2, TOKEN_2));
+	}
+
+	@Test
+	void testIsValidWithValidToken() {
+		assertTrue(registry.isValid(TOKEN_1), "Expected TOKEN_1 to be valid");
+		assertTrue(registry.isValid(TOKEN_2), "Expected TOKEN_2 to be valid");
+	}
+
+	@Test
+	void testIsValidWithInvalidToken() {
+		assertFalse(registry.isValid("invalid-token"), "Expected invalid token to be rejected");
+	}
+
+	@Test
+	void testGetPrincipalWithValidToken() {
+		assertEquals(PRINCIPAL_1, registry.getPrincipal(TOKEN_1), "Expected principal for TOKEN_1 to be user1");
+		assertEquals(PRINCIPAL_2, registry.getPrincipal(TOKEN_2), "Expected principal for TOKEN_2 to be user2");
+	}
+
+	@Test
+	void testGetPrincipalWithInvalidToken() {
+		assertNull(registry.getPrincipal("nonexistent-token"), "Expected principal to be null for unknown token");
+	}
+
+	@Test
+	void testIsValidWithEmptyRegistry() {
+		ApiKeyRegistry emptyRegistry = new ApiKeyRegistry(Map.of());
+		assertFalse(emptyRegistry.isValid(TOKEN_1), "Expected TOKEN_1 to be invalid in empty registry");
+	}
+
+	@Test
+	void testGetPrincipalWithEmptyRegistry() {
+		ApiKeyRegistry emptyRegistry = new ApiKeyRegistry(Map.of());
+		assertNull(emptyRegistry.getPrincipal(TOKEN_1), "Expected principal to be null in empty registry");
+	}
+}

--- a/metricshub-doc/src/site/markdown/integrations/ai-agent-mcp.md
+++ b/metricshub-doc/src/site/markdown/integrations/ai-agent-mcp.md
@@ -34,13 +34,20 @@ Before configuring the AI agents integration, make sure that:
 * your AI assistant supports **MCP SSE transport**
 * **MetricsHub is installed and running**
 * you have network access to the machine where **MetricsHub** is running
-* the `31888` port is accessible from your machine or MCP client.
+* the `31888` port is accessible from your machine or MCP client
+* you have generated an [API key](../security/api-keys.md) to authenticate against the **MetricsHub MCP Server**.
 
 > **Important**: Some MCP clients may require **HTTPS with a valid TLS certificate**. In such cases, you must enable HTTPS on your **MetricsHub** instance. One common approach is to place **MetricsHub** behind a reverse proxy (e.g., NGINX or Apache) with TLS termination, and ensure that the certificate is trusted by the client.
 
 ## Configuring the integration
 
 Configure your AI assistant to connect to `http://<hostname>:31888/sse`. Make sure to replace `<hostname>` with the actual hostname or IP address of the machine where **MetricsHub** is running.
+
+Each request to the **MetricsHub MCP Server** must include the [API key](../security/api-keys.md) in the `Authorization` header as follows:
+
+```
+Authorization: Bearer <your_api_key>
+```
 
 ## Using the MCP tools
 


### PR DESCRIPTION
This pull request introduces API key-based authentication for the MetricsHub Agent, along with supporting infrastructure for managing and validating API keys. It also includes updates to the server configuration and tests to ensure the new functionality works as intended.

### Authentication Enhancements:
* Added `spring-boot-starter-security` dependency to enable Spring Security features (`metricshub-agent/pom.xml`).
* Implemented `ApiKeyAuthFilter` to authenticate requests using API keys provided in the `Authorization` header (`metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyAuthFilter.java`).
* Introduced `ApiKeyRegistry` for managing and validating API keys, including support for expiration dates (`metricshub-agent/src/main/java/org/metricshub/web/security/ApiKeyRegistry.java`).
* Created `SecurityConfig` to configure Spring Security with the new API key authentication filter (`metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java`).

### Server Configuration Updates:
* Added a static block to set the default timezone to UTC for consistent time handling (`metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java`).
* Modified the server initialization to register `ApiKeyRegistry` as a singleton bean and resolve API keys from the KeyStore (`metricshub-agent/src/main/java/org/metricshub/web/MetricsHubAgentServer.java`). [[1]](diffhunk://#diff-bbfb7419eaa5cd944d90282085997d5fcb28bc0aee43740f4f36b3510d565fc0L67-R88) [[2]](diffhunk://#diff-bbfb7419eaa5cd944d90282085997d5fcb28bc0aee43740f4f36b3510d565fc0R97-R137)

### Code Refactoring:
* Moved the `API_KEY_PREFIX` constant to `AgentConstants` for centralized management and removed redundant definitions (`metricshub-agent/src/main/java/org/metricshub/agent/helper/AgentConstants.java`, `metricshub-agent/src/main/java/org/metricshub/cli/service/ApiKeyCliService.java`). [[1]](diffhunk://#diff-e9fcffcb336f847ffe7089c9a14138fef0907ff067e661ec5c85831f8983cd19R152-R156) [[2]](diffhunk://#diff-276d3c59aeaa10ab90fe4503e2c11dbad3acada50c006969856eec3c2cd438b1R24-R25) [[3]](diffhunk://#diff-276d3c59aeaa10ab90fe4503e2c11dbad3acada50c006969856eec3c2cd438b1L77-L78)

### Unit Tests:
* Added unit tests for `ApiKeyAuthFilter` to validate authentication logic and error handling (`metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyAuthFilterTest.java`).
* Added unit tests for `ApiKeyRegistry` to verify key validation and retrieval functionality (`metricshub-agent/src/test/java/org/metricshub/web/security/ApiKeyRegistryTest.java`).

### Application Tests
<img width="2041" height="1053" alt="image" src="https://github.com/user-attachments/assets/050fb295-ba71-42e9-a8f4-0bc603c6b010" />
Bad token

<img width="2015" height="1172" alt="image" src="https://github.com/user-attachments/assets/0dd4ef68-9430-454a-870f-ae339f163c9a" />

OpenAI Bad Token
<img width="2306" height="993" alt="image" src="https://github.com/user-attachments/assets/d9f661e0-86df-42b2-b9c6-73f53245cd3b" />
