### PR TITLE
EPIC-OpAMP-02: Integrate the OpAMP client into the MetricsHub Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This is a multi-module project:
 
 ## Remote Management (OpAMP)
 
-The MetricsHub Agent embeds an [OpAMP](https://opentelemetry.io/docs/specs/opamp/) client for centralized fleet management. When enabled, the agent connects to an OpAMP server over plain HTTP polling, reports its identity (`service.name`, `service.version`, `host.name`, plus `os.type`, `host.arch` and `build_number`), status and health, and can receive software package offers for automatic upgrades.
+The MetricsHub Agent embeds an [OpAMP](https://opentelemetry.io/docs/specs/opamp/) client for centralized fleet management. When enabled, the agent connects to an OpAMP server over plain HTTP polling and reports its identity (`service.name`, `service.version`, `host.name`, plus `os.type`, `host.arch` and `build_number`), status and health. Automatic software upgrades through OpAMP package offers are under development (see [#1286](https://github.com/MetricsHub/metricshub-community/issues/1286)); until that lands, package offers are not accepted.
 
 The feature is **disabled by default**. Enable it with a top-level `opamp:` section in `metricshub.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This is a multi-module project:
 * **metricshub-jmx-extension**: Enables monitoring of Java applications through JMX (Java Management Extensions).
 * **metricshub-emulation-extension**: Replays recorded protocol exchanges (HTTP, SNMP, WMI, WBEM, SSH, IPMI, JDBC, JMX) from local files, enabling offline testing and development without live infrastructure.
 * **metricshub-hardware**: Hardware Energy and Sustainability module, dedicated to managing and monitoring hardware-related metrics, focusing on energy consumption and sustainability aspects.
+* **metricshub-opamp-client**: In-house minimal [OpAMP](https://opentelemetry.io/docs/specs/opamp/) (Open Agent Management Protocol) client embedded in the MetricsHub Agent for remote management: status, identity and health reporting over HTTP polling, plus package-offer handling for automatic upgrades.
 * **metricshub-yaml-configuration-extension**: Extension that loads configuration fragments from YAML files located in a configuration directory.
 * **metricshub-programmable-configuration-extension**: Provides a programmable configuration mechanism, allowing users to define custom configurations through [Apache Velocity](https://velocity.apache.org/) scripts.
 * **metricshub-web**: Provides a user interface for interacting with MetricsHub features and functionalities.
@@ -58,6 +59,26 @@ This is a multi-module project:
 
 > [!TIP]
 > Looking for connectors? Check the [MetricsHub Community Connectors](https://github.com/metricshub/community-connectors) repository.
+
+## Remote Management (OpAMP)
+
+The MetricsHub Agent embeds an [OpAMP](https://opentelemetry.io/docs/specs/opamp/) client for centralized fleet management. When enabled, the agent connects to an OpAMP server over plain HTTP polling, reports its identity (`service.name`, `service.version`, `host.name`, plus `os.type`, `host.arch` and `build_number`), status and health, and can receive software package offers for automatic upgrades.
+
+The feature is **disabled by default**. Enable it with a top-level `opamp:` section in `metricshub.yaml`:
+
+```yaml
+opamp:
+  enabled: true
+  endpoint: https://opamp.example.com/v1/opamp  # OpAMP server endpoint (plain HTTP transport)
+  headers:                                      # Optional headers sent with every request;
+    Authorization: Bearer ${env::OPAMP_TOKEN}   # values may be encrypted with the MetricsHub keystore
+  certificateFile: /opt/metricshub/security/opamp-ca.pem # Optional trusted certificate (PEM)
+  pollInterval: 30s                             # Interval between two polls (default: 30s)
+  requestTimeout: 10s                           # Timeout of one HTTP exchange (default: 10s)
+  reportHealth: true                            # Report agent health (default: true)
+```
+
+Changing the `opamp:` section triggers a configuration reload; the OpAMP connection itself survives reloads that do not touch this section. The agent identity (`instance_uid`, a UUIDv7) is persisted in the `security` directory next to the MetricsHub keystore, so it survives restarts and upgrades.
 
 ## How to build the Project
 

--- a/metricshub-agent/pom.xml
+++ b/metricshub-agent/pom.xml
@@ -46,6 +46,12 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- MetricsHub OpAMP Client -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>metricshub-opamp-client</artifactId>
+		</dependency>
+
 		<!-- MetricsHub Community Connectors -->
 		<dependency>
 			<groupId>org.metricshub</groupId>

--- a/metricshub-agent/src/main/java/org/metricshub/agent/MetricsHubAgentApplication.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/MetricsHubAgentApplication.java
@@ -31,6 +31,8 @@ import org.apache.logging.log4j.ThreadContext;
 import org.metricshub.agent.context.AgentContext;
 import org.metricshub.agent.helper.AgentConstants;
 import org.metricshub.agent.helper.ConfigHelper;
+import org.metricshub.agent.opamp.OpAmpService;
+import org.metricshub.agent.process.runtime.ProcessControl;
 import org.metricshub.agent.service.ReloadService;
 import org.metricshub.agent.service.ReloadService.ReloadResult;
 import org.metricshub.agent.service.task.DirectoryWatcherTask;
@@ -99,6 +101,13 @@ public class MetricsHubAgentApplication implements Runnable {
 			// Start the Spring server on a separate thread, handing it the holder so the
 			// AgentContextHolder singleton bean is our own instance (used by every service).
 			new Thread(() -> MetricsHubAgentServer.startServer(agentContextHolder)).start();
+
+			// Start the OpAMP service at application level, outside the restartable AgentContext:
+			// its supervisor re-reads the opamp: configuration from the holder and keeps the
+			// OpAMP connection alive across configuration reloads.
+			final var opAmpService = new OpAmpService(agentContextHolder);
+			opAmpService.start();
+			ProcessControl.addShutdownHook(opAmpService::shutdown);
 
 			// Start the DirectoryWatcherTask to watch for changes in the configuration directory
 			final Path configDirectory = bootAgentContext.getConfigDirectory();

--- a/metricshub-agent/src/main/java/org/metricshub/agent/config/AgentConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/config/AgentConfig.java
@@ -159,6 +159,10 @@ public class AgentConfig {
 	@JsonProperty("web")
 	private Map<String, String> webConfig = loadWebConfig();
 
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private OpAmpConfig opamp = OpAmpConfig.builder().build();
+
 	/**
 	 * Build a new empty instance
 	 *

--- a/metricshub-agent/src/main/java/org/metricshub/agent/config/OpAmpConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/config/OpAmpConfig.java
@@ -1,0 +1,105 @@
+package org.metricshub.agent.config;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static com.fasterxml.jackson.annotation.Nulls.SKIP;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.metricshub.engine.deserialization.TimeDeserializer;
+
+/**
+ * Configuration of the OpAMP (Open Agent Management Protocol) client embedded in the MetricsHub
+ * Agent: remote management endpoint, authentication headers, TLS trust material and polling
+ * cadence. Disabled by default.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OpAmpConfig {
+
+	/**
+	 * Default interval in seconds between two OpAMP polls.
+	 */
+	public static final long DEFAULT_POLL_INTERVAL = 30;
+
+	/**
+	 * Default timeout in seconds of one OpAMP HTTP exchange.
+	 */
+	public static final long DEFAULT_REQUEST_TIMEOUT = 10;
+
+	/**
+	 * Whether the OpAMP client is enabled.
+	 */
+	private boolean enabled;
+
+	/**
+	 * The OpAMP server endpoint (e.g. {@code https://opamp.example.com/v1/opamp}).
+	 */
+	@JsonSetter(nulls = SKIP)
+	private String endpoint;
+
+	/**
+	 * Headers sent with every OpAMP request (e.g. {@code Authorization}). Values may be encrypted
+	 * with the MetricsHub keystore.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private Map<String, String> headers = new HashMap<>();
+
+	/**
+	 * Path to a PEM file containing the trusted certificate used to verify the OpAMP server's TLS
+	 * credentials; {@code null} to use the system trust store.
+	 */
+	@JsonSetter(nulls = SKIP)
+	private String certificateFile;
+
+	/**
+	 * Interval in seconds between two OpAMP polls.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = TimeDeserializer.class)
+	private long pollInterval = DEFAULT_POLL_INTERVAL;
+
+	/**
+	 * Timeout in seconds of one OpAMP HTTP exchange.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = TimeDeserializer.class)
+	private long requestTimeout = DEFAULT_REQUEST_TIMEOUT;
+
+	/**
+	 * Whether the agent reports its health to the OpAMP server.
+	 */
+	@Default
+	private boolean reportHealth = true;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpAgentDescriptionMapper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpAgentDescriptionMapper.java
@@ -1,0 +1,127 @@
+package org.metricshub.agent.opamp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.metricshub.agent.helper.AgentConstants.AGENT_INFO_BUILD_NUMBER_ATTRIBUTE_KEY;
+import static org.metricshub.agent.helper.AgentConstants.AGENT_INFO_VERSION_ATTRIBUTE_KEY;
+import static org.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY;
+import static org.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY;
+import static org.metricshub.agent.helper.AgentConstants.AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY;
+
+import java.util.Map;
+import org.metricshub.agent.context.AgentInfo;
+import org.metricshub.opamp.proto.AgentDescription;
+import org.metricshub.opamp.proto.AnyValue;
+import org.metricshub.opamp.proto.KeyValue;
+
+/**
+ * Maps the MetricsHub {@link AgentInfo} attributes to the OpAMP {@code AgentDescription} message.
+ * <p>
+ * Identifying attributes follow the OpAMP recommendations ({@code service.name},
+ * {@code service.version}, {@code host.name}); non-identifying attributes carry the material the
+ * OpAMP server needs to select the right upgrade artifact ({@code os.type}, {@code host.arch},
+ * {@code build_number}).
+ * </p>
+ */
+public class OpAmpAgentDescriptionMapper {
+
+	/**
+	 * OpAMP identifying attribute key for the service version.
+	 */
+	static final String SERVICE_VERSION_ATTRIBUTE_KEY = "service.version";
+
+	/**
+	 * OpAMP non-identifying attribute key for the host CPU architecture.
+	 */
+	static final String HOST_ARCH_ATTRIBUTE_KEY = "host.arch";
+
+	private OpAmpAgentDescriptionMapper() {}
+
+	/**
+	 * Builds the OpAMP {@code AgentDescription} from the agent information.
+	 *
+	 * @param agentInfo the agent information
+	 * @return the corresponding {@code AgentDescription}
+	 */
+	public static AgentDescription map(final AgentInfo agentInfo) {
+		final Map<String, String> attributes = agentInfo.getAttributes();
+		final AgentDescription.Builder builder = AgentDescription.newBuilder();
+
+		addAttribute(
+			builder,
+			true,
+			AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY,
+			attributes.get(AGENT_RESOURCE_SERVICE_NAME_ATTRIBUTE_KEY)
+		);
+		addAttribute(builder, true, SERVICE_VERSION_ATTRIBUTE_KEY, attributes.get(AGENT_INFO_VERSION_ATTRIBUTE_KEY));
+		addAttribute(
+			builder,
+			true,
+			AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY,
+			attributes.get(AGENT_RESOURCE_HOST_NAME_ATTRIBUTE_KEY)
+		);
+
+		addAttribute(
+			builder,
+			false,
+			AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY,
+			attributes.get(AGENT_RESOURCE_OS_TYPE_ATTRIBUTE_KEY)
+		);
+		addAttribute(builder, false, HOST_ARCH_ATTRIBUTE_KEY, System.getProperty("os.arch"));
+		addAttribute(
+			builder,
+			false,
+			AGENT_INFO_BUILD_NUMBER_ATTRIBUTE_KEY,
+			attributes.get(AGENT_INFO_BUILD_NUMBER_ATTRIBUTE_KEY)
+		);
+
+		return builder.build();
+	}
+
+	/**
+	 * Adds a string attribute to the description builder, skipping null or blank values.
+	 *
+	 * @param builder     the description builder
+	 * @param identifying whether the attribute is identifying
+	 * @param key         the attribute key
+	 * @param value       the attribute value
+	 */
+	private static void addAttribute(
+		final AgentDescription.Builder builder,
+		final boolean identifying,
+		final String key,
+		final String value
+	) {
+		if (value == null || value.isBlank()) {
+			return;
+		}
+		final KeyValue keyValue = KeyValue.newBuilder()
+			.setKey(key)
+			.setValue(AnyValue.newBuilder().setStringValue(value).build())
+			.build();
+		if (identifying) {
+			builder.addIdentifyingAttributes(keyValue);
+		} else {
+			builder.addNonIdentifyingAttributes(keyValue);
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpHealthMapper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpHealthMapper.java
@@ -1,0 +1,76 @@
+package org.metricshub.agent.opamp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+import org.metricshub.opamp.proto.ComponentHealth;
+import org.metricshub.web.dto.ApplicationStatus;
+import org.metricshub.web.dto.ApplicationStatus.Status;
+
+/**
+ * Maps the MetricsHub {@link ApplicationStatus} to the OpAMP {@code ComponentHealth} message: a
+ * top-level health with the agent status, plus an {@code otel_collector} sub-component. Resource
+ * counters, memory and CPU are deliberately excluded — they are already exported as metrics
+ * through the OTLP self-monitoring pipeline.
+ */
+public class OpAmpHealthMapper {
+
+	/**
+	 * Name of the OpenTelemetry Collector sub-component in the health map.
+	 */
+	static final String OTEL_COLLECTOR_COMPONENT = "otel_collector";
+
+	private OpAmpHealthMapper() {}
+
+	/**
+	 * Builds the OpAMP {@code ComponentHealth} from the application status.
+	 *
+	 * @param applicationStatus the current application status
+	 * @return the corresponding {@code ComponentHealth}
+	 */
+	public static ComponentHealth map(final ApplicationStatus applicationStatus) {
+		final boolean healthy = applicationStatus.getStatus() == Status.UP;
+		final long nowNanos = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis());
+		final long startTimeNanos = TimeUnit.MILLISECONDS.toNanos(ManagementFactory.getRuntimeMXBean().getStartTime());
+
+		final ComponentHealth.Builder builder = ComponentHealth.newBuilder()
+			.setHealthy(healthy)
+			.setStatus(applicationStatus.getStatus().toString())
+			.setStartTimeUnixNano(startTimeNanos)
+			.setStatusTimeUnixNano(nowNanos);
+
+		final String otelCollectorStatus = applicationStatus.getOtelCollectorStatus();
+		if (otelCollectorStatus != null) {
+			builder.putComponentHealthMap(
+				OTEL_COLLECTOR_COMPONENT,
+				ComponentHealth.newBuilder()
+					.setHealthy("running".equals(otelCollectorStatus) || "disabled".equals(otelCollectorStatus))
+					.setStatus(otelCollectorStatus)
+					.setStatusTimeUnixNano(nowNanos)
+					.build()
+			);
+		}
+
+		return builder.build();
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -189,6 +189,10 @@ public class OpAmpService {
 			newClient.start();
 			client = newClient;
 		} catch (Exception e) {
+			// Clear the active configuration so the next supervisor tick retries the startup:
+			// a transient failure (e.g. missing CA file) must not disable OpAMP until the
+			// configuration changes or the agent restarts.
+			activeConfig = null;
 			log.error("Failed to start the OpAMP client on {}: {}", endpoint, e.getMessage());
 			log.debug("Failed to start the OpAMP client:", e);
 		}
@@ -209,11 +213,42 @@ public class OpAmpService {
 			.withEndpoint(URI.create(config.getEndpoint().trim()))
 			.withHeaders(headers)
 			.withCertificateFile(config.getCertificateFile())
-			.withPollInterval(Duration.ofSeconds(config.getPollInterval()))
-			.withRequestTimeout(Duration.ofSeconds(config.getRequestTimeout()))
+			.withPollInterval(
+				Duration.ofSeconds(
+					atLeastOneSecond("pollInterval", config.getPollInterval(), OpAmpConfig.DEFAULT_POLL_INTERVAL)
+				)
+			)
+			.withRequestTimeout(
+				Duration.ofSeconds(
+					atLeastOneSecond("requestTimeout", config.getRequestTimeout(), OpAmpConfig.DEFAULT_REQUEST_TIMEOUT)
+				)
+			)
 			.withInstanceUidFile(resolveInstanceUidFile())
 			.withReportHealth(config.isReportHealth())
 			.build();
+	}
+
+	/**
+	 * Guards a duration setting against zero or negative values (e.g. {@code pollInterval: 0} or
+	 * a sub-second duration collapsing to zero seconds), which would turn the polling loop into a
+	 * tight loop hammering the OpAMP server.
+	 *
+	 * @param settingName  the name of the setting, used for logging
+	 * @param seconds      the configured value in seconds
+	 * @param defaultValue the default value in seconds applied when the configured value is invalid
+	 * @return a positive number of seconds
+	 */
+	private static long atLeastOneSecond(final String settingName, final long seconds, final long defaultValue) {
+		if (seconds < 1) {
+			log.warn(
+				"Invalid OpAMP {} ({} seconds); using the default value of {} seconds.",
+				settingName,
+				seconds,
+				defaultValue
+			);
+			return defaultValue;
+		}
+		return seconds;
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -181,20 +181,40 @@ public class OpAmpService {
 			return;
 		}
 
+		OpampClient newClient = null;
 		try {
-			final OpampClient newClient = clientFactory.apply(buildSettings(newConfig));
+			newClient = clientFactory.apply(buildSettings(newConfig));
 			// Report a complete first message
 			newClient.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));
 			newClient.setHealth(OpAmpHealthMapper.map(applicationStatusService.reportApplicationStatus()));
 			newClient.start();
 			client = newClient;
 		} catch (Exception e) {
+			// Release the resources of a client whose startup failed: the retry below builds a
+			// fresh one, and leaking an executor and HTTP client on every attempt must not happen.
+			closeQuietly(newClient);
 			// Clear the active configuration so the next supervisor tick retries the startup:
 			// a transient failure (e.g. missing CA file) must not disable OpAMP until the
 			// configuration changes or the agent restarts.
 			activeConfig = null;
 			log.error("Failed to start the OpAMP client on {}: {}", endpoint, e.getMessage());
 			log.debug("Failed to start the OpAMP client:", e);
+		}
+	}
+
+	/**
+	 * Stops a client best-effort, swallowing any secondary failure.
+	 *
+	 * @param failedClient the client to stop; {@code null} is ignored
+	 */
+	private static void closeQuietly(final OpampClient failedClient) {
+		if (failedClient == null) {
+			return;
+		}
+		try {
+			failedClient.stop("OpAMP client startup failed");
+		} catch (Exception stopError) {
+			log.debug("Failed to release the OpAMP client that could not start:", stopError);
 		}
 	}
 

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -1,0 +1,266 @@
+package org.metricshub.agent.opamp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.agent.config.OpAmpConfig;
+import org.metricshub.agent.context.AgentContext;
+import org.metricshub.agent.helper.ConfigHelper;
+import org.metricshub.agent.security.PasswordEncrypt;
+import org.metricshub.opamp.client.OpampClient;
+import org.metricshub.opamp.client.OpampClientCallbacks;
+import org.metricshub.opamp.client.OpampClientSettings;
+import org.metricshub.opamp.client.impl.HttpPollingOpampClient;
+import org.metricshub.web.AgentContextHolder;
+import org.metricshub.web.service.ApplicationStatusService;
+
+/**
+ * Application-level service owning the embedded OpAMP client.
+ * <p>
+ * The service lives outside the restartable {@link AgentContext}: a small supervisor tick
+ * periodically re-reads the {@code opamp:} configuration from the current context, starts, stops
+ * or rebuilds the OpAMP client only when that configuration changes, and refreshes the agent
+ * description and health reported to the OpAMP server. The client connection therefore survives
+ * configuration reloads that do not touch the {@code opamp:} section.
+ * </p>
+ */
+@Slf4j
+public class OpAmpService {
+
+	/**
+	 * Name of the file persisting the OpAMP agent instance UID, stored in the MetricsHub
+	 * security directory.
+	 */
+	public static final String OPAMP_INSTANCE_UID_FILENAME = "opamp-instance-uid";
+
+	/**
+	 * Period in seconds of the supervisor tick.
+	 */
+	static final long SUPERVISOR_PERIOD_SECONDS = 30;
+
+	private final AgentContextHolder agentContextHolder;
+	private final ApplicationStatusService applicationStatusService;
+	private final Function<OpampClientSettings, OpampClient> clientFactory;
+	private final ScheduledExecutorService supervisor;
+
+	private OpampClient client;
+	private OpAmpConfig activeConfig;
+
+	/**
+	 * Creates the service with the default OpAMP client factory.
+	 *
+	 * @param agentContextHolder the holder of the current agent context
+	 */
+	public OpAmpService(final AgentContextHolder agentContextHolder) {
+		this(agentContextHolder, settings ->
+			HttpPollingOpampClient.builder().withSettings(settings).withCallbacks(new LoggingCallbacks()).build()
+		);
+	}
+
+	/**
+	 * Creates the service with a caller-provided client factory (used by tests).
+	 *
+	 * @param agentContextHolder the holder of the current agent context
+	 * @param clientFactory      the factory building an {@link OpampClient} from settings
+	 */
+	OpAmpService(
+		final AgentContextHolder agentContextHolder,
+		final Function<OpampClientSettings, OpampClient> clientFactory
+	) {
+		this.agentContextHolder = agentContextHolder;
+		this.applicationStatusService = new ApplicationStatusService(agentContextHolder);
+		this.clientFactory = clientFactory;
+		this.supervisor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+			final Thread thread = new Thread(runnable, "metricshub-opamp-supervisor");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	/**
+	 * Starts the supervisor tick.
+	 */
+	public void start() {
+		supervisor.scheduleWithFixedDelay(this::superviseSafely, 0, SUPERVISOR_PERIOD_SECONDS, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * Stops the supervisor and the OpAMP client. Called from the JVM shutdown hook.
+	 */
+	public synchronized void shutdown() {
+		supervisor.shutdownNow();
+		if (client != null) {
+			client.stop("Agent shutting down");
+			client = null;
+		}
+	}
+
+	/**
+	 * Runs one supervision pass, never letting an exception kill the supervisor schedule.
+	 */
+	private void superviseSafely() {
+		try {
+			supervise();
+		} catch (Exception e) {
+			log.error("OpAMP supervision failed: {}", e.getMessage());
+			log.debug("OpAMP supervision failed:", e);
+		}
+	}
+
+	/**
+	 * Reconciles the OpAMP client with the current configuration and refreshes the reported
+	 * agent description and health.
+	 */
+	synchronized void supervise() {
+		final AgentContext agentContext = agentContextHolder.getAgentContext();
+		if (agentContext == null || agentContext.getAgentConfig() == null) {
+			return;
+		}
+
+		final OpAmpConfig config = agentContext.getAgentConfig().getOpamp();
+		if (!Objects.equals(config, activeConfig)) {
+			reconfigure(agentContext, config);
+		}
+
+		if (client != null && client.isStarted()) {
+			client.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));
+			client.setHealth(OpAmpHealthMapper.map(applicationStatusService.reportApplicationStatus()));
+		}
+	}
+
+	/**
+	 * Applies a new {@code opamp:} configuration: stops the running client and starts a new one
+	 * when the configuration enables OpAMP.
+	 *
+	 * @param agentContext the current agent context
+	 * @param newConfig    the new OpAMP configuration
+	 */
+	private void reconfigure(final AgentContext agentContext, final OpAmpConfig newConfig) {
+		if (client != null) {
+			client.stop("OpAMP configuration changed");
+			client = null;
+		}
+		activeConfig = newConfig;
+
+		if (newConfig == null || !newConfig.isEnabled()) {
+			log.info("OpAMP is disabled.");
+			return;
+		}
+		final String endpoint = newConfig.getEndpoint();
+		if (endpoint == null || endpoint.isBlank()) {
+			log.warn("OpAMP is enabled but no endpoint is configured; the OpAMP client is not started.");
+			return;
+		}
+
+		try {
+			final OpampClient newClient = clientFactory.apply(buildSettings(newConfig));
+			// Report a complete first message
+			newClient.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));
+			newClient.setHealth(OpAmpHealthMapper.map(applicationStatusService.reportApplicationStatus()));
+			newClient.start();
+			client = newClient;
+		} catch (Exception e) {
+			log.error("Failed to start the OpAMP client on {}: {}", endpoint, e.getMessage());
+			log.debug("Failed to start the OpAMP client:", e);
+		}
+	}
+
+	/**
+	 * Builds the OpAMP client settings from the agent configuration. Header values encrypted with
+	 * the MetricsHub keystore are decrypted; plain values pass through unchanged.
+	 *
+	 * @param config the OpAMP configuration
+	 * @return the client settings
+	 */
+	OpampClientSettings buildSettings(final OpAmpConfig config) {
+		final Map<String, String> headers = new HashMap<>();
+		config.getHeaders().forEach((key, value) -> headers.put(key, decrypt(value)));
+
+		return OpampClientSettings.builder()
+			.withEndpoint(URI.create(config.getEndpoint().trim()))
+			.withHeaders(headers)
+			.withCertificateFile(config.getCertificateFile())
+			.withPollInterval(Duration.ofSeconds(config.getPollInterval()))
+			.withRequestTimeout(Duration.ofSeconds(config.getRequestTimeout()))
+			.withInstanceUidFile(resolveInstanceUidFile())
+			.withReportHealth(config.isReportHealth())
+			.build();
+	}
+
+	/**
+	 * Resolves the file persisting the OpAMP instance UID: it lives next to the MetricsHub
+	 * keystore in the security directory, which survives upgrades on all platforms.
+	 *
+	 * @return the instance UID file path
+	 */
+	static Path resolveInstanceUidFile() {
+		return PasswordEncrypt.getKeyStoreFile(true)
+			.toPath()
+			.toAbsolutePath()
+			.getParent()
+			.resolve(OPAMP_INSTANCE_UID_FILENAME);
+	}
+
+	/**
+	 * Decrypts a configuration value with the MetricsHub keystore; plain values are returned
+	 * unchanged.
+	 *
+	 * @param value the raw configuration value
+	 * @return the decrypted value
+	 */
+	private static String decrypt(final String value) {
+		if (value == null) {
+			return null;
+		}
+		return new String(ConfigHelper.decrypt(value.toCharArray()));
+	}
+
+	/**
+	 * Callbacks logging the OpAMP connectivity transitions.
+	 */
+	static class LoggingCallbacks implements OpampClientCallbacks {
+
+		@Override
+		public void onConnect() {
+			log.info("Connected to the OpAMP server.");
+		}
+
+		@Override
+		public void onConnectFailed(final Throwable error, final Duration nextAttemptDelay) {
+			log.warn(
+				"Connection to the OpAMP server failed ({}); next attempt in {} seconds.",
+				error == null ? "unknown error" : error.getMessage(),
+				nextAttemptDelay.toSeconds()
+			);
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/ReloadService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/ReloadService.java
@@ -205,7 +205,8 @@ public class ReloadService {
 			!Objects.equals(runningConf.getAttributes(), newConf.getAttributes()) ||
 			!Objects.equals(runningConf.getMetrics(), newConf.getMetrics()) ||
 			!Objects.equals(runningConf.getStateSetCompression(), newConf.getStateSetCompression()) ||
-			!Objects.equals(runningConf.getPatchDirectory(), newConf.getPatchDirectory())
+			!Objects.equals(runningConf.getPatchDirectory(), newConf.getPatchDirectory()) ||
+			!Objects.equals(runningConf.getOpamp(), newConf.getOpamp())
 		);
 		// CHECKSTYLE:ON
 	}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/config/OpAmpConfigTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/config/OpAmpConfigTest.java
@@ -1,0 +1,60 @@
+package org.metricshub.agent.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.metricshub.agent.helper.ConfigHelper;
+import org.metricshub.engine.common.helpers.JsonHelper;
+
+class OpAmpConfigTest {
+
+	private static AgentConfig deserialize(final String yaml) throws Exception {
+		return JsonHelper.deserialize(
+			ConfigHelper.newObjectMapper(),
+			new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)),
+			AgentConfig.class
+		);
+	}
+
+	@Test
+	void opampSectionShouldBeDeserialized() throws Exception {
+		final AgentConfig agentConfig = deserialize(
+			"""
+			opamp:
+			  enabled: true
+			  endpoint: https://opamp.example.com/v1/opamp
+			  headers:
+			    Authorization: Bearer my-token
+			  certificateFile: /opt/metricshub/security/opamp-ca.pem
+			  pollInterval: 1m
+			  requestTimeout: 20
+			  reportHealth: false
+			"""
+		);
+
+		final OpAmpConfig opamp = agentConfig.getOpamp();
+		assertTrue(opamp.isEnabled());
+		assertEquals("https://opamp.example.com/v1/opamp", opamp.getEndpoint());
+		assertEquals(Map.of("Authorization", "Bearer my-token"), opamp.getHeaders());
+		assertEquals("/opt/metricshub/security/opamp-ca.pem", opamp.getCertificateFile());
+		assertEquals(60, opamp.getPollInterval());
+		assertEquals(20, opamp.getRequestTimeout());
+		assertFalse(opamp.isReportHealth());
+	}
+
+	@Test
+	void opampShouldBeDisabledByDefault() throws Exception {
+		final AgentConfig agentConfig = deserialize("loggerLevel: error\n");
+
+		final OpAmpConfig opamp = agentConfig.getOpamp();
+		assertFalse(opamp.isEnabled());
+		assertEquals(OpAmpConfig.DEFAULT_POLL_INTERVAL, opamp.getPollInterval());
+		assertEquals(OpAmpConfig.DEFAULT_REQUEST_TIMEOUT, opamp.getRequestTimeout());
+		assertTrue(opamp.isReportHealth());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpMappersTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpMappersTest.java
@@ -1,0 +1,113 @@
+package org.metricshub.agent.opamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.metricshub.agent.context.AgentInfo;
+import org.metricshub.opamp.proto.AgentDescription;
+import org.metricshub.opamp.proto.ComponentHealth;
+import org.metricshub.opamp.proto.KeyValue;
+import org.metricshub.web.dto.ApplicationStatus;
+import org.metricshub.web.dto.ApplicationStatus.Status;
+
+class OpAmpMappersTest {
+
+	private static Optional<String> attributeValue(final java.util.List<KeyValue> attributes, final String key) {
+		return attributes
+			.stream()
+			.filter(keyValue -> keyValue.getKey().equals(key))
+			.map(keyValue -> keyValue.getValue().getStringValue())
+			.findFirst();
+	}
+
+	@Test
+	void agentDescriptionShouldCarryIdentityAndSelectionAttributes() {
+		final AgentInfo agentInfo = mock(AgentInfo.class);
+		when(agentInfo.getAttributes()).thenReturn(
+			Map.of(
+				"service.name",
+				"MetricsHub Agent",
+				"version",
+				"3.9.05",
+				"host.name",
+				"server-01",
+				"os.type",
+				"linux",
+				"build_number",
+				"abcdef12"
+			)
+		);
+
+		final AgentDescription description = OpAmpAgentDescriptionMapper.map(agentInfo);
+
+		assertEquals(
+			Optional.of("MetricsHub Agent"),
+			attributeValue(description.getIdentifyingAttributesList(), "service.name")
+		);
+		assertEquals(Optional.of("3.9.05"), attributeValue(description.getIdentifyingAttributesList(), "service.version"));
+		assertEquals(Optional.of("server-01"), attributeValue(description.getIdentifyingAttributesList(), "host.name"));
+		assertEquals(Optional.of("linux"), attributeValue(description.getNonIdentifyingAttributesList(), "os.type"));
+		assertEquals(
+			Optional.of("abcdef12"),
+			attributeValue(description.getNonIdentifyingAttributesList(), "build_number")
+		);
+		assertTrue(attributeValue(description.getNonIdentifyingAttributesList(), "host.arch").isPresent());
+	}
+
+	@Test
+	void agentDescriptionShouldSkipMissingAttributes() {
+		final AgentInfo agentInfo = mock(AgentInfo.class);
+		when(agentInfo.getAttributes()).thenReturn(Map.of());
+
+		final AgentDescription description = OpAmpAgentDescriptionMapper.map(agentInfo);
+
+		assertTrue(attributeValue(description.getIdentifyingAttributesList(), "service.name").isEmpty());
+		assertTrue(attributeValue(description.getIdentifyingAttributesList(), "service.version").isEmpty());
+	}
+
+	@Test
+	void healthShouldReflectAnUpApplication() {
+		final ApplicationStatus applicationStatus = ApplicationStatus.builder()
+			.status(Status.UP)
+			.otelCollectorStatus("running")
+			.build();
+
+		final ComponentHealth health = OpAmpHealthMapper.map(applicationStatus);
+
+		assertTrue(health.getHealthy());
+		assertEquals("UP", health.getStatus());
+		assertTrue(health.getStartTimeUnixNano() > 0);
+		final ComponentHealth collector = health.getComponentHealthMapOrThrow(OpAmpHealthMapper.OTEL_COLLECTOR_COMPONENT);
+		assertTrue(collector.getHealthy());
+		assertEquals("running", collector.getStatus());
+	}
+
+	@Test
+	void healthShouldReflectADownApplicationAndErroredCollector() {
+		final ApplicationStatus applicationStatus = ApplicationStatus.builder()
+			.status(Status.DOWN)
+			.otelCollectorStatus("errored")
+			.build();
+
+		final ComponentHealth health = OpAmpHealthMapper.map(applicationStatus);
+
+		assertFalse(health.getHealthy());
+		assertEquals("DOWN", health.getStatus());
+		assertFalse(health.getComponentHealthMapOrThrow(OpAmpHealthMapper.OTEL_COLLECTOR_COMPONENT).getHealthy());
+	}
+
+	@Test
+	void healthShouldOmitTheCollectorComponentWhenUnknown() {
+		final ApplicationStatus applicationStatus = ApplicationStatus.builder().status(Status.UP).build();
+
+		final ComponentHealth health = OpAmpHealthMapper.map(applicationStatus);
+
+		assertEquals(0, health.getComponentHealthMapCount());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
@@ -155,6 +155,16 @@ class OpAmpServiceTest {
 	}
 
 	@Test
+	void failedStartShouldReleaseTheClientResources() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		org.mockito.Mockito.doThrow(new IllegalStateException("Simulated start failure")).when(client).start();
+
+		opAmpService.supervise();
+
+		verify(client, times(1)).stop("OpAMP client startup failed");
+	}
+
+	@Test
 	void startupFailureShouldBeRetriedOnTheNextTick() {
 		agentConfig.setOpamp(enabledConfig(ENDPOINT));
 		final AtomicReference<Boolean> failFirstAttempt = new AtomicReference<>(true);

--- a/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
@@ -155,6 +155,41 @@ class OpAmpServiceTest {
 	}
 
 	@Test
+	void startupFailureShouldBeRetriedOnTheNextTick() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		final AtomicReference<Boolean> failFirstAttempt = new AtomicReference<>(true);
+		final OpAmpService retryingService = new OpAmpService(agentContextHolder, settings -> {
+			factoryInvocations++;
+			if (Boolean.TRUE.equals(failFirstAttempt.getAndSet(false))) {
+				throw new IllegalStateException("Simulated transient startup failure");
+			}
+			return client;
+		});
+
+		retryingService.supervise();
+		// The transient failure is retried with the unchanged configuration
+		retryingService.supervise();
+
+		assertEquals(2, factoryInvocations);
+		verify(client, times(1)).start();
+	}
+
+	@Test
+	void invalidDurationsShouldFallBackToDefaults() {
+		final OpAmpConfig config = OpAmpConfig.builder()
+			.enabled(true)
+			.endpoint(ENDPOINT)
+			.pollInterval(0)
+			.requestTimeout(-5)
+			.build();
+
+		final OpampClientSettings settings = opAmpService.buildSettings(config);
+
+		assertEquals(Duration.ofSeconds(OpAmpConfig.DEFAULT_POLL_INTERVAL), settings.getPollInterval());
+		assertEquals(Duration.ofSeconds(OpAmpConfig.DEFAULT_REQUEST_TIMEOUT), settings.getRequestTimeout());
+	}
+
+	@Test
 	void buildSettingsShouldMapTheConfiguration() {
 		final OpAmpConfig config = OpAmpConfig.builder()
 			.enabled(true)

--- a/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
@@ -1,0 +1,182 @@
+package org.metricshub.agent.opamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.metricshub.agent.config.AgentConfig;
+import org.metricshub.agent.config.OpAmpConfig;
+import org.metricshub.agent.context.AgentContext;
+import org.metricshub.agent.context.AgentInfo;
+import org.metricshub.opamp.client.OpampClient;
+import org.metricshub.opamp.client.OpampClientSettings;
+import org.metricshub.web.AgentContextHolder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpAmpServiceTest {
+
+	private static final String ENDPOINT = "https://opamp.example.com/v1/opamp";
+
+	@Mock
+	private AgentContextHolder agentContextHolder;
+
+	@Mock
+	private AgentContext agentContext;
+
+	@Mock
+	private AgentInfo agentInfo;
+
+	@Mock
+	private OpampClient client;
+
+	private AgentConfig agentConfig;
+	private AtomicReference<OpampClientSettings> capturedSettings;
+	private OpAmpService opAmpService;
+	private int factoryInvocations;
+
+	@BeforeEach
+	void setUp() {
+		agentConfig = AgentConfig.builder().build();
+		capturedSettings = new AtomicReference<>();
+		factoryInvocations = 0;
+
+		when(agentContextHolder.getAgentContext()).thenReturn(agentContext);
+		when(agentContext.getAgentConfig()).thenAnswer(invocation -> agentConfig);
+		when(agentContext.getAgentInfo()).thenReturn(agentInfo);
+		when(agentInfo.getAttributes()).thenReturn(
+			Map.of("service.name", "MetricsHub Agent", "version", "3.9.05", "host.name", "test-host")
+		);
+		when(client.isStarted()).thenReturn(true);
+
+		opAmpService = new OpAmpService(agentContextHolder, settings -> {
+			capturedSettings.set(settings);
+			factoryInvocations++;
+			return client;
+		});
+	}
+
+	private static OpAmpConfig enabledConfig(final String endpoint) {
+		return OpAmpConfig.builder().enabled(true).endpoint(endpoint).build();
+	}
+
+	@Test
+	void disabledConfigurationShouldNotStartTheClient() {
+		opAmpService.supervise();
+
+		assertEquals(0, factoryInvocations);
+	}
+
+	@Test
+	void enabledConfigurationShouldStartTheClientOnce() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+
+		opAmpService.supervise();
+		opAmpService.supervise();
+
+		assertEquals(1, factoryInvocations);
+		verify(client, times(1)).start();
+		// Description and health are reported before start and refreshed on every tick
+		verify(client, times(3)).setAgentDescription(any());
+		verify(client, times(3)).setHealth(any());
+		assertEquals(URI.create(ENDPOINT), capturedSettings.get().getEndpoint());
+	}
+
+	@Test
+	void enabledConfigurationWithoutEndpointShouldNotStartTheClient() {
+		agentConfig.setOpamp(OpAmpConfig.builder().enabled(true).build());
+
+		opAmpService.supervise();
+
+		assertEquals(0, factoryInvocations);
+	}
+
+	@Test
+	void configurationChangeShouldRebuildTheClient() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		opAmpService.supervise();
+
+		agentConfig.setOpamp(enabledConfig("https://other.example.com/v1/opamp"));
+		opAmpService.supervise();
+
+		assertEquals(2, factoryInvocations);
+		verify(client, times(1)).stop("OpAMP configuration changed");
+		assertEquals(URI.create("https://other.example.com/v1/opamp"), capturedSettings.get().getEndpoint());
+	}
+
+	@Test
+	void disablingShouldStopTheClient() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		opAmpService.supervise();
+
+		agentConfig.setOpamp(OpAmpConfig.builder().enabled(false).build());
+		opAmpService.supervise();
+
+		assertEquals(1, factoryInvocations);
+		verify(client, times(1)).stop("OpAMP configuration changed");
+	}
+
+	@Test
+	void shutdownShouldStopTheClient() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		opAmpService.supervise();
+
+		opAmpService.shutdown();
+
+		verify(client, times(1)).stop("Agent shutting down");
+	}
+
+	@Test
+	void clientStartFailureShouldBeContained() {
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		final OpAmpService failingService = new OpAmpService(agentContextHolder, settings -> {
+			throw new IllegalStateException("Simulated client creation failure");
+		});
+
+		failingService.supervise();
+
+		verify(client, never()).start();
+	}
+
+	@Test
+	void buildSettingsShouldMapTheConfiguration() {
+		final OpAmpConfig config = OpAmpConfig.builder()
+			.enabled(true)
+			.endpoint(" " + ENDPOINT + " ")
+			.headers(Map.of("Authorization", "Bearer token"))
+			.certificateFile("/tmp/ca.pem")
+			.pollInterval(60)
+			.requestTimeout(15)
+			.reportHealth(false)
+			.build();
+
+		final OpampClientSettings settings = opAmpService.buildSettings(config);
+
+		assertEquals(URI.create(ENDPOINT), settings.getEndpoint());
+		assertEquals(Map.of("Authorization", "Bearer token"), settings.getHeaders());
+		assertEquals("/tmp/ca.pem", settings.getCertificateFile());
+		assertEquals(Duration.ofSeconds(60), settings.getPollInterval());
+		assertEquals(Duration.ofSeconds(15), settings.getRequestTimeout());
+		assertEquals(false, settings.isReportHealth());
+		assertEquals(
+			List.of(OpAmpService.OPAMP_INSTANCE_UID_FILENAME),
+			List.of(settings.getInstanceUidFile().getFileName().toString())
+		);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/service/ReloadServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/service/ReloadServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.metricshub.agent.config.AgentConfig;
 import org.metricshub.agent.config.AlertingSystemConfig;
+import org.metricshub.agent.config.OpAmpConfig;
 import org.metricshub.agent.config.ResourceConfig;
 import org.metricshub.agent.config.ResourceGroupConfig;
 import org.metricshub.agent.config.otel.OtelCollectorConfig;
@@ -550,6 +551,17 @@ class ReloadServiceTest {
 				"sequential",
 				AgentConfig.builder().otelConfig(Map.of(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "noop")).sequential(true).build(),
 				AgentConfig.builder().otelConfig(Map.of(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "noop")).sequential(false).build()
+			),
+			Arguments.of(
+				"opamp",
+				AgentConfig.builder()
+					.otelConfig(Map.of(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "noop"))
+					.opamp(OpAmpConfig.builder().enabled(false).build())
+					.build(),
+				AgentConfig.builder()
+					.otelConfig(Map.of(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, "noop"))
+					.opamp(OpAmpConfig.builder().enabled(true).endpoint("https://opamp.example.com/v1/opamp").build())
+					.build()
 			),
 			Arguments.of(
 				"enableSelfMonitoring",

--- a/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
@@ -12,6 +12,16 @@ otel:
   # otel.exporter.otlp.metrics.endpoint: http://localhost:4317
   # otel.exporter.otlp.metrics.protocol: grpc # Options include grpc and http/protobuf
 
+# Remote management through OpAMP (Open Agent Management Protocol)
+# opamp:
+#   enabled: true
+#   endpoint: https://opamp.example.com/v1/opamp
+#   headers:
+#     Authorization: Bearer ${env::OPAMP_TOKEN}
+#   # certificateFile: /opt/metricshub/security/opamp-ca.pem # Trusted certificate (PEM) for the OpAMP server
+#   # pollInterval: 30s
+#   # reportHealth: true
+
 # Simple resource configuration
 resources:
 

--- a/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
@@ -12,6 +12,16 @@ otel:
   # otel.exporter.otlp.metrics.endpoint: http://localhost:4317
   # otel.exporter.otlp.metrics.protocol: grpc # Options include grpc and http/protobuf
 
+# Remote management through OpAMP (Open Agent Management Protocol)
+# opamp:
+#   enabled: true
+#   endpoint: https://opamp.example.com/v1/opamp
+#   headers:
+#     Authorization: Bearer ${env::OPAMP_TOKEN}
+#   # certificateFile: C:\ProgramData\MetricsHub\security\opamp-ca.pem # Trusted certificate (PEM) for the OpAMP server
+#   # pollInterval: 30s
+#   # reportHealth: true
+
 # Simple resource configuration
 resources:
 


### PR DESCRIPTION
Part of **EPIC #1286 — MetricsHub / OpAMP**. Closes #1281. Base branch: `EPIC-OpAMP`. Builds on EPIC-OpAMP-01 (#1287).

## What

Integrates the `metricshub-opamp-client` into the MetricsHub Agent: the agent can now connect to an OpAMP server, report its identity, status and health, and is ready to receive package offers once the Upgrade Manager lands (EPIC-OpAMP-03).

### Configuration

New top-level `opamp:` section (disabled by default — zero behavior change for existing installations):

```yaml
opamp:
  enabled: true
  endpoint: https://opamp.example.com/v1/opamp
  headers:
    Authorization: Bearer ${env::OPAMP_TOKEN}   # values may be keystore-encrypted
  certificateFile: /opt/metricshub/security/opamp-ca.pem
  pollInterval: 30s
  reportHealth: true
```

`OpAmpConfig` is wired into `AgentConfig` and `ReloadService.globalConfigurationHasChanged` (an `opamp:` change triggers the global reload path). Commented blocks added to the Linux/Windows example configs.

### Lifecycle placement

`OpAmpService` is created in `MetricsHubAgentApplication.run()` **outside the restartable `AgentContext`**: a 30 s supervisor tick re-reads the `opamp:` section from `AgentContextHolder`, and starts/stops/rebuilds the client **only when that section changes** — the OpAMP connection survives ordinary configuration reloads and context restarts. A JVM shutdown hook (`ProcessControl.addShutdownHook`) delivers the final `AgentDisconnect`.

### Reporting

- **AgentDescription** — identifying: `service.name`, `service.version`, `host.name` (from `AgentInfo`); non-identifying: `os.type`, `host.arch`, `build_number` — the material the OpAMP server needs to select the right upgrade artifact. (`installer.type` arrives with the `DeploymentDetector` in EPIC-OpAMP-03.)
- **ComponentHealth** — agent `UP`/`DOWN` from `ApplicationStatusService` plus an `otel_collector` sub-component (`running`/`disabled` = healthy). Memory/CPU/counters deliberately excluded — already exported via OTLP self-monitoring.
- **Identity** — the OpAMP `instance_uid` (UUIDv7) persists next to the keystore in the `security/` directory, which survives package upgrades on all platforms.

Header values run through the MetricsHub keystore decryption (`ConfigHelper.decrypt`); plaintext values pass through unchanged.

## Validation

- `mvn prettier:write` ✅ / `mvn license:check-file-header` ✅ 0 issues / `mvn checkstyle:check` ✅ 0 violations
- `mvn verify` on `metricshub-agent` ✅ — **717 tests, 0 failures** (3 pre-existing skips)
- New coverage: `OpAmpConfig` YAML deserialization (incl. `1m` duration parsing and defaults), both mappers, 8 `OpAmpService` supervisor scenarios (enable/disable/reconfigure/failure-containment/shutdown), and the `opamp` change-detection case in `ReloadServiceTest`

Affected modules: `metricshub-agent`, `metricshub-assets` (example configs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
