### PR TITLE
Issue #775: On Windows, write logs to ./logs if writable instead of s…

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
@@ -122,11 +122,19 @@ public class ConfigHelper {
 	 */
 	public static Path getDefaultOutputDirectory() {
 		if (LocalOsHandler.isWindows()) {
+			try {
+				Path cwdLogs = Paths.get(LOG_DIRECTORY_NAME).toAbsolutePath();
+				Path created = createDirectories(cwdLogs);
+				if (Files.isWritable(created)) {
+					return created;
+				}
+			} catch (IllegalStateException | SecurityException ignored) {}
+
 			final String localAppDataPath = System.getenv("LOCALAPPDATA");
 
 			// Make sure the LOCALAPPDATA path is valid
 			if (localAppDataPath != null && !localAppDataPath.isBlank()) {
-				return createDirectories(Paths.get(localAppDataPath, PRODUCT_WIN_DIR_NAME, "logs"));
+				return createDirectories(Paths.get(localAppDataPath, PRODUCT_WIN_DIR_NAME, LOG_DIRECTORY_NAME));
 			}
 		}
 


### PR DESCRIPTION
* Updated ConfigHelper.java

## Tested : 

### Test 1 : default ./logs is writable

#### MetricsHub community 
<img width="1071" height="713" alt="Capture d'écran 2025-08-19 121950" src="https://github.com/user-attachments/assets/91bb2c4b-5cf4-41b7-9b07-a47ab67e69ec" />
<img width="839" height="297" alt="Capture d'écran 2025-08-19 121520" src="https://github.com/user-attachments/assets/e5e6827b-58e1-4e83-8c1b-8c619121141e" />

#### MetricsHub Entreprise

<img width="1584" height="377" alt="Capture d'écran 2025-08-19 152322" src="https://github.com/user-attachments/assets/3e2af14b-c97f-4e02-b169-59917fb022ca" />


### Test 2 : ./logs not writable (fallback to system path)

#### MetricsHub community 

<img width="984" height="792" alt="Capture d'écran 2025-08-19 121702" src="https://github.com/user-attachments/assets/8d8dc28c-d1a9-4e4d-8d6f-48f9849bf9b4" />
<img width="1137" height="472" alt="Capture d'écran 2025-08-19 121731" src="https://github.com/user-attachments/assets/531c766c-ff0e-4b86-94e2-9b3e58634dd4" />

#### MetricsHub Entreprise 

<img width="1944" height="782" alt="image" src="https://github.com/user-attachments/assets/879df793-c0de-4c89-b89a-6acf0fe93a12" />

### Test 3 : logs is a file (collision) → fallback to system path

#### MetricsHub community 

<img width="1897" height="718" alt="Capture d'écran 2025-08-19 122319" src="https://github.com/user-attachments/assets/67dac9dc-0e96-4de8-a67f-3806b3fddeb9" />

#### MetricsHub Entreprise

<img width="2288" height="782" alt="image" src="https://github.com/user-attachments/assets/9df38544-3629-41c4-98f4-afc1ae3638a4" />

