### PR TITLE
Issue #783: Pin GitHub Actions runners to fixed versions (avoid -latest) until Maven Changelog supports Git ≥2.51

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,12 +20,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-24.04, windows-2025 ]
+        os: [ ubuntu24/20250810.1.0, win25/20250810.1.0 ]
 
     steps:
 
     - name: Install gcc-multilib
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-multilib
@@ -75,28 +75,28 @@ jobs:
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
         name: metricshub-community-linux-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}.tar.gz
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-2025' }}
+      if: ${{ matrix.os == 'win25/20250810.1.0'  }}
       with:
         name: metricshub-community-windows-package-${{ env.metricshub_version }}
         path: ./metricshub-community-windows/target/metricshub-community-windows-${{ env.metricshub_version }}.zip
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
         name: metricshub-site-${{ env.metricshub_version }}
         path: ./metricshub-doc/target/metricshub-doc-${{ env.metricshub_version }}-site.jar
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
         name: metricshub-community-docker-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}-docker.tar.gz

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -20,12 +20,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-2025 ]
 
     steps:
 
     - name: Install gcc-multilib
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-multilib
@@ -75,28 +75,28 @@ jobs:
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-linux-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}.tar.gz
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-2025' }}
       with:
         name: metricshub-community-windows-package-${{ env.metricshub_version }}
         path: ./metricshub-community-windows/target/metricshub-community-windows-${{ env.metricshub_version }}.zip
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-site-${{ env.metricshub_version }}
         path: ./metricshub-doc/target/metricshub-doc-${{ env.metricshub_version }}-site.jar
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-docker-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}-docker.tar.gz

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -20,12 +20,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-2025 ]
 
     steps:
 
     - name: Install gcc-multilib
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-multilib
@@ -78,28 +78,28 @@ jobs:
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-linux-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}.tar.gz
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-2025' }}
       with:
         name: metricshub-community-windows-package-${{ env.metricshub_version }}
         path: ./metricshub-community-windows/target/metricshub-community-windows-${{ env.metricshub_version }}.zip
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-site-${{ env.metricshub_version }}
         path: ./metricshub-doc/target/metricshub-doc-${{ env.metricshub_version }}-site.jar
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-docker-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}-docker.tar.gz

--- a/.github/workflows/maven-deploy.yml
+++ b/.github/workflows/maven-deploy.yml
@@ -20,12 +20,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-24.04, windows-2025 ]
+        os: [ ubuntu24/20250810.1.0, win25/20250810.1.0 ]
 
     steps:
 
     - name: Install gcc-multilib
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-multilib
@@ -78,28 +78,28 @@ jobs:
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-community-linux-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}.tar.gz
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-2025' }}
+      if: ${{ matrix.os == 'win25/20250810.1.0' }}
       with:
         name: metricshub-community-windows-package-${{ env.metricshub_version }}
         path: ./metricshub-community-windows/target/metricshub-community-windows-${{ env.metricshub_version }}.zip
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-site-${{ env.metricshub_version }}
         path: ./metricshub-doc/target/metricshub-doc-${{ env.metricshub_version }}-site.jar
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-community-docker-package-${{ env.metricshub_version }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ env.metricshub_version }}-docker.tar.gz

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -42,7 +42,7 @@ jobs:
   prepare:
     name:  Prepare Release v${{ inputs.releaseVersion }}
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu24/20250810.1.0
 
     outputs:
       branchName: ${{ env.branchName }}
@@ -118,7 +118,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-24.04, windows-2025 ]
+        os: [ ubuntu24/20250810.1.0, win25/20250810.1.0 ]
     
     steps:
 
@@ -180,13 +180,13 @@ jobs:
 
     - name: Upload Maven Site to GitHub Pages
       uses: actions/upload-pages-artifact@v3
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         path: ./metricshub-doc/target/site
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-community-linux-package-${{ inputs.releaseVersion }}
         path: |
@@ -195,7 +195,7 @@ jobs:
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-2025' }}
+      if: ${{ matrix.os == 'win25/20250810.1.0' }}
       with:
         name: metricshub-community-windows-package-${{ inputs.releaseVersion }}
         path: |
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-site-${{ inputs.releaseVersion }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-24.04' }}
+      if: ${{ matrix.os == 'ubuntu24/20250810.1.0' }}
       with:
         name: metricshub-community-docker-package-${{ inputs.releaseVersion }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ inputs.releaseVersion }}-docker.tar.gz
@@ -224,7 +224,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu24/20250810.1.0
     needs: release
     steps:
     - name: Deploy to GitHub Pages
@@ -234,7 +234,7 @@ jobs:
   # Finalize job
   finalize:
     name: Finalize release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu24/20250810.1.0
     needs: [ prepare, release, deploy ]
     steps:
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -42,7 +42,7 @@ jobs:
   prepare:
     name:  Prepare Release v${{ inputs.releaseVersion }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       branchName: ${{ env.branchName }}
@@ -118,7 +118,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-2025 ]
     
     steps:
 
@@ -180,13 +180,13 @@ jobs:
 
     - name: Upload Maven Site to GitHub Pages
       uses: actions/upload-pages-artifact@v3
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         path: ./metricshub-doc/target/site
 
     - name: Upload Linux Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-linux-package-${{ inputs.releaseVersion }}
         path: |
@@ -195,7 +195,7 @@ jobs:
 
     - name: Upload Windows Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-2025' }}
       with:
         name: metricshub-community-windows-package-${{ inputs.releaseVersion }}
         path: |
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload Site Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-site-${{ inputs.releaseVersion }}
         path: |
@@ -213,7 +213,7 @@ jobs:
 
     - name: Upload Docker Artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-24.04' }}
       with:
         name: metricshub-community-docker-package-${{ inputs.releaseVersion }}
         path: ./metricshub-community-linux/target/metricshub-community-linux-${{ inputs.releaseVersion }}-docker.tar.gz
@@ -224,7 +224,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: release
     steps:
     - name: Deploy to GitHub Pages
@@ -234,7 +234,7 @@ jobs:
   # Finalize job
   finalize:
     name: Finalize release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ prepare, release, deploy ]
     steps:
 


### PR DESCRIPTION
* Updated maven-build.yml, maven-deploy.yml, and maven-release.yml