### PR TITLE
Add full CRUD REST API for configuration files + JUnit tests

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
@@ -88,27 +88,40 @@ public class ConfigurationFilesController {
 			throw ex;
 		} catch (Exception ex) {
 			throw new ResponseStatusException(
-				HttpStatus.INTERNAL_SERVER_ERROR,
-				"Unexpected error while reading file: " + ex.getMessage(),
-				ex
-			);
+					HttpStatus.INTERNAL_SERVER_ERROR,
+					"Unexpected error while reading file: " + ex.getMessage(),
+					ex);
 		}
 	}
 
+	/**
+	 * Endpoint to create or update a configuration file.
+	 * 
+	 * @param fileName the name of the configuration file to create or update.
+	 * @param content  the content to write to the configuration file.
+	 * @return a ResponseEntity with a success message.
+	 */
 	@PutMapping(value = "/content")
 	public ResponseEntity<String> saveOrUpdateConfigurationFile(
-		@RequestParam("name") String fileName,
-		@RequestBody(required = false) String content
-	) {
+			@RequestParam("name") String fileName,
+			@RequestBody(required = false) String content) {
 		configurationFilesService.saveOrUpdateFile(fileName, content);
 		return ResponseEntity.ok("Configuration file saved successfully.");
 	}
 
+	/**
+	 * Endpoint to validate a configuration file's content.
+	 * If no content is provided in the request body, the file currently on disk
+	 * 
+	 * @param fileName the name of the configuration file to validate.
+	 * @param content  the content to validate; if null, validates the file on disk.
+	 * @return an ObjectNode containing validation results.
+	 * @throws ResponseStatusException with status 404 if the file is not found,
+	 */
 	@PostMapping(value = "/content", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<ObjectNode> validateConfigurationFile(
-		@RequestParam("name") String fileName,
-		@RequestBody(required = false) String content
-	) {
+			@RequestParam("name") String fileName,
+			@RequestBody(required = false) String content) {
 		// If no body is provided, validate the file currently on disk
 		if (content == null) {
 			content = configurationFilesService.getFileContent(fileName);
@@ -116,17 +129,32 @@ public class ConfigurationFilesController {
 		return ResponseEntity.ok(configurationFilesService.validateFile(fileName, content));
 	}
 
+	/**
+	 * Endpoint to delete a configuration file by its name.
+	 * 
+	 * @param fileName the name of the configuration file to delete.
+	 * @return a ResponseEntity with no content.
+	 * @throws ResponseStatusException with status 404 if the file is not found.
+	 */
 	@DeleteMapping(value = "/content")
 	public ResponseEntity<Void> deleteConfigurationFile(@RequestParam("name") String fileName) {
 		configurationFilesService.deleteFile(fileName);
 		return ResponseEntity.noContent().build();
 	}
 
+	/**
+	 * Endpoint to rename a configuration file.
+	 * 
+	 * @param oldName the current name of the configuration file.
+	 * @param body    a map containing the new name with key "newName".
+	 * @return a ResponseEntity with no content.
+	 * @throws ResponseStatusException with status 400 if the new name is missing or
+	 *                                 invalid
+	 */
 	@PatchMapping(value = "/content")
 	public ResponseEntity<Void> renameConfigurationFile(
-		@RequestParam("name") String oldName,
-		@RequestBody Map<String, String> body
-	) {
+			@RequestParam("name") String oldName,
+			@RequestBody Map<String, String> body) {
 		final String newName = body == null ? null : body.get("newName");
 		if (newName == null || newName.isBlank()) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Field 'newName' is required.");

--- a/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
@@ -1,0 +1,61 @@
+package org.metricshub.web.controller;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.List;
+import org.metricshub.web.dto.ConfigurationFile;
+import org.metricshub.web.service.ConfigurationFilesService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for managing configuration files.
+ */
+@RestController
+@RequestMapping(value = "/api/config-files")
+public class ConfigurationFilesController {
+
+	private ConfigurationFilesService configurationFilesService;
+
+	/**
+	 * Constructor for ConfigurationFilesController.
+	 *
+	 * @param configurationFilesService the ConfigurationFilesService to handle configuration file requests.
+	 */
+	@Autowired
+	public ConfigurationFilesController(final ConfigurationFilesService configurationFilesService) {
+		this.configurationFilesService = configurationFilesService;
+	}
+
+	/**
+	 * Endpoint to list all configuration files with their metadata.
+	 *
+	 * @return A list of ConfigurationFile representing all configuration files.
+	 */
+	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public List<ConfigurationFile> listConfigurationFiles() {
+		return configurationFilesService.getAllConfigurationFiles();
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/controller/ConfigurationFilesController.java
@@ -26,7 +26,14 @@ import org.metricshub.web.dto.ConfigurationFile;
 import org.metricshub.web.service.ConfigurationFilesService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,12 +44,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "/api/config-files")
 public class ConfigurationFilesController {
 
-	private ConfigurationFilesService configurationFilesService;
+	private final ConfigurationFilesService configurationFilesService;
 
 	/**
 	 * Constructor for ConfigurationFilesController.
 	 *
-	 * @param configurationFilesService the ConfigurationFilesService to handle configuration file requests.
+	 * @param configurationFilesService the ConfigurationFilesService to handle
+	 *                                  configuration file requests.
 	 */
 	@Autowired
 	public ConfigurationFilesController(final ConfigurationFilesService configurationFilesService) {
@@ -57,5 +65,94 @@ public class ConfigurationFilesController {
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public List<ConfigurationFile> listConfigurationFiles() {
 		return configurationFilesService.getAllConfigurationFiles();
+	}
+
+	/**
+	 * Endpoint to get the content of a specific configuration file.
+	 *
+	 * @param fileName The name of the configuration file.
+	 * @return The content of the file as plain text.
+	 */
+	@GetMapping(value = "/{fileName}", produces = MediaType.TEXT_PLAIN_VALUE)
+	public ResponseEntity<String> getConfigurationFile(@PathVariable String fileName) {
+		String content = configurationFilesService.getFileContent(fileName);
+		return ResponseEntity.ok(content);
+	}
+
+	/**
+	 * Endpoint to create or update the content of a configuration file.
+	 *
+	 * @param fileName The name of the configuration file.
+	 * @param content  The new content of the configuration file.
+	 * @return A success message.
+	 */
+	@PutMapping(value = "/{fileName}", consumes = MediaType.TEXT_PLAIN_VALUE)
+	public ResponseEntity<String> saveOrUpdateConfigurationFile(
+		@PathVariable String fileName,
+		@RequestBody String content
+	) {
+		configurationFilesService.saveOrUpdateFile(fileName, content);
+		return ResponseEntity.ok("Configuration file saved successfully.");
+	}
+
+	/**
+	 * Endpoint to validate the content of a configuration file.
+	 *
+	 * @param fileName The name of the configuration file.
+	 * @param content  The content to validate.
+	 * @return A JSON object containing validation errors or success message.
+	 */
+	@PostMapping(
+		value = "/{fileName}",
+		consumes = MediaType.TEXT_PLAIN_VALUE,
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	public ResponseEntity<Object> validateConfigurationFile(@PathVariable String fileName, @RequestBody String content) {
+		var validationResult = configurationFilesService.validateFile(fileName, content);
+		return ResponseEntity.ok(validationResult);
+	}
+
+	/**
+	 * Endpoint to delete a configuration file.
+	 *
+	 * @param fileName The name of the configuration file to delete.
+	 * @return A success message.
+	 */
+	@DeleteMapping(value = "/{fileName}")
+	public ResponseEntity<String> deleteConfigurationFile(@PathVariable String fileName) {
+		configurationFilesService.deleteFile(fileName);
+		return ResponseEntity.ok("Configuration file deleted successfully.");
+	}
+
+	/**
+	 * Endpoint to rename a configuration file.
+	 *
+	 * @param fileName      The current name of the configuration file.
+	 * @param renameRequest The request body containing the new file name.
+	 * @return A success message.
+	 */
+	@PatchMapping(value = "/{fileName}", consumes = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<String> renameConfigurationFile(
+		@PathVariable String fileName,
+		@RequestBody RenameRequest renameRequest
+	) {
+		configurationFilesService.renameFile(fileName, renameRequest.getNewName());
+		return ResponseEntity.ok("Configuration file renamed successfully.");
+	}
+
+	/**
+	 * DTO for rename request body.
+	 */
+	public static class RenameRequest {
+
+		private String newName;
+
+		public String getNewName() {
+			return newName;
+		}
+
+		public void setNewName(String newName) {
+			this.newName = newName;
+		}
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/web/dto/ConfigurationFile.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/dto/ConfigurationFile.java
@@ -1,0 +1,41 @@
+package org.metricshub.web.dto;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO representing a configuration file with its metadata.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConfigurationFile {
+
+	private String name;
+	private long size;
+	private String lastModificationTime;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -130,7 +130,7 @@ public class ConfigurationFilesService {
 	 */
 	private static boolean hasYamlExtension(Path path) {
 		// Make sure the file has a valid yaml extension
-		var fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+		final var fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
 		return YAML_EXTENSIONS.stream().anyMatch(fileName::endsWith);
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -108,6 +108,7 @@ public class ConfigurationFilesService {
 	public String getFileContent(final String fileName) {
 		final Path dir = requireConfigDir();
 		final Path file = resolveSafeYaml(dir, fileName);
+		log.info("Reading config file: {}", file.toAbsolutePath());
 
 		if (!Files.exists(file)) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Configuration file not found.");

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -72,11 +72,7 @@ public class ConfigurationFilesService {
 			final var configurationDirectory = agentContext.getConfigDirectory();
 			// List all the files
 			try (
-				Stream<Path> files = Files.find(
-					configurationDirectory,
-					MAX_DEPTH,
-					ConfigurationFilesService::keepOnlyRegularYamlFile
-				)
+				Stream<Path> files = Files.find(configurationDirectory, MAX_DEPTH, ConfigurationFilesService::isRegularYamlFile)
 			) {
 				return files
 					.map(this::buildConfigurationFile)
@@ -92,12 +88,13 @@ public class ConfigurationFilesService {
 	}
 
 	/**
-	 * Predicate to filter only regular files with YAML extensions.
+	 * Checks if the given path is a regular file with a YAML extension.
+	 *
 	 * @param path                The path to the file.
 	 * @param basicFileAttributes The file attributes.
 	 * @return true if the file is a regular file and has a YAML extension, false otherwise.
 	 */
-	private static boolean keepOnlyRegularYamlFile(final Path path, final BasicFileAttributes basicFileAttributes) {
+	private static boolean isRegularYamlFile(final Path path, final BasicFileAttributes basicFileAttributes) {
 		return basicFileAttributes.isRegularFile() && hasYamlExtension(path);
 	}
 

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -1,0 +1,136 @@
+package org.metricshub.web.service;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.web.AgentContextHolder;
+import org.metricshub.web.dto.ConfigurationFile;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service class for managing configuration files.
+ */
+@Slf4j
+@Service
+public class ConfigurationFilesService {
+
+	/**
+	 * Allowed file extensions for configuration files.
+	 */
+	private static final Set<String> YAML_EXTENSIONS = Set.of(".yml", ".yaml");
+
+	/**
+	 * Maximum directory traversal depth when searching for configuration files.
+	 */
+	private static final int MAX_DEPTH = 1;
+
+	private AgentContextHolder agentContextHolder;
+
+	@Autowired
+	public ConfigurationFilesService(final AgentContextHolder agentContextHolder) {
+		this.agentContextHolder = agentContextHolder;
+	}
+
+	/**
+	 * Retrieves a list of all configuration files with their metadata.
+	 *
+	 * @return A list of {@link ConfigurationFile} representing all configuration files.
+	 */
+	public List<ConfigurationFile> getAllConfigurationFiles() {
+		final var agentContext = agentContextHolder.getAgentContext();
+		if (agentContext != null) {
+			final var configurationDirectory = agentContext.getConfigDirectory();
+			// List all the files
+			try (
+				Stream<Path> files = Files.find(
+					configurationDirectory,
+					MAX_DEPTH,
+					ConfigurationFilesService::keepOnlyRegularYamlFile
+				)
+			) {
+				return files
+					.map(this::buildConfigurationFile)
+					.filter(Objects::nonNull)
+					.sorted(Comparator.comparing(ConfigurationFile::getName, String.CASE_INSENSITIVE_ORDER))
+					.toList();
+			} catch (Exception e) {
+				log.error("Failed to list configuration directory: '{}'. Error: {}", configurationDirectory, e.getMessage());
+				log.debug("Failed to list configuration directory: '{}'. Exception:", configurationDirectory, e);
+			}
+		}
+		return List.of();
+	}
+
+	/**
+	 * Predicate to filter only regular files with YAML extensions.
+	 * @param path                The path to the file.
+	 * @param basicFileAttributes The file attributes.
+	 * @return true if the file is a regular file and has a YAML extension, false otherwise.
+	 */
+	private static boolean keepOnlyRegularYamlFile(final Path path, final BasicFileAttributes basicFileAttributes) {
+		return basicFileAttributes.isRegularFile() && hasYamlExtension(path);
+	}
+
+	/**
+	 * Builds a {@link ConfigurationFile} from the given file path.
+	 *
+	 * @param path the path to the configuration file
+	 * @return the ConfigurationFile with file metadata, or null if an error occurs
+	 */
+	private ConfigurationFile buildConfigurationFile(final Path path) {
+		try {
+			return ConfigurationFile
+				.builder()
+				.name(path.getFileName().toString())
+				.size(Files.size(path))
+				.lastModificationTime(Files.getLastModifiedTime(path).toString())
+				.build();
+		} catch (IOException e) {
+			log.error("Failed to read configuration file metadata: '{}'. Error: {}", path, e.getMessage());
+			log.debug("Failed to read configuration file metadata: '{}'. Exception:", path, e);
+			return null;
+		}
+	}
+
+	/**
+	 * Checks if the file has a valid YAML extension.
+	 *
+	 * @param path the path to the file
+	 * @return true if the file has a valid YAML extension, false otherwise
+	 */
+	private static boolean hasYamlExtension(Path path) {
+		// Make sure the file has a valid yaml extension
+		var fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
+		return YAML_EXTENSIONS.stream().anyMatch(fileName::endsWith);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -21,9 +21,15 @@ package org.metricshub.web.service;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import java.util.List;
@@ -35,7 +41,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.dto.ConfigurationFile;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.error.MarkedYAMLException;
 
 /**
  * Service class for managing configuration files.
@@ -54,7 +64,8 @@ public class ConfigurationFilesService {
 	 */
 	private static final int MAX_DEPTH = 1;
 
-	private AgentContextHolder agentContextHolder;
+	private final AgentContextHolder agentContextHolder;
+	private final Yaml yaml = new Yaml();
 
 	@Autowired
 	public ConfigurationFilesService(final AgentContextHolder agentContextHolder) {
@@ -64,7 +75,8 @@ public class ConfigurationFilesService {
 	/**
 	 * Retrieves a list of all configuration files with their metadata.
 	 *
-	 * @return A list of {@link ConfigurationFile} representing all configuration files.
+	 * @return A list of {@link ConfigurationFile} representing all configuration
+	 *         files.
 	 */
 	public List<ConfigurationFile> getAllConfigurationFiles() {
 		final var agentContext = agentContextHolder.getAgentContext();
@@ -88,11 +100,146 @@ public class ConfigurationFilesService {
 	}
 
 	/**
+	 * Returns the content of a configuration file as UTF-8 text.
+	 *
+	 * @param fileName the configuration file name (e.g. metricshub.yaml)
+	 * @return file content
+	 */
+	public String getFileContent(final String fileName) {
+		final Path dir = requireConfigDir();
+		final Path file = resolveSafeYaml(dir, fileName);
+
+		if (!Files.exists(file)) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Configuration file not found.");
+		}
+		try {
+			return Files.readString(file, StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			log.error("Failed to read configuration file: '{}'. Error: {}", file, e.getMessage());
+			log.debug("Failed to read configuration file: '{}'. Exception:", file, e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to read configuration file.", e);
+		}
+	}
+
+	/**
+	 * Saves or updates the content of a configuration file (atomic write).
+	 *
+	 * @param fileName the configuration file name
+	 * @param content  the content to write
+	 */
+	public void saveOrUpdateFile(final String fileName, final String content) {
+		final Path dir = requireConfigDir();
+		final Path target = resolveSafeYaml(dir, fileName);
+
+		try {
+			Files.createDirectories(dir);
+			// Write to a temp file, then move atomically
+			final Path tmp = Files.createTempFile(dir, fileName + ".", ".tmp");
+			Files.writeString(
+				tmp,
+				content == null ? "" : content,
+				StandardCharsets.UTF_8,
+				StandardOpenOption.TRUNCATE_EXISTING
+			);
+			try {
+				Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+			} catch (AtomicMoveNotSupportedException amnse) {
+				Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} catch (IOException e) {
+			log.error("Failed to save configuration file: '{}'. Error: {}", target, e.getMessage());
+			log.debug("Failed to save configuration file: '{}'. Exception:", target, e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to save configuration file.", e);
+		}
+	}
+
+	/**
+	 * Validates the YAML content of a configuration file.
+	 * Returns a JSON object: { "valid": boolean, "errors": [ ... ] }
+	 *
+	 * @param fileName for context in messages
+	 * @param content  YAML content to validate
+	 * @return validation result JSON
+	 */
+	public ObjectNode validateFile(final String fileName, final String content) {
+		final ObjectNode result = JsonNodeFactory.instance.objectNode();
+		try {
+			yaml.load(content == null ? "" : content);
+			result.put("valid", true);
+			result.putArray("errors");
+			return result;
+		} catch (MarkedYAMLException ye) {
+			final var errors = result.put("valid", false).putArray("errors");
+			errors.add(safeMessage("YAML syntax error in '%s': %s".formatted(fileName, ye.getMessage())));
+			return result;
+		} catch (Exception e) {
+			final var errors = result.put("valid", false).putArray("errors");
+			errors.add(safeMessage("Validation error in '%s': %s".formatted(fileName, e.getMessage())));
+			return result;
+		}
+	}
+
+	/**
+	 * Deletes a configuration file.
+	 *
+	 * @param fileName the configuration file name
+	 */
+	public void deleteFile(final String fileName) {
+		final Path dir = requireConfigDir();
+		final Path file = resolveSafeYaml(dir, fileName);
+
+		try {
+			if (!Files.deleteIfExists(file)) {
+				throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Configuration file not found.");
+			}
+		} catch (ResponseStatusException rse) {
+			throw rse;
+		} catch (IOException e) {
+			log.error("Failed to delete configuration file: '{}'. Error: {}", file, e.getMessage());
+			log.debug("Failed to delete configuration file: '{}'. Exception:", file, e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to delete configuration file.", e);
+		}
+	}
+
+	/**
+	 * Renames (moves) a configuration file to a new name within the same directory.
+	 *
+	 * @param oldName existing file name
+	 * @param newName target file name (must be .yml/.yaml and not exist)
+	 */
+	public void renameFile(final String oldName, final String newName) {
+		final Path dir = requireConfigDir();
+		final Path source = resolveSafeYaml(dir, oldName);
+		final Path target = resolveSafeYaml(dir, newName);
+
+		if (!Files.exists(source)) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Source configuration file not found.");
+		}
+		if (Files.exists(target)) {
+			throw new ResponseStatusException(HttpStatus.CONFLICT, "Target file name already exists.");
+		}
+		try {
+			try {
+				Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+			} catch (AtomicMoveNotSupportedException amnse) {
+				Files.move(source, target);
+			}
+		} catch (IOException e) {
+			log.error("Failed to rename configuration file: '{}' -> '{}'. Error: {}", source, target, e.getMessage());
+			log.debug("Failed to rename configuration file: '{}' -> '{}'. Exception:", source, target, e);
+			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to rename configuration file.", e);
+		}
+	}
+
+	/* =========================== Internals =========================== */
+
+	/**
 	 * Checks if the given path is a regular file with a YAML extension.
 	 *
 	 * @param path                The path to the file.
 	 * @param basicFileAttributes The file attributes.
-	 * @return true if the file is a regular file and has a YAML extension, false otherwise.
+	 * @return true if the file is a regular file and has a YAML extension, false
+	 *         otherwise.
 	 */
 	private static boolean isRegularYamlFile(final Path path, final BasicFileAttributes basicFileAttributes) {
 		return basicFileAttributes.isRegularFile() && hasYamlExtension(path);
@@ -129,5 +276,58 @@ public class ConfigurationFilesService {
 		// Make sure the file has a valid yaml extension
 		final var fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
 		return YAML_EXTENSIONS.stream().anyMatch(fileName::endsWith);
+	}
+
+	/**
+	 * Resolves and validates a YAML file name within a base directory (no
+	 * traversal, correct extension).
+	 *
+	 * @param baseDir  configuration directory
+	 * @param fileName simple file name (no path)
+	 * @return resolved path
+	 */
+	private Path resolveSafeYaml(final Path baseDir, final String fileName) {
+		if (fileName == null || fileName.isBlank()) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "File name is required.");
+		}
+		if (fileName.contains("/") || fileName.contains("\\") || fileName.contains("..")) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid file name.");
+		}
+		final var lower = fileName.toLowerCase(Locale.ROOT);
+		if (YAML_EXTENSIONS.stream().noneMatch(lower::endsWith)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only .yml or .yaml files are allowed.");
+		}
+		final Path resolved = baseDir.resolve(fileName).normalize();
+		if (!resolved.startsWith(baseDir)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid file path.");
+		}
+		return resolved;
+	}
+
+	/**
+	 * Ensures the agent configuration directory is available.
+	 *
+	 * @return configuration directory path
+	 */
+	private Path requireConfigDir() {
+		final var agentContext = agentContextHolder.getAgentContext();
+		if (agentContext == null || agentContext.getConfigDirectory() == null) {
+			throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Configuration directory is not available.");
+		}
+		return agentContext.getConfigDirectory();
+	}
+
+	/**
+	 * Produces a trimmed, safe error message for JSON payloads.
+	 *
+	 * @param raw raw message
+	 * @return sanitized message
+	 */
+	private String safeMessage(final String raw) {
+		if (raw == null) {
+			return "Unknown error";
+		}
+		final String trimmed = raw.strip();
+		return trimmed.length() > 1000 ? trimmed.substring(0, 1000) + "…" : trimmed;
 	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/controller/ConfigurationFilesControllerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/controller/ConfigurationFilesControllerTest.java
@@ -1,12 +1,23 @@
 package org.metricshub.web.controller;
 
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.metricshub.web.dto.ConfigurationFile;
@@ -15,11 +26,14 @@ import org.mockito.Mockito;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
 
 class ConfigurationFilesControllerTest {
 
 	private MockMvc mockMvc;
 	private ConfigurationFilesService configurationFilesService;
+
+	private final ObjectMapper mapper = new ObjectMapper();
 
 	@BeforeEach
 	void setup() {
@@ -68,5 +82,123 @@ class ConfigurationFilesControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(content().json("[]"));
+	}
+
+	// -------------------- NEW TESTS --------------------
+
+	@Test
+	void testShouldGetFileContent() throws Exception {
+		when(configurationFilesService.getFileContent("metricshub.yaml")).thenReturn("key: value\n");
+
+		mockMvc
+			.perform(get("/api/config-files/content").param("name", "metricshub.yaml"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+			.andExpect(content().string("key: value\n"));
+	}
+
+	@Test
+	void testGetFileContentNotFound() throws Exception {
+		when(configurationFilesService.getFileContent("missing.yaml"))
+			.thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.NOT_FOUND, "Not Found"));
+
+		mockMvc.perform(get("/api/config-files/content").param("name", "missing.yaml")).andExpect(status().isNotFound());
+	}
+
+	@Test
+	void testShouldSaveOrUpdateFile() throws Exception {
+		doNothing().when(configurationFilesService).saveOrUpdateFile("metricshub.yaml", "test: noo\n");
+
+		mockMvc
+			.perform(
+				put("/api/config-files/content")
+					.param("name", "metricshub.yaml")
+					.contentType(MediaType.TEXT_PLAIN)
+					.content("test: noo\n".getBytes(StandardCharsets.UTF_8))
+			)
+			.andExpect(status().isOk())
+			.andExpect(content().string("Configuration file saved successfully."));
+
+		verify(configurationFilesService).saveOrUpdateFile("metricshub.yaml", "test: noo\n");
+	}
+
+	@Test
+	void testShouldValidateProvidedYaml() throws Exception {
+		ObjectNode result = JsonNodeFactory.instance.objectNode();
+		result.put("valid", true).putArray("errors");
+
+		when(configurationFilesService.validateFile("metricshub.yaml", "a: 1\n")).thenReturn(result);
+
+		mockMvc
+			.perform(
+				post("/api/config-files/content")
+					.param("name", "metricshub.yaml")
+					.contentType(MediaType.TEXT_PLAIN)
+					.content("a: 1\n")
+					.accept(MediaType.APPLICATION_JSON)
+			)
+			.andExpect(status().isOk())
+			.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.valid").value(true))
+			.andExpect(jsonPath("$.errors").isArray());
+	}
+
+	@Test
+	void testShouldValidateFileOnDiskWhenNoBody() throws Exception {
+		when(configurationFilesService.getFileContent("metricshub.yaml")).thenReturn("x: 2\n");
+
+		ObjectNode result = JsonNodeFactory.instance.objectNode();
+		result.put("valid", false).putArray("errors").add("Invalid YAML");
+
+		when(configurationFilesService.validateFile("metricshub.yaml", "x: 2\n")).thenReturn(result);
+
+		mockMvc
+			.perform(post("/api/config-files/content").param("name", "metricshub.yaml"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.valid").value(false))
+			.andExpect(jsonPath("$.errors[0]").value("Invalid YAML"));
+	}
+
+	@Test
+	void testShouldDeleteFile() throws Exception {
+		doNothing().when(configurationFilesService).deleteFile("metricshub.yaml");
+
+		mockMvc
+			.perform(delete("/api/config-files/content").param("name", "metricshub.yaml"))
+			.andExpect(status().isNoContent());
+
+		verify(configurationFilesService).deleteFile("metricshub.yaml");
+	}
+
+	@Test
+	void testShouldRenameFile() throws Exception {
+		doNothing().when(configurationFilesService).renameFile("old.yaml", "new.yaml");
+
+		String body = mapper.writeValueAsString(Map.of("newName", "new.yaml"));
+
+		mockMvc
+			.perform(
+				patch("/api/config-files/content")
+					.param("name", "old.yaml")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(body)
+			)
+			.andExpect(status().isNoContent());
+
+		verify(configurationFilesService).renameFile("old.yaml", "new.yaml");
+	}
+
+	@Test
+	void testRenameFileMissingNewName() throws Exception {
+		String body = mapper.writeValueAsString(Map.of()); // empty JSON
+
+		mockMvc
+			.perform(
+				patch("/api/config-files/content")
+					.param("name", "old.yaml")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(body)
+			)
+			.andExpect(status().isBadRequest());
 	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/controller/ConfigurationFilesControllerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/controller/ConfigurationFilesControllerTest.java
@@ -1,0 +1,72 @@
+package org.metricshub.web.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.metricshub.web.dto.ConfigurationFile;
+import org.metricshub.web.service.ConfigurationFilesService;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class ConfigurationFilesControllerTest {
+
+	private MockMvc mockMvc;
+	private ConfigurationFilesService configurationFilesService;
+
+	@BeforeEach
+	void setup() {
+		configurationFilesService = Mockito.mock(ConfigurationFilesService.class);
+		final ConfigurationFilesController controller = new ConfigurationFilesController(configurationFilesService);
+		mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+	}
+
+	@Test
+	void testShouldListConfigurationFiles() throws Exception {
+		final ConfigurationFile f1 = ConfigurationFile
+			.builder()
+			.name("metricshub.yaml")
+			.size(1024L)
+			.lastModificationTime("2025-09-01T10:15:30Z")
+			.build();
+
+		final ConfigurationFile f2 = ConfigurationFile
+			.builder()
+			.name("general-settings.yaml")
+			.size(256L)
+			.lastModificationTime("2025-09-02T08:00:00Z")
+			.build();
+
+		when(configurationFilesService.getAllConfigurationFiles()).thenReturn(List.of(f2, f1));
+
+		mockMvc
+			.perform(get("/api/config-files"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.length()").value(2))
+			.andExpect(jsonPath("$[0].name").value("general-settings.yaml"))
+			.andExpect(jsonPath("$[0].size").value(256))
+			.andExpect(jsonPath("$[0].lastModificationTime").value("2025-09-02T08:00:00Z"))
+			.andExpect(jsonPath("$[1].name").value("metricshub.yaml"))
+			.andExpect(jsonPath("$[1].size").value(1024))
+			.andExpect(jsonPath("$[1].lastModificationTime").value("2025-09-01T10:15:30Z"));
+	}
+
+	@Test
+	void testShouldReturnEmptyListWhenNoFiles() throws Exception {
+		when(configurationFilesService.getAllConfigurationFiles()).thenReturn(List.of());
+
+		mockMvc
+			.perform(get("/api/config-files"))
+			.andExpect(status().isOk())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(content().json("[]"));
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
@@ -1,0 +1,78 @@
+package org.metricshub.web.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.context.AgentContext;
+import org.metricshub.web.AgentContextHolder;
+import org.metricshub.web.dto.ConfigurationFile;
+import org.mockito.Mockito;
+
+class ConfigurationFilesServiceTest {
+
+	@TempDir
+	Path tempConfigDir;
+
+	@Test
+	void testShouldListYamlFilesAtDepthOneSorted() throws Exception {
+		// Create files in the temp config directory
+		final Path aYml = tempConfigDir.resolve("a.yml");
+		final Path bYaml = tempConfigDir.resolve("B.yaml");
+		final Path notYaml = tempConfigDir.resolve("ignore.txt");
+		final Path subDir = tempConfigDir.resolve("sub");
+		final Path deepYaml = subDir.resolve("deep.yaml");
+
+		Files.writeString(aYml, "k: v");
+		Files.writeString(bYaml, "say: hello");
+		Files.writeString(notYaml, "nope");
+		Files.createDirectories(subDir);
+		Files.writeString(deepYaml, "too: deep");
+
+		// Mock AgentContextHolder -> AgentContext -> getConfigDirectory()
+		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
+		final AgentContext agentContext = Mockito.mock(AgentContext.class);
+		when(holder.getAgentContext()).thenReturn(agentContext);
+		when(agentContext.getConfigDirectory()).thenReturn(tempConfigDir);
+
+		final ConfigurationFilesService service = new ConfigurationFilesService(holder);
+
+		// Get the configuration YAML files
+		final List<ConfigurationFile> files = service.getAllConfigurationFiles();
+
+		// Assert
+		assertEquals(2, files.size(), "Only .yml/.yaml at depth 1 should be listed");
+
+		// Sorted case-insensitively by name -> "a.yml" then "B.yaml"
+		final ConfigurationFile first = files.get(0);
+		final ConfigurationFile second = files.get(1);
+
+		assertEquals("a.yml", first.getName(), "First file should be a.yml");
+		assertEquals("B.yaml", second.getName(), "Second file should be B.yaml");
+
+		// Sizes should match content length we wrote above
+		assertEquals(Files.size(aYml), first.getSize(), "Size of a.yml should match");
+		assertEquals(Files.size(bYaml), second.getSize(), "Size of B.yaml should match");
+
+		// lastModificationTime should be populated (ISO-8601 string from FileTime#toString)
+		assertNotNull(first.getLastModificationTime(), "lastModificationTime must not be null");
+		assertNotNull(second.getLastModificationTime(), "lastModificationTime must not be null");
+	}
+
+	@Test
+	void testShouldReturnEmptyListWhenNoAgentContext() {
+		// AgentContextHolder returns null -> service should return empty list
+		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
+		when(holder.getAgentContext()).thenReturn(null);
+
+		final ConfigurationFilesService service = new ConfigurationFilesService(holder);
+
+		final List<ConfigurationFile> files = service.getAllConfigurationFiles();
+		assertEquals(0, files.size(), "Should return empty list when AgentContext is null");
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/ConfigurationFilesServiceTest.java
@@ -1,9 +1,11 @@
 package org.metricshub.web.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -13,11 +15,31 @@ import org.metricshub.agent.context.AgentContext;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.dto.ConfigurationFile;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 class ConfigurationFilesServiceTest {
 
 	@TempDir
 	Path tempConfigDir;
+
+	// ---------- helpers ----------
+
+	private ConfigurationFilesService newServiceWithDir(Path dir) {
+		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
+		final AgentContext agentContext = Mockito.mock(AgentContext.class);
+		when(holder.getAgentContext()).thenReturn(agentContext);
+		when(agentContext.getConfigDirectory()).thenReturn(dir);
+		return new ConfigurationFilesService(holder);
+	}
+
+	private ConfigurationFilesService newServiceWithNoContext() {
+		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
+		when(holder.getAgentContext()).thenReturn(null);
+		return new ConfigurationFilesService(holder);
+	}
+
+	// ---------- existing tests (kept) ----------
 
 	@Test
 	void testShouldListYamlFilesAtDepthOneSorted() throws Exception {
@@ -34,45 +56,180 @@ class ConfigurationFilesServiceTest {
 		Files.createDirectories(subDir);
 		Files.writeString(deepYaml, "too: deep");
 
-		// Mock AgentContextHolder -> AgentContext -> getConfigDirectory()
-		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
-		final AgentContext agentContext = Mockito.mock(AgentContext.class);
-		when(holder.getAgentContext()).thenReturn(agentContext);
-		when(agentContext.getConfigDirectory()).thenReturn(tempConfigDir);
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
 
-		final ConfigurationFilesService service = new ConfigurationFilesService(holder);
-
-		// Get the configuration YAML files
 		final List<ConfigurationFile> files = service.getAllConfigurationFiles();
 
-		// Assert
 		assertEquals(2, files.size(), "Only .yml/.yaml at depth 1 should be listed");
 
-		// Sorted case-insensitively by name -> "a.yml" then "B.yaml"
 		final ConfigurationFile first = files.get(0);
 		final ConfigurationFile second = files.get(1);
 
 		assertEquals("a.yml", first.getName(), "First file should be a.yml");
 		assertEquals("B.yaml", second.getName(), "Second file should be B.yaml");
 
-		// Sizes should match content length we wrote above
 		assertEquals(Files.size(aYml), first.getSize(), "Size of a.yml should match");
 		assertEquals(Files.size(bYaml), second.getSize(), "Size of B.yaml should match");
 
-		// lastModificationTime should be populated (ISO-8601 string from FileTime#toString)
 		assertNotNull(first.getLastModificationTime(), "lastModificationTime must not be null");
 		assertNotNull(second.getLastModificationTime(), "lastModificationTime must not be null");
 	}
 
 	@Test
 	void testShouldReturnEmptyListWhenNoAgentContext() {
-		// AgentContextHolder returns null -> service should return empty list
-		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
-		when(holder.getAgentContext()).thenReturn(null);
-
-		final ConfigurationFilesService service = new ConfigurationFilesService(holder);
+		final ConfigurationFilesService service = newServiceWithNoContext();
 
 		final List<ConfigurationFile> files = service.getAllConfigurationFiles();
 		assertEquals(0, files.size(), "Should return empty list when AgentContext is null");
+	}
+
+	// ---------- new tests ----------
+
+	@Test
+	void testGetFileContent_ok() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path file = tempConfigDir.resolve("metricshub.yaml");
+		Files.writeString(file, "hello: world", StandardCharsets.UTF_8);
+
+		String content = service.getFileContent("metricshub.yaml");
+		assertEquals("hello: world", content);
+	}
+
+	@Test
+	void testGetFileContent_notFound() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		ResponseStatusException ex = assertThrows(
+			ResponseStatusException.class,
+			() -> service.getFileContent("missing.yaml")
+		);
+		assertEquals(404, ex.getStatusCode().value());
+		assertTrue(ex.getReason().contains("not found"));
+	}
+
+	@Test
+	void testGetFileContent_invalidName_rejectTraversal() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		ResponseStatusException ex = assertThrows(
+			ResponseStatusException.class,
+			() -> service.getFileContent("../evil.yaml")
+		);
+		assertEquals(HttpStatus.BAD_REQUEST.value(), ex.getStatusCode().value());
+	}
+
+	@Test
+	void testGetFileContent_invalidExtension() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		ResponseStatusException ex = assertThrows(
+			ResponseStatusException.class,
+			() -> service.getFileContent("config.txt")
+		);
+		assertEquals(HttpStatus.BAD_REQUEST.value(), ex.getStatusCode().value());
+		assertTrue(ex.getReason().contains(".yml") || ex.getReason().contains(".yaml"));
+	}
+
+	@Test
+	void testSaveOrUpdate_createsAndOverwrites() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path path = tempConfigDir.resolve("app.yaml");
+
+		// create
+		service.saveOrUpdateFile("app.yaml", "a: 1");
+		assertTrue(Files.exists(path));
+		assertEquals("a: 1", Files.readString(path, StandardCharsets.UTF_8));
+
+		// overwrite
+		service.saveOrUpdateFile("app.yaml", "a: 2\nb: 3");
+		assertEquals("a: 2\nb: 3", Files.readString(path, StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void testValidateFile_validAndInvalid() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		// valid
+		ObjectNode ok = service.validateFile("good.yaml", "k: v\nlist:\n  - x\n  - y");
+		assertTrue(ok.get("valid").asBoolean());
+		assertTrue(ok.get("errors").isArray());
+		assertEquals(0, ok.withArray("errors").size());
+
+		// invalid
+		ObjectNode bad = service.validateFile("bad.yaml", "k: : v\n list: [ 1, 2");
+		assertFalse(bad.get("valid").asBoolean());
+		JsonNode errors = bad.get("errors");
+		assertTrue(errors.isArray());
+		assertTrue(errors.size() >= 1);
+		assertTrue(errors.get(0).asText().toLowerCase().contains("yaml"));
+	}
+
+	@Test
+	void testDeleteFile_existing() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path path = tempConfigDir.resolve("to-delete.yml");
+		Files.writeString(path, "x: y");
+
+		service.deleteFile("to-delete.yml");
+		assertFalse(Files.exists(path));
+	}
+
+	@Test
+	void testDeleteFile_missing() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.deleteFile("nope.yml"));
+		assertEquals(HttpStatus.NOT_FOUND.value(), ex.getStatusCode().value());
+	}
+
+	@Test
+	void testRenameFile_ok() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path src = tempConfigDir.resolve("old.yaml");
+		final Path dst = tempConfigDir.resolve("new.yaml");
+		Files.writeString(src, "name: old");
+
+		service.renameFile("old.yaml", "new.yaml");
+
+		assertFalse(Files.exists(src));
+		assertTrue(Files.exists(dst));
+		assertEquals("name: old", Files.readString(dst, StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void testRenameFile_sourceMissing() {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+
+		ResponseStatusException ex = assertThrows(
+			ResponseStatusException.class,
+			() -> service.renameFile("absent.yaml", "new.yaml")
+		);
+		assertEquals(HttpStatus.NOT_FOUND.value(), ex.getStatusCode().value());
+	}
+
+	@Test
+	void testRenameFile_targetExists() throws Exception {
+		final ConfigurationFilesService service = newServiceWithDir(tempConfigDir);
+		final Path src = tempConfigDir.resolve("a.yaml");
+		final Path dst = tempConfigDir.resolve("b.yaml");
+		Files.writeString(src, "x: 1");
+		Files.writeString(dst, "x: 2");
+
+		ResponseStatusException ex = assertThrows(
+			ResponseStatusException.class,
+			() -> service.renameFile("a.yaml", "b.yaml")
+		);
+		assertEquals(HttpStatus.CONFLICT.value(), ex.getStatusCode().value());
+	}
+
+	@Test
+	void testRequireConfigDir_unavailable() {
+		// holder returns null; any public method that accesses config dir should 503
+		final AgentContextHolder holder = Mockito.mock(AgentContextHolder.class);
+		when(holder.getAgentContext()).thenReturn(null);
+		final ConfigurationFilesService service = new ConfigurationFilesService(holder);
+
+		ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.getFileContent("x.yaml"));
+		assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), ex.getStatusCode().value());
 	}
 }


### PR DESCRIPTION
### Description
This PR introduces a complete set of REST endpoints to manage YAML configuration files in MetricsHub Agent.
It also adds comprehensive unit tests for both the controller and the service layer.

### Changes included
New REST endpoints `ConfigurationFilesController`
- `GET /api/config-files`
Returns a list of all configuration files with metadata (name, size, lastModificationTime).

- `GET /api/config-files/content?name=<file>`
Returns the raw content of a specific configuration file as plain text.

- `PUT /api/config-files/content?name=<file>`
Creates or updates a configuration file with the provided YAML content.

- `POST /api/config-files/content?name=<file>`
Validates the YAML syntax of a configuration file.
Returns { "valid": true } or detailed error messages.

- `DELETE /api/config-files/content?name=<file>`
Deletes the specified configuration file.

- `PATCH /api/config-files/content?name=<file>`
Renames a configuration file.
Request body example:
`{ "newName": "new.yaml" }`

Service logic (ConfigurationFilesService)

Unit tests

- Controller tests: ConfigurationFilesControllerTest

- Happy paths and error cases for all endpoints.

- Uses MockMvc to simulate HTTP requests.

- Achieved full controller coverage (10 tests).

- Service tests: ConfigurationFilesServiceTest

- Validates core file operations with a real temp filesystem (@TempDir).

- Tests for edge cases like missing files, invalid YAML, conflicts, etc.