### PR TITLE
Issue #777: Fixed TableUnion that doesn't update raw result

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/source/SourceTable.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/source/SourceTable.java
@@ -178,7 +178,11 @@ public class SourceTable {
 
 		// Hard-coded source
 		return Optional.of(
-			SourceTable.builder().table(SourceTable.csvToTable(sourceKey, MetricsHubConstants.TABLE_SEP)).build()
+			SourceTable
+				.builder()
+				.table(SourceTable.csvToTable(sourceKey, MetricsHubConstants.TABLE_SEP))
+				.rawData(sourceKey)
+				.build()
 		);
 	}
 }


### PR DESCRIPTION
This pull request makes a small improvement to the `lookupSourceTable` method by ensuring that the `rawData` field is set when building a `SourceTable` object. This change helps preserve the original source key in the resulting object.

- The `SourceTable` builder in `lookupSourceTable` now sets the `rawData` field to the value of `sourceKey` alongside the `table` field.

### Testing
<img width="714" height="490" alt="image" src="https://github.com/user-attachments/assets/dba21ebf-c7e3-445f-ab48-f16e495c7a40" />

<img width="1576" height="240" alt="image" src="https://github.com/user-attachments/assets/d2f6c7b2-216a-4b0c-a20d-9f794976170c" />

