### PR TITLE
Issue #772: Ability to reference ${resource.attribute::ATTRIBUTE} where ATTRIBUTE is an attribute specified at the resource level (or above)

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/helper/ConfigHelper.java
@@ -1151,6 +1151,7 @@ public class ConfigHelper {
 			.configuredConnectorId(configuredConnectorId)
 			.connectorVariables(resourceConfig.getConnectorVariables())
 			.resolveHostnameToFqdn(resourceConfig.getResolveHostnameToFqdn())
+			.attributes(attributes)
 			.build();
 	}
 

--- a/metricshub-engine/src/main/java/org/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/configuration/HostConfiguration.java
@@ -57,6 +57,8 @@ public class HostConfiguration {
 	private DeviceKind hostType;
 	private boolean resolveHostnameToFqdn;
 
+	private Map<String, String> attributes;
+
 	@Default
 	private long strategyTimeout = DEFAULT_JOB_TIMEOUT;
 
@@ -168,6 +170,7 @@ public class HostConfiguration {
 			.connectorVariables(connectorVariables != null ? new HashMap<>(connectorVariables) : null)
 			.configurations(configurations != null ? new HashMap<>(configurations) : null)
 			.configuredConnectorId(configuredConnectorId)
+			.attributes(attributes != null ? new HashMap<>(attributes) : null)
 			.build();
 	}
 }

--- a/metricshub-engine/src/main/java/org/metricshub/engine/configuration/HostConfiguration.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/configuration/HostConfiguration.java
@@ -56,7 +56,6 @@ public class HostConfiguration {
 	private String hostId;
 	private DeviceKind hostType;
 	private boolean resolveHostnameToFqdn;
-
 	private Map<String, String> attributes;
 
 	@Default

--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/source/SourceUpdaterProcessor.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/source/SourceUpdaterProcessor.java
@@ -77,7 +77,12 @@ import org.metricshub.engine.telemetry.TelemetryManager;
 public class SourceUpdaterProcessor implements ISourceProcessor {
 
 	private static final Pattern MONO_INSTANCE_REPLACEMENT_PATTERN = Pattern.compile(
-		"\\$\\{attribute::(\\w+)\\}",
+		"\\$\\{attribute::([^}]+)\\}",
+		Pattern.CASE_INSENSITIVE
+	);
+
+	private static final Pattern RESOURCE_ATTRIBUTE_REFERENCE_PATTERN = Pattern.compile(
+		"\\$\\{resource\\.attribute::([^}]+)\\}",
 		Pattern.CASE_INSENSITIVE
 	);
 
@@ -190,6 +195,9 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 			return runExecuteForEachEntryOf(copy);
 		}
 
+		copy.update(value ->
+			replaceResourceAttributeReferences(value, telemetryManager.getHostConfiguration().getAttributes())
+		);
 		copy.update(value -> replaceAttributeReferences(value, attributes));
 
 		copy.update(value -> replaceSourceReference(value, copy));
@@ -297,30 +305,60 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 	}
 
 	/**
-	 * Replace the attribute identifiers referenced in the key
-	 * with the attribute values that need to be retrieved from the given attributes lookup.
+	 * Replace the attribute identifiers referenced in the key with the attribute
+	 * values that need to be retrieved from the given attributes lookup.
 	 *
-	 * @param key        The key where to replace the deviceId.
-	 * @param attributes Key-value pairs of the monitor's attributes
+	 * @param key        the input string where replacements occur
+	 * @param attributes attribute map
+	 * @param pattern    regex with group 1 capturing the key
 	 * @return String value
 	 */
-	public static String replaceAttributeReferences(final String key, final Map<String, String> attributes) {
-		if (attributes == null || key == null) {
+	private static String replaceReferencesWithPattern(
+		final String key,
+		final Map<String, String> attributes,
+		final Pattern pattern
+	) {
+		if (key == null || attributes == null) {
 			return key;
 		}
 
-		final Matcher matcher = MONO_INSTANCE_REPLACEMENT_PATTERN.matcher(key);
+		final Matcher matcher = pattern.matcher(key);
 
 		final StringBuffer sb = new StringBuffer();
 		while (matcher.find()) {
-			final String attributesValue = attributes.get(matcher.group(1));
+			final String attrKey = matcher.group(1).trim();
+			final String attributesValue = attributes.get(attrKey);
 			if (attributesValue != null) {
 				matcher.appendReplacement(sb, Matcher.quoteReplacement(attributesValue));
 			}
 		}
 		matcher.appendTail(sb);
-
 		return sb.toString();
+	}
+
+	/**
+	 * Replaces `${attribute::KEY}` in {@code key} using monitor attributes.
+	 *
+	 * @param key         input string
+	 * @param attributes  monitor attributes
+	 * @return resolved string, or original {@code key}
+	 */
+	public static String replaceAttributeReferences(final String key, final Map<String, String> attributes) {
+		return replaceReferencesWithPattern(key, attributes, MONO_INSTANCE_REPLACEMENT_PATTERN);
+	}
+
+	/**
+	 * Replaces `${resource.attributes::KEY}` in {@code key} using resource-level attributes.
+	 *
+	 * @param key                 input string
+	 * @param resourceAttributes  resource attributes
+	 * @return resolved string, or original {@code key}
+	 */
+	public static String replaceResourceAttributeReferences(
+		final String key,
+		final Map<String, String> resourceAttributes
+	) {
+		return replaceReferencesWithPattern(key, resourceAttributes, RESOURCE_ATTRIBUTE_REFERENCE_PATTERN);
 	}
 
 	/**
@@ -531,6 +569,9 @@ public class SourceUpdaterProcessor implements ISourceProcessor {
 				continue;
 			}
 
+			copy.update(value ->
+				replaceResourceAttributeReferences(value, telemetryManager.getHostConfiguration().getAttributes())
+			);
 			copy.update(dataValue -> replaceAttributeReferences(dataValue, attributes));
 
 			copy.update(value -> replaceSourceReference(value, copy));

--- a/metricshub-engine/src/test/java/org/metricshub/engine/strategy/source/SourceUpdaterProcessorTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/strategy/source/SourceUpdaterProcessorTest.java
@@ -487,6 +487,26 @@ class SourceUpdaterProcessorTest {
 	}
 
 	@Test
+	void testReplaceResourceAttributeReferences() {
+		String header = "Authorization: Bearer ${resource.attribute::api.token}";
+		assertEquals(
+			"Authorization: Bearer mySecretToken",
+			SourceUpdaterProcessor.replaceResourceAttributeReferences(header, Map.of("api.token", "mySecretToken"))
+		);
+		assertEquals(header, SourceUpdaterProcessor.replaceResourceAttributeReferences(header, Map.of()));
+		assertEquals(header, SourceUpdaterProcessor.replaceResourceAttributeReferences(header, null));
+		assertNull(SourceUpdaterProcessor.replaceResourceAttributeReferences(null, Map.of()));
+		header = "Authorization: Bearer ${resource.attribute::api.token}/${resource.attribute::user.id}";
+		assertEquals(
+			"Authorization: Bearer mySecretToken/user123",
+			SourceUpdaterProcessor.replaceResourceAttributeReferences(
+				header,
+				Map.of("api.token", "mySecretToken", "user.id", "user123")
+			)
+		);
+	}
+
+	@Test
 	void testProcessWbemSource() {
 		final TelemetryManager telemetryManager = TelemetryManager
 			.builder()
@@ -508,11 +528,15 @@ class SourceUpdaterProcessorTest {
 	@Test
 	void testProcessWmiSource() {
 		doReturn(SourceTable.empty()).when(sourceProcessor).process(any(WmiSource.class));
+		final TelemetryManager telemetryManager = TelemetryManager
+			.builder()
+			.hostConfiguration(HostConfiguration.builder().build())
+			.build();
 		assertEquals(
 			SourceTable.empty(),
 			new SourceUpdaterProcessor(
 				sourceProcessor,
-				TelemetryManager.builder().build(),
+				telemetryManager,
 				MY_CONNECTOR_1_NAME,
 				Map.of(MONITOR_ATTRIBUTE_ID, MONITOR_ID_ATTRIBUTE_VALUE)
 			)
@@ -523,12 +547,15 @@ class SourceUpdaterProcessorTest {
 	@Test
 	void testProcessCommandLineSource() {
 		doReturn(SourceTable.empty()).when(sourceProcessor).process(any(CommandLineSource.class));
-
+		final TelemetryManager telemetryManager = TelemetryManager
+			.builder()
+			.hostConfiguration(HostConfiguration.builder().build())
+			.build();
 		assertEquals(
 			SourceTable.empty(),
 			new SourceUpdaterProcessor(
 				sourceProcessor,
-				TelemetryManager.builder().build(),
+				telemetryManager,
 				MY_CONNECTOR_1_NAME,
 				Map.of(MONITOR_ATTRIBUTE_ID, MONITOR_ID_ATTRIBUTE_VALUE)
 			)
@@ -637,11 +664,15 @@ class SourceUpdaterProcessorTest {
 
 		final SourceTable sourceTable = SourceTable.builder().table(List.of(List.of("12345"))).build();
 		doReturn(sourceTable).when(sourceProcessor).process(any(JmxSource.class));
+		final TelemetryManager telemetryManager = TelemetryManager
+			.builder()
+			.hostConfiguration(HostConfiguration.builder().build())
+			.build();
 		assertEquals(
 			sourceTable,
 			new SourceUpdaterProcessor(
 				sourceProcessor,
-				TelemetryManager.builder().build(),
+				telemetryManager,
 				MY_CONNECTOR_1_NAME,
 				Map.of(MONITOR_ATTRIBUTE_ID, MONITOR_ID_ATTRIBUTE_VALUE)
 			)


### PR DESCRIPTION
* Updated ConfigHelper.java, HostConfiguration.java, SourceUpdaterProcessor.java, and SourceUpdaterProcessorTest.java


### Tested :

#### Test 1: attribute defined at the resourceGroups level
<img src="https://github.com/user-attachments/assets/04f009ae-8931-4d48-b5c3-6cc57c5ec2de" width="45%" />
<img src="https://github.com/user-attachments/assets/40fa7bc4-15a7-470e-9901-53dc956c04ef" width="45%" />


<img src="https://github.com/user-attachments/assets/115718a5-c952-4e62-bfa8-4e80a8050f32" width="90%" />

#### Test 2: attribute defined at the resources level
<img src="https://github.com/user-attachments/assets/18598d94-39be-4713-825a-9a0f7ea868c1" width="45%" />
<img src="https://github.com/user-attachments/assets/7e001ac5-6beb-4282-aeb9-1aa7663c4ec3" width="45%" />


<img src="https://github.com/user-attachments/assets/d4b23c8c-ae9e-4bb3-a687-49d77ed6b641" width="90%" />


