### PR TITLE
Issue #762: Fixed devices configured with SNMPv3 AES cannot be monitored in MetricsHub Community Edition v1.0.06 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
 			<dependency>
 				<groupId>org.metricshub</groupId>
 				<artifactId>snmp-java</artifactId>
-				<version>2.1.00</version>
+				<version>2.1.01</version>
 			</dependency>
 			<dependency>
 				<groupId>org.metricshub</groupId>


### PR DESCRIPTION
* Updated pom.xml

### Tested 
<img width="1161" height="590" alt="Capture d'écran 2025-08-07 173334" src="https://github.com/user-attachments/assets/eead5f44-5c26-40e5-ad0f-3bc91e86c7c3" />
