### PR TITLE
EPIC-OpAMP-03: Upgrade engine driven by OpAMP package offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ This is a multi-module project:
 
 ## Remote Management (OpAMP)
 
-The MetricsHub Agent embeds an [OpAMP](https://opentelemetry.io/docs/specs/opamp/) client for centralized fleet management. When enabled, the agent connects to an OpAMP server over plain HTTP polling and reports its identity (`service.name`, `service.version`, `host.name`, plus `os.type`, `host.arch` and `build_number`), status and health. Automatic software upgrades through OpAMP package offers are under development (see [#1286](https://github.com/MetricsHub/metricshub-community/issues/1286)); until that lands, package offers are not accepted.
+The MetricsHub Agent embeds an [OpAMP](https://opentelemetry.io/docs/specs/opamp/) client for centralized fleet management. When enabled, the agent connects to an OpAMP server over plain HTTP polling and reports its identity (`service.name`, `service.version`, `host.name`, plus `os.type`, `host.arch` and `build_number`), status and health.
+
+On package-manager based installations (Debian, RPM, Windows MSI), the agent also advertises the OpAMP `AcceptsPackages` capability and processes software package offers: the offered package is downloaded from the repository over HTTPS, verified against the offered SHA-256, staged in an upgrade directory that survives the installation, and tracked through a persistent upgrade transaction whose outcome (success or failure) is reconciled and reported after the agent restarts. The final detached installation step ships with the platform upgrade runners (see [#1286](https://github.com/MetricsHub/metricshub-community/issues/1286)); until they land, offers fail cleanly at the installation stage with an explicit status. The upgrade policy is configured through the top-level `upgrade:` section (`enabled`, `allowDowngrade`, `hostAllowlist`, `maxPackageSizeBytes`, `downloadTimeout`, `downloadRetries`, `installTimeout`, `trustedCertificateFile`). Archive (tar.gz/zip) and Docker deployments never accept package offers.
 
 The feature is **disabled by default**. Enable it with a top-level `opamp:` section in `metricshub.yaml`:
 

--- a/metricshub-agent/src/main/java/org/metricshub/agent/MetricsHubAgentApplication.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/MetricsHubAgentApplication.java
@@ -36,7 +36,10 @@ import org.metricshub.agent.process.runtime.ProcessControl;
 import org.metricshub.agent.service.ReloadService;
 import org.metricshub.agent.service.ReloadService.ReloadResult;
 import org.metricshub.agent.service.task.DirectoryWatcherTask;
+import org.metricshub.agent.upgrade.UpgradeManager;
+import org.metricshub.agent.upgrade.opamp.OpampUpgradeAdapter;
 import org.metricshub.engine.extension.ExtensionManager;
+import org.metricshub.opamp.client.packages.OpampPackagesHandler;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.AgentContextReaderTracker;
 import org.metricshub.web.MetricsHubAgentServer;
@@ -102,10 +105,19 @@ public class MetricsHubAgentApplication implements Runnable {
 			// AgentContextHolder singleton bean is our own instance (used by every service).
 			new Thread(() -> MetricsHubAgentServer.startServer(agentContextHolder)).start();
 
+			// Reconcile a pending upgrade transaction before anything reports to OpAMP, so the
+			// upgrade verdict (SUCCEEDED/FAILED) is part of the first OpAMP status report.
+			final var upgradeManager = new UpgradeManager(agentContextHolder);
+			upgradeManager.reconcileOnStartup();
+
 			// Start the OpAMP service at application level, outside the restartable AgentContext:
 			// its supervisor re-reads the opamp: configuration from the holder and keeps the
-			// OpAMP connection alive across configuration reloads.
-			final var opAmpService = new OpAmpService(agentContextHolder);
+			// OpAMP connection alive across configuration reloads. Package offers are accepted
+			// only on deployments supporting in-place upgrades (deb/rpm/msi).
+			final OpampPackagesHandler packagesHandler = upgradeManager.isPackageUpgradeSupported()
+				? new OpampUpgradeAdapter(upgradeManager)
+				: null;
+			final var opAmpService = new OpAmpService(agentContextHolder, packagesHandler);
 			opAmpService.start();
 			ProcessControl.addShutdownHook(opAmpService::shutdown);
 

--- a/metricshub-agent/src/main/java/org/metricshub/agent/config/AgentConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/config/AgentConfig.java
@@ -163,6 +163,10 @@ public class AgentConfig {
 	@JsonSetter(nulls = SKIP)
 	private OpAmpConfig opamp = OpAmpConfig.builder().build();
 
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private UpgradeConfig upgrade = UpgradeConfig.builder().build();
+
 	/**
 	 * Build a new empty instance
 	 *

--- a/metricshub-agent/src/main/java/org/metricshub/agent/config/UpgradeConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/config/UpgradeConfig.java
@@ -1,0 +1,123 @@
+package org.metricshub.agent.config;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static com.fasterxml.jackson.annotation.Nulls.SKIP;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.metricshub.engine.deserialization.TimeDeserializer;
+
+/**
+ * Configuration of the automatic upgrade feature driven by OpAMP package offers: download limits,
+ * source restrictions and installation policy. Honored only when the {@code opamp:} section is
+ * enabled.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UpgradeConfig {
+
+	/**
+	 * Default maximum package size in bytes (1 GiB).
+	 */
+	public static final long DEFAULT_MAX_PACKAGE_SIZE_BYTES = 1024L * 1024 * 1024;
+
+	/**
+	 * Default download timeout in seconds.
+	 */
+	public static final long DEFAULT_DOWNLOAD_TIMEOUT = 1800;
+
+	/**
+	 * Default number of download attempts.
+	 */
+	public static final int DEFAULT_DOWNLOAD_RETRIES = 3;
+
+	/**
+	 * Default installation timeout in seconds: an upgrade still not finished after this delay is
+	 * reconciled as failed.
+	 */
+	public static final long DEFAULT_INSTALL_TIMEOUT = 1800;
+
+	/**
+	 * Whether automatic upgrades are enabled (when OpAMP itself is enabled).
+	 */
+	@Default
+	private boolean enabled = true;
+
+	/**
+	 * Whether package offers older than the running version are accepted.
+	 */
+	private boolean allowDowngrade;
+
+	/**
+	 * Maximum accepted package size in bytes.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private long maxPackageSizeBytes = DEFAULT_MAX_PACKAGE_SIZE_BYTES;
+
+	/**
+	 * Timeout in seconds of one download attempt.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = TimeDeserializer.class)
+	private long downloadTimeout = DEFAULT_DOWNLOAD_TIMEOUT;
+
+	/**
+	 * Number of download attempts before the upgrade fails.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private int downloadRetries = DEFAULT_DOWNLOAD_RETRIES;
+
+	/**
+	 * Timeout in seconds of the detached installation.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	@JsonDeserialize(using = TimeDeserializer.class)
+	private long installTimeout = DEFAULT_INSTALL_TIMEOUT;
+
+	/**
+	 * Hosts allowed as package download sources; empty to allow any HTTPS host.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private List<String> hostAllowlist = new ArrayList<>();
+
+	/**
+	 * Path to a PEM file containing the trusted certificate used to verify the package
+	 * repository's TLS credentials; {@code null} to use the system trust store.
+	 */
+	@JsonSetter(nulls = SKIP)
+	private String trustedCertificateFile;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -40,6 +40,7 @@ import org.metricshub.opamp.client.OpampClient;
 import org.metricshub.opamp.client.OpampClientCallbacks;
 import org.metricshub.opamp.client.OpampClientSettings;
 import org.metricshub.opamp.client.impl.HttpPollingOpampClient;
+import org.metricshub.opamp.client.packages.OpampPackagesHandler;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.service.ApplicationStatusService;
 
@@ -71,23 +72,37 @@ public class OpAmpService {
 	private final ApplicationStatusService applicationStatusService;
 	private final Function<OpampClientSettings, OpampClient> clientFactory;
 	private final ScheduledExecutorService supervisor;
+	private final OpampPackagesHandler packagesHandler;
 
 	private OpampClient client;
 	private OpAmpConfig activeConfig;
+	private Boolean activeUpgradeEnabled;
+
+	/**
+	 * Creates the service with the default OpAMP client factory and no packages handler.
+	 *
+	 * @param agentContextHolder the holder of the current agent context
+	 */
+	public OpAmpService(final AgentContextHolder agentContextHolder) {
+		this(agentContextHolder, (OpampPackagesHandler) null);
+	}
 
 	/**
 	 * Creates the service with the default OpAMP client factory.
 	 *
 	 * @param agentContextHolder the holder of the current agent context
+	 * @param packagesHandler    the handler receiving OpAMP package offers; {@code null} when
+	 *                           automatic upgrades are not supported on this deployment
 	 */
-	public OpAmpService(final AgentContextHolder agentContextHolder) {
-		this(agentContextHolder, settings ->
+	public OpAmpService(final AgentContextHolder agentContextHolder, final OpampPackagesHandler packagesHandler) {
+		this(agentContextHolder, packagesHandler, settings ->
 			HttpPollingOpampClient.builder().withSettings(settings).withCallbacks(new LoggingCallbacks()).build()
 		);
 	}
 
 	/**
-	 * Creates the service with a caller-provided client factory (used by tests).
+	 * Creates the service with a caller-provided client factory and no packages handler (used by
+	 * tests).
 	 *
 	 * @param agentContextHolder the holder of the current agent context
 	 * @param clientFactory      the factory building an {@link OpampClient} from settings
@@ -96,7 +111,23 @@ public class OpAmpService {
 		final AgentContextHolder agentContextHolder,
 		final Function<OpampClientSettings, OpampClient> clientFactory
 	) {
+		this(agentContextHolder, null, clientFactory);
+	}
+
+	/**
+	 * Creates the service with caller-provided collaborators.
+	 *
+	 * @param agentContextHolder the holder of the current agent context
+	 * @param packagesHandler    the handler receiving OpAMP package offers; may be {@code null}
+	 * @param clientFactory      the factory building an {@link OpampClient} from settings
+	 */
+	OpAmpService(
+		final AgentContextHolder agentContextHolder,
+		final OpampPackagesHandler packagesHandler,
+		final Function<OpampClientSettings, OpampClient> clientFactory
+	) {
 		this.agentContextHolder = agentContextHolder;
+		this.packagesHandler = packagesHandler;
 		this.applicationStatusService = new ApplicationStatusService(agentContextHolder);
 		this.clientFactory = clientFactory;
 		this.supervisor = Executors.newSingleThreadScheduledExecutor(runnable -> {
@@ -147,8 +178,9 @@ public class OpAmpService {
 		}
 
 		final OpAmpConfig config = agentContext.getAgentConfig().getOpamp();
-		if (!Objects.equals(config, activeConfig)) {
-			reconfigure(agentContext, config);
+		final boolean upgradeEnabled = isUpgradeEnabled(agentContext);
+		if (!Objects.equals(config, activeConfig) || !Objects.equals(upgradeEnabled, activeUpgradeEnabled)) {
+			reconfigure(agentContext, config, upgradeEnabled);
 		}
 
 		if (client != null && client.isStarted()) {
@@ -164,12 +196,13 @@ public class OpAmpService {
 	 * @param agentContext the current agent context
 	 * @param newConfig    the new OpAMP configuration
 	 */
-	private void reconfigure(final AgentContext agentContext, final OpAmpConfig newConfig) {
+	private void reconfigure(final AgentContext agentContext, final OpAmpConfig newConfig, final boolean upgradeEnabled) {
 		if (client != null) {
 			client.stop("OpAMP configuration changed");
 			client = null;
 		}
 		activeConfig = newConfig;
+		activeUpgradeEnabled = upgradeEnabled;
 
 		if (newConfig == null || !newConfig.isEnabled()) {
 			log.info("OpAMP is disabled.");
@@ -184,6 +217,10 @@ public class OpAmpService {
 		OpampClient newClient = null;
 		try {
 			newClient = clientFactory.apply(buildSettings(newConfig));
+			if (packagesHandler != null && upgradeEnabled) {
+				// Advertises the AcceptsPackages/ReportsPackageStatuses capabilities
+				newClient.setPackagesHandler(packagesHandler);
+			}
 			// Report a complete first message
 			newClient.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));
 			newClient.setHealth(OpAmpHealthMapper.map(applicationStatusService.reportApplicationStatus()));
@@ -216,6 +253,16 @@ public class OpAmpService {
 		} catch (Exception stopError) {
 			log.debug("Failed to release the OpAMP client that could not start:", stopError);
 		}
+	}
+
+	/**
+	 * Indicates whether automatic upgrades are enabled in the agent configuration.
+	 *
+	 * @param agentContext the current agent context
+	 * @return {@code true} when the {@code upgrade:} section is enabled
+	 */
+	private static boolean isUpgradeEnabled(final AgentContext agentContext) {
+		return agentContext.getAgentConfig().getUpgrade() != null && agentContext.getAgentConfig().getUpgrade().isEnabled();
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -231,6 +231,11 @@ public class OpAmpService {
 			newClient.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));
 			newClient.setHealth(OpAmpHealthMapper.map(applicationStatusService.reportApplicationStatus()));
 			newClient.start();
+			if (packagesHandler instanceof OpampUpgradeAdapter adapter && upgradeEnabled) {
+				// The client seeded its package statuses from a pre-start snapshot: re-report the
+				// latest snapshot so a transition that raced the handoff is not lost
+				adapter.republishSnapshot();
+			}
 			client = newClient;
 		} catch (Exception e) {
 			// Release the resources of a client whose startup failed: the retry below builds a

--- a/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/opamp/OpAmpService.java
@@ -36,6 +36,7 @@ import org.metricshub.agent.config.OpAmpConfig;
 import org.metricshub.agent.context.AgentContext;
 import org.metricshub.agent.helper.ConfigHelper;
 import org.metricshub.agent.security.PasswordEncrypt;
+import org.metricshub.agent.upgrade.opamp.OpampUpgradeAdapter;
 import org.metricshub.opamp.client.OpampClient;
 import org.metricshub.opamp.client.OpampClientCallbacks;
 import org.metricshub.opamp.client.OpampClientSettings;
@@ -220,6 +221,11 @@ public class OpAmpService {
 			if (packagesHandler != null && upgradeEnabled) {
 				// Advertises the AcceptsPackages/ReportsPackageStatuses capabilities
 				newClient.setPackagesHandler(packagesHandler);
+				if (packagesHandler instanceof OpampUpgradeAdapter adapter) {
+					// Rebind the status sink to the new client so upgrade transitions occurring
+					// before the next package offer still reach the live client
+					adapter.bindSink(newClient.packageStatusSink());
+				}
 			}
 			// Report a complete first message
 			newClient.setAgentDescription(OpAmpAgentDescriptionMapper.map(agentContext.getAgentInfo()));

--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/ReloadService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/ReloadService.java
@@ -206,7 +206,8 @@ public class ReloadService {
 			!Objects.equals(runningConf.getMetrics(), newConf.getMetrics()) ||
 			!Objects.equals(runningConf.getStateSetCompression(), newConf.getStateSetCompression()) ||
 			!Objects.equals(runningConf.getPatchDirectory(), newConf.getPatchDirectory()) ||
-			!Objects.equals(runningConf.getOpamp(), newConf.getOpamp())
+			!Objects.equals(runningConf.getOpamp(), newConf.getOpamp()) ||
+			!Objects.equals(runningConf.getUpgrade(), newConf.getUpgrade())
 		);
 		// CHECKSTYLE:ON
 	}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeDirectories.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeDirectories.java
@@ -1,0 +1,58 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.metricshub.agent.helper.AgentConstants;
+import org.metricshub.agent.helper.ConfigHelper;
+import org.metricshub.engine.common.helpers.LocalOsHandler;
+
+/**
+ * Resolves the upgrade staging directory, which must survive the package upgrade itself:
+ * {@code %ProgramData%/MetricsHub/upgrade} on Windows and {@code <install>/lib/upgrade} on other
+ * platforms (unowned files under the installation tree are preserved by dpkg/rpm across
+ * upgrades).
+ */
+public class UpgradeDirectories {
+
+	/**
+	 * Name of the upgrade staging directory.
+	 */
+	public static final String UPGRADE_DIRECTORY_NAME = "upgrade";
+
+	private UpgradeDirectories() {}
+
+	/**
+	 * Resolves the upgrade staging directory without creating it.
+	 *
+	 * @return the staging directory path
+	 */
+	public static Path resolveStagingDirectory() {
+		if (LocalOsHandler.isWindows()) {
+			return ConfigHelper.getProgramDataPath()
+				.map(programData -> Paths.get(programData, AgentConstants.PRODUCT_WIN_DIR_NAME, UPGRADE_DIRECTORY_NAME))
+				.orElseGet(() -> ConfigHelper.getSubPath(UPGRADE_DIRECTORY_NAME));
+		}
+		return ConfigHelper.getSubPath(UPGRADE_DIRECTORY_NAME);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeException.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeException.java
@@ -1,0 +1,50 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Failure of an upgrade step. The message is user-facing: it is persisted in the upgrade
+ * transaction and reported to the OpAMP server as the package {@code error_message}.
+ */
+public class UpgradeException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates an upgrade failure.
+	 *
+	 * @param message the user-facing failure cause
+	 */
+	public UpgradeException(final String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates an upgrade failure with a cause.
+	 *
+	 * @param message the user-facing failure cause
+	 * @param cause   the underlying exception
+	 */
+	public UpgradeException(final String message, final Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeLock.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeLock.java
@@ -1,0 +1,93 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Single-upgrade guard: an in-memory flag backed by a lock file in the staging directory, so a
+ * second upgrade cannot start while one is being prepared or installed — even across an agent
+ * restart while the detached installer is running.
+ */
+@Slf4j
+public class UpgradeLock {
+
+	/**
+	 * Name of the lock file created in the staging directory.
+	 */
+	public static final String LOCK_FILE_NAME = "upgrade.lock";
+
+	private final Path lockFile;
+	private final AtomicBoolean held = new AtomicBoolean(false);
+
+	/**
+	 * Creates the lock in the given staging directory.
+	 *
+	 * @param stagingDirectory the upgrade staging directory
+	 */
+	public UpgradeLock(final Path stagingDirectory) {
+		this.lockFile = stagingDirectory.resolve(LOCK_FILE_NAME);
+	}
+
+	/**
+	 * Attempts to acquire the lock.
+	 *
+	 * @return {@code true} when the lock was acquired
+	 */
+	public boolean tryAcquire() {
+		if (!held.compareAndSet(false, true)) {
+			return false;
+		}
+		try {
+			Files.createDirectories(lockFile.getParent());
+			Files.createFile(lockFile);
+			return true;
+		} catch (IOException e) {
+			held.set(false);
+			log.warn("Cannot acquire the upgrade lock {}: {}", lockFile, e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * Releases the lock (in memory and on disk).
+	 */
+	public void release() {
+		held.set(false);
+		try {
+			Files.deleteIfExists(lockFile);
+		} catch (IOException e) {
+			log.warn("Cannot release the upgrade lock {}: {}", lockFile, e.getMessage());
+		}
+	}
+
+	/**
+	 * Releases a lock file left behind by a previous process (startup reconciliation).
+	 */
+	public void releaseStale() {
+		release();
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -1,0 +1,453 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.metricshub.agent.helper.AgentConstants.AGENT_INFO_VERSION_ATTRIBUTE_KEY;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.api.UpgradeEvent;
+import org.metricshub.agent.upgrade.api.UpgradeStatusListener;
+import org.metricshub.agent.upgrade.download.PackageDownloader;
+import org.metricshub.agent.upgrade.runner.DeploymentDetector;
+import org.metricshub.agent.upgrade.runner.RunnerLauncher;
+import org.metricshub.agent.upgrade.runner.UnsupportedRunnerLauncher;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransactionStore;
+import org.metricshub.agent.upgrade.validate.PackageValidator;
+import org.metricshub.web.AgentContextHolder;
+
+/**
+ * Orchestrates automatic upgrades driven by OpAMP package offers: validates the offer, downloads
+ * and validates the package, persists an upgrade transaction that survives the restart, launches
+ * the detached installer, and reconciles the outcome when the agent starts again.
+ * <p>
+ * Offers are processed on a single worker thread; one upgrade at a time is enforced by
+ * {@link UpgradeLock}. Lifecycle transitions are published to the registered
+ * {@link UpgradeStatusListener}.
+ * </p>
+ */
+@Slf4j
+public class UpgradeManager {
+
+	/**
+	 * Name of the top-level package this agent manages.
+	 */
+	public static final String PACKAGE_NAME = "metricshub";
+
+	private final Supplier<String> currentVersionSupplier;
+	private final Supplier<UpgradeConfig> configSupplier;
+	private final Path stagingDirectory;
+	private final UpgradeTransactionStore transactionStore;
+	private final UpgradeLock lock;
+	private final PackageDownloader downloader;
+	private final PackageValidator validator;
+	private final DeploymentDetector deploymentDetector;
+	private final RunnerLauncher runnerLauncher;
+	private final ExecutorService worker;
+
+	private volatile UpgradeStatusListener statusListener = event -> {};
+
+	private final Object snapshotLock = new Object();
+	private UpgradeEvent lastEvent;
+
+	/**
+	 * Creates the manager with production wiring.
+	 *
+	 * @param agentContextHolder the holder of the current agent context
+	 */
+	public UpgradeManager(final AgentContextHolder agentContextHolder) {
+		this(
+			() -> agentContextHolder.getAgentContext().getAgentInfo().getAttributes().get(AGENT_INFO_VERSION_ATTRIBUTE_KEY),
+			() -> agentContextHolder.getAgentContext().getAgentConfig().getUpgrade(),
+			UpgradeDirectories.resolveStagingDirectory(),
+			new PackageDownloader(),
+			new PackageValidator(),
+			new DeploymentDetector(),
+			new UnsupportedRunnerLauncher()
+		);
+	}
+
+	/**
+	 * Creates the manager with caller-provided collaborators (used by tests).
+	 *
+	 * @param currentVersionSupplier supplies the version the agent currently runs
+	 * @param configSupplier         supplies the upgrade configuration
+	 * @param stagingDirectory       the upgrade staging directory
+	 * @param downloader             the package downloader
+	 * @param validator              the package validator
+	 * @param deploymentDetector     the deployment detector
+	 * @param runnerLauncher         the detached runner launcher
+	 */
+	UpgradeManager(
+		final Supplier<String> currentVersionSupplier,
+		final Supplier<UpgradeConfig> configSupplier,
+		final Path stagingDirectory,
+		final PackageDownloader downloader,
+		final PackageValidator validator,
+		final DeploymentDetector deploymentDetector,
+		final RunnerLauncher runnerLauncher
+	) {
+		this.currentVersionSupplier = currentVersionSupplier;
+		this.configSupplier = configSupplier;
+		this.stagingDirectory = stagingDirectory;
+		this.transactionStore = new UpgradeTransactionStore(stagingDirectory);
+		this.lock = new UpgradeLock(stagingDirectory);
+		this.downloader = downloader;
+		this.validator = validator;
+		this.deploymentDetector = deploymentDetector;
+		this.runnerLauncher = runnerLauncher;
+		this.worker = Executors.newSingleThreadExecutor(runnable -> {
+			final Thread thread = new Thread(runnable, "metricshub-upgrade");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	/**
+	 * Registers the listener receiving upgrade lifecycle transitions.
+	 *
+	 * @param listener the status listener
+	 */
+	public void setStatusListener(final UpgradeStatusListener listener) {
+		this.statusListener = listener != null ? listener : event -> {};
+	}
+
+	/**
+	 * Indicates whether this deployment supports automatic in-place upgrades (deb/rpm/msi).
+	 *
+	 * @return {@code true} when package offers can be honored
+	 */
+	public boolean isPackageUpgradeSupported() {
+		return deploymentDetector.detect().isUpgradable();
+	}
+
+	/**
+	 * Returns the current upgrade state snapshot, used to seed the first OpAMP status report.
+	 *
+	 * @return the last published upgrade event
+	 */
+	public UpgradeEvent getCurrentSnapshot() {
+		synchronized (snapshotLock) {
+			if (lastEvent == null) {
+				lastEvent = UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, currentVersion(), null, null);
+			}
+			return lastEvent;
+		}
+	}
+
+	/**
+	 * Reconciles a pending upgrade transaction at agent startup: an upgrade interrupted by the
+	 * installation restart is resolved by comparing the running version with the target version.
+	 * Must be called before the OpAMP client starts so the verdict is part of the first report.
+	 */
+	public void reconcileOnStartup() {
+		final UpgradeTransaction transaction = transactionStore.read();
+		if (transaction == null) {
+			lock.releaseStale();
+			return;
+		}
+
+		final String current = currentVersion();
+		final UpgradeState state = transaction.getState();
+		log.info(
+			"Reconciling the pending upgrade transaction {} ({} -> {}, state {}).",
+			transaction.getUpgradeId(),
+			transaction.getFromVersion(),
+			transaction.getToVersion(),
+			state
+		);
+
+		if (state != null && state.isInstallPhase()) {
+			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.VERIFYING, current, transaction.getToVersion(), null));
+			if (VersionHelper.isSameVersion(current, transaction.getToVersion())) {
+				finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
+			} else {
+				finishReconciliation(
+					transaction,
+					UpgradeState.FAILED,
+					"The agent restarted with version " +
+						current +
+						" while version " +
+						transaction.getToVersion() +
+						" was expected",
+					current
+				);
+			}
+		} else if (state == UpgradeState.SUCCEEDED || state == UpgradeState.FAILED) {
+			publish(UpgradeEvent.of(PACKAGE_NAME, state, current, transaction.getToVersion(), transaction.getError()));
+			transactionStore.archive(transaction);
+			lock.releaseStale();
+		} else {
+			finishReconciliation(
+				transaction,
+				UpgradeState.FAILED,
+				"The upgrade was interrupted before the installation started",
+				current
+			);
+		}
+	}
+
+	/**
+	 * Accepts a package offer for asynchronous processing.
+	 *
+	 * @param offer the package offer
+	 */
+	public void onPackageOffer(final PackageOffer offer) {
+		try {
+			worker.submit(() -> processOffer(offer));
+		} catch (RejectedExecutionException e) {
+			log.warn("The upgrade worker rejected a package offer: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Runs the upgrade pipeline for one offer: sanity checks, transaction persistence, download,
+	 * validation and detached installer launch.
+	 *
+	 * @param offer the package offer
+	 */
+	private void processOffer(final PackageOffer offer) {
+		final UpgradeConfig config = configSupplier.get();
+		final String current = currentVersion();
+
+		if (config == null || !config.isEnabled()) {
+			publish(
+				UpgradeEvent.of(
+					PACKAGE_NAME,
+					UpgradeState.FAILED,
+					current,
+					offer.version(),
+					"Automatic upgrades are disabled by configuration (upgrade.enabled)"
+				)
+			);
+			return;
+		}
+
+		if (VersionHelper.isSameVersion(current, offer.version())) {
+			log.info("The offered version {} is already installed.", offer.version());
+			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, current, offer.version(), null));
+			return;
+		}
+
+		if (!lock.tryAcquire()) {
+			log.warn("Ignoring the package offer for version {}: another upgrade is already in progress.", offer.version());
+			return;
+		}
+
+		UpgradeTransaction transaction = null;
+		try {
+			validator.validateOffer(offer, current, config, deploymentDetector.detect());
+
+			transaction = UpgradeTransaction.builder()
+				.upgradeId(UUID.randomUUID().toString())
+				.packageName(offer.packageName())
+				.fromVersion(current)
+				.toVersion(offer.version())
+				.downloadUrl(offer.downloadUrl())
+				.sha256(offer.sha256Hex())
+				.deploymentKind(deploymentDetector.detect().name())
+				.state(UpgradeState.UPDATE_AVAILABLE)
+				.createdAt(System.currentTimeMillis())
+				.installTimeoutSeconds(config.getInstallTimeout())
+				.build();
+			persistAndPublish(transaction, UpgradeState.UPDATE_AVAILABLE, null);
+
+			persistAndPublish(transaction, UpgradeState.DOWNLOADING, null);
+			final String targetVersion = offer.version();
+			final Path stagedPackage = downloader.download(offer, config, stagingDirectory, (percent, bytesPerSecond) ->
+				publish(
+					new UpgradeEvent(
+						PACKAGE_NAME,
+						UpgradeState.DOWNLOADING,
+						current,
+						targetVersion,
+						null,
+						percent,
+						bytesPerSecond
+					)
+				)
+			);
+			transaction.setPackageFile(stagedPackage.toAbsolutePath().toString());
+
+			persistAndPublish(transaction, UpgradeState.VALIDATING, null);
+			validator.validateStagedPackage(stagedPackage, offer, config);
+
+			persistAndPublish(transaction, UpgradeState.READY_TO_INSTALL, null);
+
+			transaction.setInstallStartedAt(System.currentTimeMillis());
+			persistAndPublish(transaction, UpgradeState.INSTALLING, null);
+			runnerLauncher.launch(transaction, stagedPackage, stagingDirectory);
+
+			persistAndPublish(transaction, UpgradeState.RESTARTING, null);
+			log.info(
+				"The detached upgrade runner was launched for version {}; the agent is about to be stopped.",
+				offer.version()
+			);
+			// The lock and the transaction remain: the outcome is reconciled at the next startup.
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			failUpgrade(transaction, offer, current, "The upgrade was interrupted");
+		} catch (Exception e) {
+			failUpgrade(transaction, offer, current, e.getMessage());
+		}
+	}
+
+	/**
+	 * Marks the current upgrade attempt as failed: persists the terminal state, publishes the
+	 * event, cleans the staged file and releases the lock.
+	 *
+	 * @param transaction the transaction, or {@code null} when the failure happened before it was
+	 *                    created
+	 * @param offer       the package offer
+	 * @param current     the current agent version
+	 * @param error       the failure cause
+	 */
+	private void failUpgrade(
+		final UpgradeTransaction transaction,
+		final PackageOffer offer,
+		final String current,
+		final String error
+	) {
+		log.error("Upgrade to version {} failed: {}", offer.version(), error);
+		if (transaction != null) {
+			transaction.setState(UpgradeState.FAILED);
+			transaction.setError(error);
+			try {
+				transactionStore.write(transaction);
+			} catch (IOException e) {
+				log.warn("Cannot persist the failed upgrade transaction: {}", e.getMessage());
+			}
+			transactionStore.archive(transaction);
+			deleteStagedFile(transaction);
+		}
+		// Release the lock before publishing: the event is the observable signal that the
+		// attempt is fully terminated.
+		lock.release();
+		publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.FAILED, current, offer.version(), error));
+	}
+
+	/**
+	 * Persists the transaction in the given state and publishes the corresponding event.
+	 *
+	 * @param transaction the transaction to persist
+	 * @param state       the new state
+	 * @param error       the failure cause, when any
+	 * @throws IOException when the transaction cannot be persisted
+	 */
+	private void persistAndPublish(final UpgradeTransaction transaction, final UpgradeState state, final String error)
+		throws IOException {
+		transaction.setState(state);
+		transaction.setError(error);
+		transactionStore.write(transaction);
+		publish(UpgradeEvent.of(PACKAGE_NAME, state, transaction.getFromVersion(), transaction.getToVersion(), error));
+	}
+
+	/**
+	 * Terminates a reconciliation: persists the verdict, publishes it, archives the transaction,
+	 * cleans the staged file and releases the lock.
+	 *
+	 * @param transaction the reconciled transaction
+	 * @param verdict     the terminal state
+	 * @param error       the failure cause, when any
+	 * @param current     the current agent version
+	 */
+	private void finishReconciliation(
+		final UpgradeTransaction transaction,
+		final UpgradeState verdict,
+		final String error,
+		final String current
+	) {
+		transaction.setState(verdict);
+		transaction.setError(error);
+		try {
+			transactionStore.write(transaction);
+		} catch (IOException e) {
+			log.warn("Cannot persist the reconciled upgrade transaction: {}", e.getMessage());
+		}
+		transactionStore.archive(transaction);
+		deleteStagedFile(transaction);
+		lock.releaseStale();
+		publish(UpgradeEvent.of(PACKAGE_NAME, verdict, current, transaction.getToVersion(), error));
+		if (verdict == UpgradeState.SUCCEEDED) {
+			log.info("Upgrade to version {} succeeded.", transaction.getToVersion());
+		} else {
+			log.error("Upgrade to version {} failed: {}", transaction.getToVersion(), error);
+		}
+	}
+
+	/**
+	 * Deletes the staged package file of a finished upgrade attempt.
+	 *
+	 * @param transaction the finished transaction
+	 */
+	private void deleteStagedFile(final UpgradeTransaction transaction) {
+		if (transaction.getPackageFile() == null) {
+			return;
+		}
+		try {
+			Files.deleteIfExists(Path.of(transaction.getPackageFile()));
+		} catch (IOException e) {
+			log.debug("Cannot delete the staged package {}: {}", transaction.getPackageFile(), e.getMessage());
+		}
+	}
+
+	/**
+	 * Publishes an event to the registered listener and records it as the current snapshot.
+	 *
+	 * @param event the event to publish
+	 */
+	private void publish(final UpgradeEvent event) {
+		synchronized (snapshotLock) {
+			lastEvent = event;
+		}
+		try {
+			statusListener.onUpgradeEvent(event);
+		} catch (Exception e) {
+			log.warn("The upgrade status listener failed: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Returns the version the agent currently runs.
+	 *
+	 * @return the current version, or an empty string when unavailable
+	 */
+	private String currentVersion() {
+		try {
+			final String version = currentVersionSupplier.get();
+			return version != null ? version : "";
+		} catch (Exception e) {
+			log.debug("Cannot determine the current agent version: {}", e.getMessage());
+			return "";
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -76,7 +76,7 @@ public class UpgradeManager {
 	private final RunnerLauncher runnerLauncher;
 	private final ExecutorService worker;
 
-	private volatile UpgradeStatusListener statusListener = event -> {};
+	private volatile UpgradeStatusListener statusListener = _ -> {};
 	private volatile String installedHashHex;
 
 	private final Object snapshotLock = new Object();
@@ -153,7 +153,7 @@ public class UpgradeManager {
 	 * @param listener the status listener
 	 */
 	public void setStatusListener(final UpgradeStatusListener listener) {
-		this.statusListener = listener != null ? listener : event -> {};
+		this.statusListener = listener != null ? listener : _ -> {};
 	}
 
 	/**
@@ -317,16 +317,8 @@ public class UpgradeManager {
 			return;
 		}
 
-		if (VersionHelper.isSameVersion(current, offer.version()) && !hasDifferentPackageIdentity(offer)) {
+		if (VersionHelper.isSameVersion(current, offer.version()) && hasSameInstalledIdentity(offer)) {
 			log.info("The offered version {} is already installed.", offer.version());
-			// The agent runs the offered version: adopt the offered identity hash so the fleet
-			// state converges even for packages that were not installed through OpAMP.
-			if (installedHashHex == null && offer.packageHash() != null && offer.packageHash().length > 0) {
-				installedHashHex = offer.packageHashHex();
-				transactionStore.writeInstalledPackage(
-					new UpgradeTransactionStore.InstalledPackageRecord(current, installedHashHex)
-				);
-			}
 			publish(
 				UpgradeEvent.of(
 					PACKAGE_NAME,
@@ -557,19 +549,21 @@ public class UpgradeManager {
 	}
 
 	/**
-	 * Indicates whether the offered package identity differs from the installed one. Per the
-	 * OpAMP specification, package identity is defined by the offered package hash: a differing
-	 * hash must be installed even when the version string is unchanged (same-version hotfix). An
-	 * offer without a hash, or an unknown installed identity, is treated as identical.
+	 * Indicates whether the offered package identity matches the installed one. Per the OpAMP
+	 * specification, package identity is defined by the offered package hash: a same-version
+	 * offer is only "already installed" when its identity is known to match. An unknown installed
+	 * identity (a package never installed through OpAMP) therefore triggers the installation —
+	 * the identity is learned once the runner confirms it. An offer without a hash carries no
+	 * identity, so version equality is the only available evidence.
 	 *
 	 * @param offer the package offer
-	 * @return {@code true} when the offered identity is known to differ from the installed one
+	 * @return {@code true} when the offered identity is not known to differ from the installed one
 	 */
-	private boolean hasDifferentPackageIdentity(final PackageOffer offer) {
-		if (offer.packageHash() == null || offer.packageHash().length == 0 || installedHashHex == null) {
-			return false;
+	private boolean hasSameInstalledIdentity(final PackageOffer offer) {
+		if (offer.packageHash() == null || offer.packageHash().length == 0) {
+			return true;
 		}
-		return !installedHashHex.equalsIgnoreCase(offer.packageHashHex());
+		return installedHashHex != null && installedHashHex.equalsIgnoreCase(offer.packageHashHex());
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -40,6 +40,7 @@ import org.metricshub.agent.upgrade.api.UpgradeStatusListener;
 import org.metricshub.agent.upgrade.download.PackageDownloader;
 import org.metricshub.agent.upgrade.runner.DeploymentDetector;
 import org.metricshub.agent.upgrade.runner.RunnerLauncher;
+import org.metricshub.agent.upgrade.runner.RunnerMarkers;
 import org.metricshub.agent.upgrade.runner.UnsupportedRunnerLauncher;
 import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
 import org.metricshub.agent.upgrade.transaction.UpgradeTransactionStore;
@@ -220,7 +221,24 @@ public class UpgradeManager {
 					null
 				)
 			);
-			if (VersionHelper.isSameVersion(current, transaction.getToVersion())) {
+			if (VersionHelper.isSameVersion(transaction.getFromVersion(), transaction.getToVersion())) {
+				// Same-version hotfix: the running version is identical whether or not the
+				// installer ran, so the verdict relies on the runner's completion marker.
+				if (RunnerMarkers.installSucceeded(stagingDirectory)) {
+					finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
+				} else {
+					finishReconciliation(
+						transaction,
+						UpgradeState.FAILED,
+						"The installation of the same-version package " +
+							transaction.getToVersion() +
+							" could not be verified (" +
+							RunnerMarkers.readResult(stagingDirectory).orElse("no runner result marker") +
+							")",
+						current
+					);
+				}
+			} else if (VersionHelper.isSameVersion(current, transaction.getToVersion())) {
 				finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
 			} else {
 				finishReconciliation(
@@ -483,6 +501,7 @@ public class UpgradeManager {
 		}
 		transactionStore.archive(transaction);
 		deleteStagedFile(transaction);
+		RunnerMarkers.clear(stagingDirectory);
 		lock.releaseStale();
 		if (verdict == UpgradeState.SUCCEEDED) {
 			adoptInstalledIdentity(transaction);

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -26,6 +26,7 @@ import static org.metricshub.agent.helper.AgentConstants.AGENT_INFO_VERSION_ATTR
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HexFormat;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -158,7 +159,7 @@ public class UpgradeManager {
 	public UpgradeEvent getCurrentSnapshot() {
 		synchronized (snapshotLock) {
 			if (lastEvent == null) {
-				lastEvent = UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, currentVersion(), null, null);
+				lastEvent = UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, currentVersion(), null, null, null);
 			}
 			return lastEvent;
 		}
@@ -187,7 +188,16 @@ public class UpgradeManager {
 		);
 
 		if (state != null && state.isInstallPhase()) {
-			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.VERIFYING, current, transaction.getToVersion(), null));
+			publish(
+				UpgradeEvent.of(
+					PACKAGE_NAME,
+					UpgradeState.VERIFYING,
+					current,
+					transaction.getToVersion(),
+					hashOf(transaction),
+					null
+				)
+			);
 			if (VersionHelper.isSameVersion(current, transaction.getToVersion())) {
 				finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
 			} else {
@@ -203,7 +213,16 @@ public class UpgradeManager {
 				);
 			}
 		} else if (state == UpgradeState.SUCCEEDED || state == UpgradeState.FAILED) {
-			publish(UpgradeEvent.of(PACKAGE_NAME, state, current, transaction.getToVersion(), transaction.getError()));
+			publish(
+				UpgradeEvent.of(
+					PACKAGE_NAME,
+					state,
+					current,
+					transaction.getToVersion(),
+					hashOf(transaction),
+					transaction.getError()
+				)
+			);
 			transactionStore.archive(transaction);
 			lock.releaseStale();
 		} else {
@@ -246,6 +265,7 @@ public class UpgradeManager {
 					UpgradeState.FAILED,
 					current,
 					offer.version(),
+					offer.packageHash(),
 					"Automatic upgrades are disabled by configuration (upgrade.enabled)"
 				)
 			);
@@ -254,7 +274,7 @@ public class UpgradeManager {
 
 		if (VersionHelper.isSameVersion(current, offer.version())) {
 			log.info("The offered version {} is already installed.", offer.version());
-			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, current, offer.version(), null));
+			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, current, offer.version(), offer.packageHash(), null));
 			return;
 		}
 
@@ -274,6 +294,7 @@ public class UpgradeManager {
 				.toVersion(offer.version())
 				.downloadUrl(offer.downloadUrl())
 				.sha256(offer.sha256Hex())
+				.packageHash(offer.packageHashHex())
 				.deploymentKind(deploymentDetector.detect().name())
 				.state(UpgradeState.UPDATE_AVAILABLE)
 				.createdAt(System.currentTimeMillis())
@@ -290,6 +311,7 @@ public class UpgradeManager {
 						UpgradeState.DOWNLOADING,
 						current,
 						targetVersion,
+						offer.packageHash(),
 						null,
 						percent,
 						bytesPerSecond
@@ -352,7 +374,7 @@ public class UpgradeManager {
 		// Release the lock before publishing: the event is the observable signal that the
 		// attempt is fully terminated.
 		lock.release();
-		publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.FAILED, current, offer.version(), error));
+		publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.FAILED, current, offer.version(), offer.packageHash(), error));
 	}
 
 	/**
@@ -368,7 +390,16 @@ public class UpgradeManager {
 		transaction.setState(state);
 		transaction.setError(error);
 		transactionStore.write(transaction);
-		publish(UpgradeEvent.of(PACKAGE_NAME, state, transaction.getFromVersion(), transaction.getToVersion(), error));
+		publish(
+			UpgradeEvent.of(
+				PACKAGE_NAME,
+				state,
+				transaction.getFromVersion(),
+				transaction.getToVersion(),
+				hashOf(transaction),
+				error
+			)
+		);
 	}
 
 	/**
@@ -396,7 +427,7 @@ public class UpgradeManager {
 		transactionStore.archive(transaction);
 		deleteStagedFile(transaction);
 		lock.releaseStale();
-		publish(UpgradeEvent.of(PACKAGE_NAME, verdict, current, transaction.getToVersion(), error));
+		publish(UpgradeEvent.of(PACKAGE_NAME, verdict, current, transaction.getToVersion(), hashOf(transaction), error));
 		if (verdict == UpgradeState.SUCCEEDED) {
 			log.info("Upgrade to version {} succeeded.", transaction.getToVersion());
 		} else {
@@ -433,6 +464,24 @@ public class UpgradeManager {
 			statusListener.onUpgradeEvent(event);
 		} catch (Exception e) {
 			log.warn("The upgrade status listener failed: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Decodes the package identity hash persisted in a transaction.
+	 *
+	 * @param transaction the transaction
+	 * @return the hash bytes, or {@code null} when the transaction carries none
+	 */
+	private static byte[] hashOf(final UpgradeTransaction transaction) {
+		final String hex = transaction.getPackageHash();
+		if (hex == null || hex.isBlank()) {
+			return null;
+		}
+		try {
+			return HexFormat.of().parseHex(hex);
+		} catch (IllegalArgumentException e) {
+			return null;
 		}
 	}
 

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -28,9 +28,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HexFormat;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.metricshub.agent.config.UpgradeConfig;
@@ -64,6 +66,11 @@ public class UpgradeManager {
 	 * Name of the top-level package this agent manages.
 	 */
 	public static final String PACKAGE_NAME = "metricshub";
+
+	/**
+	 * Delay in seconds between two deferred reconciliation checks of a pending installation.
+	 */
+	static final long RECONCILE_RETRY_DELAY_SECONDS = 30;
 
 	private final Supplier<String> currentVersionSupplier;
 	private final Supplier<UpgradeConfig> configSupplier;
@@ -195,6 +202,7 @@ public class UpgradeManager {
 	public void reconcileOnStartup() {
 		final UpgradeTransaction transaction = transactionStore.read();
 		if (transaction == null) {
+			RunnerMarkers.clear(stagingDirectory);
 			lock.releaseStale();
 			return;
 		}
@@ -221,37 +229,7 @@ public class UpgradeManager {
 					null
 				)
 			);
-			if (VersionHelper.isSameVersion(transaction.getFromVersion(), transaction.getToVersion())) {
-				// Same-version hotfix: the running version is identical whether or not the
-				// installer ran, so the verdict relies on the runner's completion marker.
-				if (RunnerMarkers.installSucceeded(stagingDirectory)) {
-					finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
-				} else {
-					finishReconciliation(
-						transaction,
-						UpgradeState.FAILED,
-						"The installation of the same-version package " +
-							transaction.getToVersion() +
-							" could not be verified (" +
-							RunnerMarkers.readResult(stagingDirectory).orElse("no runner result marker") +
-							")",
-						current
-					);
-				}
-			} else if (VersionHelper.isSameVersion(current, transaction.getToVersion())) {
-				finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
-			} else {
-				finishReconciliation(
-					transaction,
-					UpgradeState.FAILED,
-					"The agent restarted with version " +
-						current +
-						" while version " +
-						transaction.getToVersion() +
-						" was expected",
-					current
-				);
-			}
+			resolveInstallPhase(transaction, current);
 		} else if (state == UpgradeState.SUCCEEDED || state == UpgradeState.FAILED) {
 			if (state == UpgradeState.SUCCEEDED) {
 				adoptInstalledIdentity(transaction);
@@ -277,6 +255,115 @@ public class UpgradeManager {
 				current
 			);
 		}
+	}
+
+	/**
+	 * Resolves a transaction interrupted during the installation phase.
+	 * <p>
+	 * A changed running version is definitive evidence. Otherwise the runner's completion marker
+	 * decides; while the marker is absent and the configured installation deadline
+	 * ({@code installStartedAt + installTimeoutSeconds}) has not elapsed, the runner may still be
+	 * working (the service manager can restart the agent early), so the transaction is kept
+	 * pending, reported as {@code Installing}, and re-checked periodically.
+	 * </p>
+	 *
+	 * @param transaction the pending install-phase transaction
+	 * @param current     the running agent version
+	 */
+	private void resolveInstallPhase(final UpgradeTransaction transaction, final String current) {
+		final boolean sameVersionHotfix = VersionHelper.isSameVersion(
+			transaction.getFromVersion(),
+			transaction.getToVersion()
+		);
+
+		if (!sameVersionHotfix && VersionHelper.isSameVersion(current, transaction.getToVersion())) {
+			finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
+			return;
+		}
+
+		if (RunnerMarkers.readResult(stagingDirectory).isPresent()) {
+			// The runner finished: its result decides (for same-version hotfixes the version can
+			// never decide; for version upgrades reaching this point the version did not change)
+			if (sameVersionHotfix && RunnerMarkers.installSucceeded(stagingDirectory)) {
+				finishReconciliation(transaction, UpgradeState.SUCCEEDED, null, current);
+			} else {
+				finishReconciliation(
+					transaction,
+					UpgradeState.FAILED,
+					"The installation of package " +
+						transaction.getToVersion() +
+						" did not complete successfully (" +
+						RunnerMarkers.readResult(stagingDirectory).orElse("no runner result marker") +
+						")",
+					current
+				);
+			}
+			return;
+		}
+
+		final long deadlineMs =
+			transaction.getInstallStartedAt() + TimeUnit.SECONDS.toMillis(transaction.getInstallTimeoutSeconds());
+		if (transaction.getInstallStartedAt() > 0 && System.currentTimeMillis() < deadlineMs) {
+			// The runner may still be working: keep the transaction (and the lock) and re-check
+			log.info(
+				"The upgrade to version {} is still within its installation deadline; the verdict is deferred.",
+				transaction.getToVersion()
+			);
+			publish(
+				UpgradeEvent.of(
+					PACKAGE_NAME,
+					UpgradeState.INSTALLING,
+					current,
+					installedHash(),
+					transaction.getToVersion(),
+					hashOf(transaction),
+					null
+				)
+			);
+			scheduleReconciliationRetry();
+			return;
+		}
+
+		finishReconciliation(
+			transaction,
+			UpgradeState.FAILED,
+			sameVersionHotfix
+				? "The installation of the same-version package " +
+					transaction.getToVersion() +
+					" could not be verified within the installation timeout"
+				: "The agent restarted with version " +
+					current +
+					" while version " +
+					transaction.getToVersion() +
+					" was expected",
+			current
+		);
+	}
+
+	/**
+	 * Schedules a deferred re-check of the pending install-phase transaction.
+	 */
+	private void scheduleReconciliationRetry() {
+		try {
+			CompletableFuture.runAsync(
+				this::retryPendingReconciliation,
+				CompletableFuture.delayedExecutor(RECONCILE_RETRY_DELAY_SECONDS, TimeUnit.SECONDS, worker)
+			);
+		} catch (RejectedExecutionException e) {
+			log.warn("The upgrade worker rejected the reconciliation retry: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Re-checks a still-pending install-phase transaction. No-op when the transaction was
+	 * resolved in the meantime.
+	 */
+	private void retryPendingReconciliation() {
+		final UpgradeTransaction transaction = transactionStore.read();
+		if (transaction == null || transaction.getState() == null || !transaction.getState().isInstallPhase()) {
+			return;
+		}
+		resolveInstallPhase(transaction, currentVersion());
 	}
 
 	/**
@@ -337,6 +424,9 @@ public class UpgradeManager {
 			log.warn("Ignoring the package offer for version {}: another upgrade is already in progress.", offer.version());
 			return;
 		}
+
+		// A marker left by a previous attempt must never bless this one
+		RunnerMarkers.clear(stagingDirectory);
 
 		UpgradeTransaction transaction = null;
 		try {

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeManager.java
@@ -76,6 +76,7 @@ public class UpgradeManager {
 	private final ExecutorService worker;
 
 	private volatile UpgradeStatusListener statusListener = event -> {};
+	private volatile String installedHashHex;
 
 	private final Object snapshotLock = new Object();
 	private UpgradeEvent lastEvent;
@@ -131,6 +132,18 @@ public class UpgradeManager {
 			thread.setDaemon(true);
 			return thread;
 		});
+		loadInstalledPackageIdentity();
+	}
+
+	/**
+	 * Loads the identity hash of the currently installed package, learned from a previously
+	 * completed OpAMP upgrade, when it still matches the running version.
+	 */
+	private void loadInstalledPackageIdentity() {
+		final UpgradeTransactionStore.InstalledPackageRecord record = transactionStore.readInstalledPackage();
+		if (record != null && VersionHelper.isSameVersion(record.version(), currentVersion())) {
+			installedHashHex = record.packageHash();
+		}
 	}
 
 	/**
@@ -159,7 +172,15 @@ public class UpgradeManager {
 	public UpgradeEvent getCurrentSnapshot() {
 		synchronized (snapshotLock) {
 			if (lastEvent == null) {
-				lastEvent = UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, currentVersion(), null, null, null);
+				lastEvent = UpgradeEvent.of(
+					PACKAGE_NAME,
+					UpgradeState.IDLE,
+					currentVersion(),
+					installedHash(),
+					null,
+					null,
+					null
+				);
 			}
 			return lastEvent;
 		}
@@ -193,6 +214,7 @@ public class UpgradeManager {
 					PACKAGE_NAME,
 					UpgradeState.VERIFYING,
 					current,
+					installedHash(),
 					transaction.getToVersion(),
 					hashOf(transaction),
 					null
@@ -213,11 +235,15 @@ public class UpgradeManager {
 				);
 			}
 		} else if (state == UpgradeState.SUCCEEDED || state == UpgradeState.FAILED) {
+			if (state == UpgradeState.SUCCEEDED) {
+				adoptInstalledIdentity(transaction);
+			}
 			publish(
 				UpgradeEvent.of(
 					PACKAGE_NAME,
 					state,
 					current,
+					installedHash(),
 					transaction.getToVersion(),
 					hashOf(transaction),
 					transaction.getError()
@@ -264,6 +290,7 @@ public class UpgradeManager {
 					PACKAGE_NAME,
 					UpgradeState.FAILED,
 					current,
+					installedHash(),
 					offer.version(),
 					offer.packageHash(),
 					"Automatic upgrades are disabled by configuration (upgrade.enabled)"
@@ -272,9 +299,27 @@ public class UpgradeManager {
 			return;
 		}
 
-		if (VersionHelper.isSameVersion(current, offer.version())) {
+		if (VersionHelper.isSameVersion(current, offer.version()) && !hasDifferentPackageIdentity(offer)) {
 			log.info("The offered version {} is already installed.", offer.version());
-			publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.IDLE, current, offer.version(), offer.packageHash(), null));
+			// The agent runs the offered version: adopt the offered identity hash so the fleet
+			// state converges even for packages that were not installed through OpAMP.
+			if (installedHashHex == null && offer.packageHash() != null && offer.packageHash().length > 0) {
+				installedHashHex = offer.packageHashHex();
+				transactionStore.writeInstalledPackage(
+					new UpgradeTransactionStore.InstalledPackageRecord(current, installedHashHex)
+				);
+			}
+			publish(
+				UpgradeEvent.of(
+					PACKAGE_NAME,
+					UpgradeState.IDLE,
+					current,
+					installedHash(),
+					offer.version(),
+					offer.packageHash(),
+					null
+				)
+			);
 			return;
 		}
 
@@ -310,6 +355,7 @@ public class UpgradeManager {
 						PACKAGE_NAME,
 						UpgradeState.DOWNLOADING,
 						current,
+						installedHash(),
 						targetVersion,
 						offer.packageHash(),
 						null,
@@ -374,7 +420,17 @@ public class UpgradeManager {
 		// Release the lock before publishing: the event is the observable signal that the
 		// attempt is fully terminated.
 		lock.release();
-		publish(UpgradeEvent.of(PACKAGE_NAME, UpgradeState.FAILED, current, offer.version(), offer.packageHash(), error));
+		publish(
+			UpgradeEvent.of(
+				PACKAGE_NAME,
+				UpgradeState.FAILED,
+				current,
+				installedHash(),
+				offer.version(),
+				offer.packageHash(),
+				error
+			)
+		);
 	}
 
 	/**
@@ -395,6 +451,7 @@ public class UpgradeManager {
 				PACKAGE_NAME,
 				state,
 				transaction.getFromVersion(),
+				installedHash(),
 				transaction.getToVersion(),
 				hashOf(transaction),
 				error
@@ -427,7 +484,20 @@ public class UpgradeManager {
 		transactionStore.archive(transaction);
 		deleteStagedFile(transaction);
 		lock.releaseStale();
-		publish(UpgradeEvent.of(PACKAGE_NAME, verdict, current, transaction.getToVersion(), hashOf(transaction), error));
+		if (verdict == UpgradeState.SUCCEEDED) {
+			adoptInstalledIdentity(transaction);
+		}
+		publish(
+			UpgradeEvent.of(
+				PACKAGE_NAME,
+				verdict,
+				current,
+				installedHash(),
+				transaction.getToVersion(),
+				hashOf(transaction),
+				error
+			)
+		);
 		if (verdict == UpgradeState.SUCCEEDED) {
 			log.info("Upgrade to version {} succeeded.", transaction.getToVersion());
 		} else {
@@ -464,6 +534,54 @@ public class UpgradeManager {
 			statusListener.onUpgradeEvent(event);
 		} catch (Exception e) {
 			log.warn("The upgrade status listener failed: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Indicates whether the offered package identity differs from the installed one. Per the
+	 * OpAMP specification, package identity is defined by the offered package hash: a differing
+	 * hash must be installed even when the version string is unchanged (same-version hotfix). An
+	 * offer without a hash, or an unknown installed identity, is treated as identical.
+	 *
+	 * @param offer the package offer
+	 * @return {@code true} when the offered identity is known to differ from the installed one
+	 */
+	private boolean hasDifferentPackageIdentity(final PackageOffer offer) {
+		if (offer.packageHash() == null || offer.packageHash().length == 0 || installedHashHex == null) {
+			return false;
+		}
+		return !installedHashHex.equalsIgnoreCase(offer.packageHashHex());
+	}
+
+	/**
+	 * Records the identity of a successfully installed package.
+	 *
+	 * @param transaction the succeeded transaction
+	 */
+	private void adoptInstalledIdentity(final UpgradeTransaction transaction) {
+		final String hash = transaction.getPackageHash();
+		if (hash != null && !hash.isBlank()) {
+			installedHashHex = hash;
+			transactionStore.writeInstalledPackage(
+				new UpgradeTransactionStore.InstalledPackageRecord(transaction.getToVersion(), hash)
+			);
+		}
+	}
+
+	/**
+	 * Decodes the identity hash of the currently installed package.
+	 *
+	 * @return the hash bytes, or {@code null} when unknown
+	 */
+	private byte[] installedHash() {
+		final String hex = installedHashHex;
+		if (hex == null || hex.isBlank()) {
+			return null;
+		}
+		try {
+			return HexFormat.of().parseHex(hex);
+		} catch (IllegalArgumentException e) {
+			return null;
 		}
 	}
 

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeState.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/UpgradeState.java
@@ -1,0 +1,94 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.Set;
+
+/**
+ * Fine-grained lifecycle of an upgrade attempt. The states map onto the coarser OpAMP
+ * {@code PackageStatusEnum} for fleet reporting, while the full state rides in the agent health
+ * status string.
+ */
+public enum UpgradeState {
+	/**
+	 * No upgrade in progress.
+	 */
+	IDLE,
+	/**
+	 * A package offer was accepted and the upgrade is starting.
+	 */
+	UPDATE_AVAILABLE,
+	/**
+	 * The package is being downloaded from the repository.
+	 */
+	DOWNLOADING,
+	/**
+	 * The downloaded package is being validated (checksum, size, type).
+	 */
+	VALIDATING,
+	/**
+	 * The package is staged and the detached installer is about to be launched.
+	 */
+	READY_TO_INSTALL,
+	/**
+	 * The detached installer has been launched.
+	 */
+	INSTALLING,
+	/**
+	 * The agent is about to be stopped by the installer.
+	 */
+	RESTARTING,
+	/**
+	 * The agent restarted and is verifying the running version against the target.
+	 */
+	VERIFYING,
+	/**
+	 * The upgrade completed and the agent runs the target version.
+	 */
+	SUCCEEDED,
+	/**
+	 * The upgrade failed.
+	 */
+	FAILED;
+
+	private static final Set<UpgradeState> TERMINAL_STATES = Set.of(IDLE, SUCCEEDED, FAILED);
+	private static final Set<UpgradeState> INSTALL_PHASE_STATES = Set.of(INSTALLING, RESTARTING, VERIFYING);
+
+	/**
+	 * Indicates whether this state ends an upgrade attempt (including the idle state).
+	 *
+	 * @return {@code true} for {@code IDLE}, {@code SUCCEEDED} and {@code FAILED}
+	 */
+	public boolean isTerminal() {
+		return TERMINAL_STATES.contains(this);
+	}
+
+	/**
+	 * Indicates whether this state belongs to the installation phase, during which the agent
+	 * process is expected to be stopped and restarted by the detached installer.
+	 *
+	 * @return {@code true} for {@code INSTALLING}, {@code RESTARTING} and {@code VERIFYING}
+	 */
+	public boolean isInstallPhase() {
+		return INSTALL_PHASE_STATES.contains(this);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/VersionHelper.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/VersionHelper.java
@@ -1,0 +1,97 @@
+package org.metricshub.agent.upgrade;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Version normalization and comparison for upgrade decisions. Package versions use the
+ * dot-separated numeric MetricsHub scheme (e.g. {@code 3.9.05}); running versions may carry a
+ * {@code -SNAPSHOT} or other qualifier that is ignored for comparison.
+ */
+public class VersionHelper {
+
+	private VersionHelper() {}
+
+	/**
+	 * Normalizes a version for comparison: trims and strips any qualifier introduced by a dash
+	 * (e.g. {@code 3.9.05-SNAPSHOT} becomes {@code 3.9.05}).
+	 *
+	 * @param version the raw version
+	 * @return the normalized version; never {@code null}
+	 */
+	public static String normalize(final String version) {
+		if (version == null) {
+			return "";
+		}
+		final String trimmed = version.trim();
+		final int dash = trimmed.indexOf('-');
+		return dash >= 0 ? trimmed.substring(0, dash) : trimmed;
+	}
+
+	/**
+	 * Indicates whether two versions are the same once normalized.
+	 *
+	 * @param left  the first version
+	 * @param right the second version
+	 * @return {@code true} when the normalized versions are equal
+	 */
+	public static boolean isSameVersion(final String left, final String right) {
+		return normalize(left).equals(normalize(right));
+	}
+
+	/**
+	 * Compares two normalized versions segment by segment. Numeric segments are compared as
+	 * numbers; non-numeric segments fall back to lexicographic comparison.
+	 *
+	 * @param left  the first version
+	 * @param right the second version
+	 * @return a negative value when {@code left} is older, zero when equal, positive when newer
+	 */
+	public static int compare(final String left, final String right) {
+		final String[] leftSegments = normalize(left).split("\\.");
+		final String[] rightSegments = normalize(right).split("\\.");
+		final int length = Math.max(leftSegments.length, rightSegments.length);
+		for (int i = 0; i < length; i++) {
+			final String leftSegment = i < leftSegments.length ? leftSegments[i] : "0";
+			final String rightSegment = i < rightSegments.length ? rightSegments[i] : "0";
+			final int result = compareSegments(leftSegment, rightSegment);
+			if (result != 0) {
+				return result;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Compares two version segments, numerically when both are numeric.
+	 *
+	 * @param left  the first segment
+	 * @param right the second segment
+	 * @return the comparison result
+	 */
+	private static int compareSegments(final String left, final String right) {
+		try {
+			return Long.compare(Long.parseLong(left), Long.parseLong(right));
+		} catch (NumberFormatException e) {
+			return left.compareTo(right);
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/PackageOffer.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/PackageOffer.java
@@ -31,6 +31,8 @@ import java.util.Map;
  * @param version     the offered version
  * @param downloadUrl the URL the package must be downloaded from
  * @param sha256      the expected SHA-256 of the package content, as raw bytes
+ * @param packageHash the offered package identity hash ({@code PackageAvailable.hash}), echoed
+ *                    back in the package statuses as required by the OpAMP specification
  * @param headers     headers to send with the download request; never {@code null}
  */
 public record PackageOffer(
@@ -38,6 +40,7 @@ public record PackageOffer(
 	String version,
 	String downloadUrl,
 	byte[] sha256,
+	byte[] packageHash,
 	Map<String, String> headers
 ) {
 	/**
@@ -47,5 +50,14 @@ public record PackageOffer(
 	 */
 	public String sha256Hex() {
 		return sha256 == null ? "" : HexFormat.of().formatHex(sha256);
+	}
+
+	/**
+	 * Returns the offered package identity hash as a lowercase hexadecimal string.
+	 *
+	 * @return the hexadecimal representation of the package hash
+	 */
+	public String packageHashHex() {
+		return packageHash == null ? "" : HexFormat.of().formatHex(packageHash);
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/PackageOffer.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/PackageOffer.java
@@ -1,0 +1,51 @@
+package org.metricshub.agent.upgrade.api;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.HexFormat;
+import java.util.Map;
+
+/**
+ * A software package offered to the agent, decoupled from the OpAMP protobuf types.
+ *
+ * @param packageName the offered package name (e.g. {@code metricshub})
+ * @param version     the offered version
+ * @param downloadUrl the URL the package must be downloaded from
+ * @param sha256      the expected SHA-256 of the package content, as raw bytes
+ * @param headers     headers to send with the download request; never {@code null}
+ */
+public record PackageOffer(
+	String packageName,
+	String version,
+	String downloadUrl,
+	byte[] sha256,
+	Map<String, String> headers
+) {
+	/**
+	 * Returns the expected SHA-256 as a lowercase hexadecimal string.
+	 *
+	 * @return the hexadecimal representation of the expected content hash
+	 */
+	public String sha256Hex() {
+		return sha256 == null ? "" : HexFormat.of().formatHex(sha256);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
@@ -30,6 +30,8 @@ import org.metricshub.agent.upgrade.UpgradeState;
  * @param packageName            the package being upgraded
  * @param state                  the new upgrade state
  * @param currentVersion         the version the agent currently runs
+ * @param currentHash            the identity hash of the currently installed package, when known
+ *                               (learned from a previous OpAMP-driven installation)
  * @param targetVersion          the offered version; {@code null} outside an upgrade attempt
  * @param targetHash             the offered package identity hash ({@code PackageAvailable.hash});
  *                               {@code null} outside an upgrade attempt
@@ -41,6 +43,7 @@ public record UpgradeEvent(
 	String packageName,
 	UpgradeState state,
 	String currentVersion,
+	byte[] currentHash,
 	String targetVersion,
 	byte[] targetHash,
 	String errorMessage,
@@ -53,6 +56,7 @@ public record UpgradeEvent(
 	 * @param packageName    the package being upgraded
 	 * @param state          the new upgrade state
 	 * @param currentVersion the version the agent currently runs
+	 * @param currentHash    the identity hash of the currently installed package, when known
 	 * @param targetVersion  the offered version
 	 * @param targetHash     the offered package identity hash
 	 * @param errorMessage   the failure cause when the state is {@code FAILED}
@@ -62,10 +66,21 @@ public record UpgradeEvent(
 		final String packageName,
 		final UpgradeState state,
 		final String currentVersion,
+		final byte[] currentHash,
 		final String targetVersion,
 		final byte[] targetHash,
 		final String errorMessage
 	) {
-		return new UpgradeEvent(packageName, state, currentVersion, targetVersion, targetHash, errorMessage, 0, 0);
+		return new UpgradeEvent(
+			packageName,
+			state,
+			currentVersion,
+			currentHash,
+			targetVersion,
+			targetHash,
+			errorMessage,
+			0,
+			0
+		);
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
@@ -31,6 +31,8 @@ import org.metricshub.agent.upgrade.UpgradeState;
  * @param state                  the new upgrade state
  * @param currentVersion         the version the agent currently runs
  * @param targetVersion          the offered version; {@code null} outside an upgrade attempt
+ * @param targetHash             the offered package identity hash ({@code PackageAvailable.hash});
+ *                               {@code null} outside an upgrade attempt
  * @param errorMessage           the failure cause when {@code state} is {@code FAILED}
  * @param downloadPercent        the download progress (0-100) during {@code DOWNLOADING}
  * @param downloadBytesPerSecond the download rate during {@code DOWNLOADING}
@@ -40,6 +42,7 @@ public record UpgradeEvent(
 	UpgradeState state,
 	String currentVersion,
 	String targetVersion,
+	byte[] targetHash,
 	String errorMessage,
 	double downloadPercent,
 	double downloadBytesPerSecond
@@ -51,6 +54,7 @@ public record UpgradeEvent(
 	 * @param state          the new upgrade state
 	 * @param currentVersion the version the agent currently runs
 	 * @param targetVersion  the offered version
+	 * @param targetHash     the offered package identity hash
 	 * @param errorMessage   the failure cause when the state is {@code FAILED}
 	 * @return the event
 	 */
@@ -59,8 +63,9 @@ public record UpgradeEvent(
 		final UpgradeState state,
 		final String currentVersion,
 		final String targetVersion,
+		final byte[] targetHash,
 		final String errorMessage
 	) {
-		return new UpgradeEvent(packageName, state, currentVersion, targetVersion, errorMessage, 0, 0);
+		return new UpgradeEvent(packageName, state, currentVersion, targetVersion, targetHash, errorMessage, 0, 0);
 	}
 }

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeEvent.java
@@ -1,0 +1,66 @@
+package org.metricshub.agent.upgrade.api;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import org.metricshub.agent.upgrade.UpgradeState;
+
+/**
+ * Snapshot of an upgrade lifecycle transition, published to the registered
+ * {@link UpgradeStatusListener}.
+ *
+ * @param packageName            the package being upgraded
+ * @param state                  the new upgrade state
+ * @param currentVersion         the version the agent currently runs
+ * @param targetVersion          the offered version; {@code null} outside an upgrade attempt
+ * @param errorMessage           the failure cause when {@code state} is {@code FAILED}
+ * @param downloadPercent        the download progress (0-100) during {@code DOWNLOADING}
+ * @param downloadBytesPerSecond the download rate during {@code DOWNLOADING}
+ */
+public record UpgradeEvent(
+	String packageName,
+	UpgradeState state,
+	String currentVersion,
+	String targetVersion,
+	String errorMessage,
+	double downloadPercent,
+	double downloadBytesPerSecond
+) {
+	/**
+	 * Creates an event without download progress.
+	 *
+	 * @param packageName    the package being upgraded
+	 * @param state          the new upgrade state
+	 * @param currentVersion the version the agent currently runs
+	 * @param targetVersion  the offered version
+	 * @param errorMessage   the failure cause when the state is {@code FAILED}
+	 * @return the event
+	 */
+	public static UpgradeEvent of(
+		final String packageName,
+		final UpgradeState state,
+		final String currentVersion,
+		final String targetVersion,
+		final String errorMessage
+	) {
+		return new UpgradeEvent(packageName, state, currentVersion, targetVersion, errorMessage, 0, 0);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeStatusListener.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/api/UpgradeStatusListener.java
@@ -1,0 +1,36 @@
+package org.metricshub.agent.upgrade.api;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Receives upgrade lifecycle transitions. Implemented by the OpAMP adapter to convert internal
+ * upgrade states into OpAMP package status reports.
+ */
+@FunctionalInterface
+public interface UpgradeStatusListener {
+	/**
+	 * Called on every upgrade state transition and on download progress updates.
+	 *
+	 * @param event the transition snapshot
+	 */
+	void onUpgradeEvent(UpgradeEvent event);
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/DownloadProgressListener.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/DownloadProgressListener.java
@@ -1,0 +1,37 @@
+package org.metricshub.agent.upgrade.download;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Receives download progress updates, forwarded to the OpAMP server as
+ * {@code PackageDownloadDetails}.
+ */
+@FunctionalInterface
+public interface DownloadProgressListener {
+	/**
+	 * Called at most once per second while a package downloads.
+	 *
+	 * @param percent        the completed percentage (0-100), or 0 when the total size is unknown
+	 * @param bytesPerSecond the smoothed download rate
+	 */
+	void onProgress(double percent, double bytesPerSecond);
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
@@ -1,0 +1,350 @@
+package org.metricshub.agent.upgrade.download;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Locale;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.UpgradeException;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+
+/**
+ * Downloads an offered package from the repository over HTTPS, computing its SHA-256 while
+ * streaming and enforcing the configured source and size restrictions. The file is written to a
+ * {@code .part} file and atomically renamed once the hash matches the offer.
+ */
+@Slf4j
+public class PackageDownloader {
+
+	private static final int BUFFER_SIZE = 64 * 1024;
+	private static final long PROGRESS_EMIT_INTERVAL_MS = 1000;
+	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+
+	/**
+	 * Downloads the offered package into the given directory, retrying up to the configured
+	 * number of attempts.
+	 *
+	 * @param offer            the package offer
+	 * @param config           the upgrade configuration (limits, allowlist, trust material)
+	 * @param targetDirectory  the directory receiving the staged package
+	 * @param progressListener the listener receiving download progress; never {@code null}
+	 * @return the path of the staged, hash-verified package file
+	 * @throws UpgradeException     when the download definitively fails
+	 * @throws InterruptedException when the downloading thread is interrupted
+	 */
+	public Path download(
+		final PackageOffer offer,
+		final UpgradeConfig config,
+		final Path targetDirectory,
+		final DownloadProgressListener progressListener
+	) throws UpgradeException, InterruptedException {
+		final URI uri = validateSource(offer, config);
+		final Path targetFile = targetDirectory.resolve(sanitizedFileName(uri, offer));
+
+		UpgradeException lastFailure = null;
+		final int attempts = Math.max(1, config.getDownloadRetries());
+		for (int attempt = 1; attempt <= attempts; attempt++) {
+			try {
+				downloadOnce(offer, config, uri, targetFile, progressListener);
+				return targetFile;
+			} catch (UpgradeException e) {
+				lastFailure = e;
+				log.warn("Package download attempt {}/{} failed: {}", attempt, attempts, e.getMessage());
+			}
+		}
+		throw lastFailure;
+	}
+
+	/**
+	 * Validates the download source: HTTPS only (plain HTTP is tolerated for loopback addresses,
+	 * for development and testing) and an optional host allowlist.
+	 *
+	 * @param offer  the package offer
+	 * @param config the upgrade configuration
+	 * @return the validated download URI
+	 * @throws UpgradeException when the source is not acceptable
+	 */
+	static URI validateSource(final PackageOffer offer, final UpgradeConfig config) throws UpgradeException {
+		final URI uri;
+		try {
+			uri = URI.create(offer.downloadUrl().trim());
+		} catch (Exception e) {
+			throw new UpgradeException("Invalid package download URL: " + offer.downloadUrl());
+		}
+		final String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+		final String host = uri.getHost() == null ? "" : uri.getHost();
+		if (!"https".equals(scheme) && !("http".equals(scheme) && isLoopback(host))) {
+			throw new UpgradeException("Package downloads require HTTPS: " + offer.downloadUrl());
+		}
+		if (!config.getHostAllowlist().isEmpty() && config.getHostAllowlist().stream().noneMatch(host::equalsIgnoreCase)) {
+			throw new UpgradeException("Package download host is not in the configured allowlist: " + host);
+		}
+		return uri;
+	}
+
+	/**
+	 * Indicates whether the given host is a loopback address.
+	 *
+	 * @param host the host name or address
+	 * @return {@code true} for loopback hosts
+	 */
+	private static boolean isLoopback(final String host) {
+		try {
+			return InetAddress.getByName(host).isLoopbackAddress();
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Builds a safe file name for the staged package from the URL path.
+	 *
+	 * @param uri   the download URI
+	 * @param offer the package offer
+	 * @return the sanitized file name
+	 */
+	static String sanitizedFileName(final URI uri, final PackageOffer offer) {
+		final String path = uri.getPath() == null ? "" : uri.getPath();
+		final int lastSlash = path.lastIndexOf('/');
+		String name = lastSlash >= 0 ? path.substring(lastSlash + 1) : path;
+		name = name.replaceAll("[^A-Za-z0-9._+-]", "_");
+		if (name.isBlank() || name.startsWith(".")) {
+			name = offer.packageName() + "-" + offer.version().replaceAll("[^A-Za-z0-9._+-]", "_");
+		}
+		return name;
+	}
+
+	/**
+	 * Performs one download attempt: streams the body through a SHA-256 digest into a
+	 * {@code .part} file, enforcing the size cap, then atomically renames it once the hash
+	 * matches.
+	 *
+	 * @param offer            the package offer
+	 * @param config           the upgrade configuration
+	 * @param uri              the validated download URI
+	 * @param targetFile       the final staged file path
+	 * @param progressListener the progress listener
+	 * @throws UpgradeException     when the attempt fails
+	 * @throws InterruptedException when the downloading thread is interrupted
+	 */
+	private void downloadOnce(
+		final PackageOffer offer,
+		final UpgradeConfig config,
+		final URI uri,
+		final Path targetFile,
+		final DownloadProgressListener progressListener
+	) throws UpgradeException, InterruptedException {
+		final Path partFile = targetFile.resolveSibling(targetFile.getFileName() + ".part");
+		try {
+			Files.createDirectories(targetFile.getParent());
+
+			final HttpClient httpClient = createHttpClient(config);
+			final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+				.uri(uri)
+				.timeout(Duration.ofSeconds(config.getDownloadTimeout()))
+				.GET();
+			offer.headers().forEach(requestBuilder::header);
+
+			final HttpResponse<InputStream> response = httpClient.send(
+				requestBuilder.build(),
+				HttpResponse.BodyHandlers.ofInputStream()
+			);
+			if (response.statusCode() != 200) {
+				throw new UpgradeException("The package repository answered with HTTP status " + response.statusCode());
+			}
+
+			final long contentLength = response.headers().firstValueAsLong("Content-Length").orElse(-1);
+			if (contentLength > config.getMaxPackageSizeBytes()) {
+				throw new UpgradeException(
+					"The package size (" +
+						contentLength +
+						" bytes) exceeds the configured maximum of " +
+						config.getMaxPackageSizeBytes() +
+						" bytes"
+				);
+			}
+
+			final byte[] actualSha256 = streamToFile(response.body(), partFile, contentLength, config, progressListener);
+
+			if (offer.sha256() == null || offer.sha256().length == 0) {
+				throw new UpgradeException("The package offer does not carry the mandatory SHA-256 content hash");
+			}
+			if (!MessageDigest.isEqual(offer.sha256(), actualSha256)) {
+				throw new UpgradeException("The downloaded package SHA-256 does not match the offered content hash");
+			}
+
+			try {
+				Files.move(partFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			} catch (AtomicMoveNotSupportedException e) {
+				Files.move(partFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} catch (IOException e) {
+			throw new UpgradeException("Package download failed: " + e.getMessage(), e);
+		} finally {
+			try {
+				Files.deleteIfExists(partFile);
+			} catch (IOException cleanupError) {
+				log.debug("Cannot delete the partial download {}: {}", partFile, cleanupError.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * Streams the response body into the given file, updating the digest, enforcing the size cap
+	 * and emitting throttled progress updates.
+	 *
+	 * @param body             the response body stream
+	 * @param partFile         the partial download file
+	 * @param contentLength    the announced content length, or -1 when unknown
+	 * @param config           the upgrade configuration
+	 * @param progressListener the progress listener
+	 * @return the SHA-256 of the streamed content
+	 * @throws IOException      on I/O failure
+	 * @throws UpgradeException when the size cap is exceeded
+	 */
+	private static byte[] streamToFile(
+		final InputStream body,
+		final Path partFile,
+		final long contentLength,
+		final UpgradeConfig config,
+		final DownloadProgressListener progressListener
+	) throws IOException, UpgradeException {
+		final MessageDigest digest = newSha256Digest();
+		long totalBytes = 0;
+		long lastEmitMs = System.currentTimeMillis();
+		long lastEmitBytes = 0;
+		double smoothedRate = 0;
+
+		try (InputStream input = body; OutputStream output = Files.newOutputStream(partFile)) {
+			final byte[] buffer = new byte[BUFFER_SIZE];
+			int read;
+			while ((read = input.read(buffer)) >= 0) {
+				totalBytes += read;
+				if (totalBytes > config.getMaxPackageSizeBytes()) {
+					throw new UpgradeException(
+						"The package exceeds the configured maximum size of " + config.getMaxPackageSizeBytes() + " bytes"
+					);
+				}
+				digest.update(buffer, 0, read);
+				output.write(buffer, 0, read);
+
+				final long nowMs = System.currentTimeMillis();
+				if (nowMs - lastEmitMs >= PROGRESS_EMIT_INTERVAL_MS) {
+					final double instantRate = ((totalBytes - lastEmitBytes) * 1000.0) / (nowMs - lastEmitMs);
+					smoothedRate = smoothedRate == 0 ? instantRate : 0.7 * smoothedRate + 0.3 * instantRate;
+					final double percent = contentLength > 0 ? (totalBytes * 100.0) / contentLength : 0;
+					progressListener.onProgress(percent, smoothedRate);
+					lastEmitMs = nowMs;
+					lastEmitBytes = totalBytes;
+				}
+			}
+		}
+		if (totalBytes == 0) {
+			throw new UpgradeException("The downloaded package is empty");
+		}
+		progressListener.onProgress(100, smoothedRate);
+		return digest.digest();
+	}
+
+	/**
+	 * Creates the SHA-256 digest.
+	 *
+	 * @return the digest instance
+	 */
+	private static MessageDigest newSha256Digest() {
+		try {
+			return MessageDigest.getInstance("SHA-256");
+		} catch (Exception e) {
+			throw new IllegalStateException("SHA-256 is not available", e);
+		}
+	}
+
+	/**
+	 * Creates the HTTP client used for the download, trusting the configured PEM certificate when
+	 * one is provided.
+	 *
+	 * @param config the upgrade configuration
+	 * @return the HTTP client
+	 * @throws UpgradeException when the trust material cannot be loaded
+	 */
+	private static HttpClient createHttpClient(final UpgradeConfig config) throws UpgradeException {
+		try {
+			final HttpClient.Builder builder = HttpClient.newBuilder()
+				.connectTimeout(CONNECT_TIMEOUT)
+				.followRedirects(HttpClient.Redirect.NORMAL);
+			final String certificateFile = config.getTrustedCertificateFile();
+			if (certificateFile != null && !certificateFile.isBlank()) {
+				builder.sslContext(createSslContext(certificateFile));
+			}
+			return builder.build();
+		} catch (Exception e) {
+			throw new UpgradeException("Failed to initialize the package download HTTP client: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Loads a custom trusted certificate (PEM) into an {@link SSLContext}.
+	 *
+	 * @param certificateFile the path to the PEM file
+	 * @return the SSL context trusting the given certificate
+	 * @throws Exception when the certificate cannot be loaded
+	 */
+	private static SSLContext createSslContext(final String certificateFile) throws Exception {
+		final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+		try (FileInputStream certificateInputStream = new FileInputStream(certificateFile)) {
+			final X509Certificate caCertificate = (X509Certificate) certificateFactory.generateCertificate(
+				certificateInputStream
+			);
+			final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+			keyStore.load(null, null);
+			keyStore.setCertificateEntry("upgrade_cert", caCertificate);
+			final TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+				TrustManagerFactory.getDefaultAlgorithm()
+			);
+			trustManagerFactory.init(keyStore);
+			final SSLContext sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, trustManagerFactory.getTrustManagers(), new SecureRandom());
+			return sslContext;
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
@@ -137,6 +137,18 @@ public class PackageDownloader {
 	}
 
 	/**
+	 * Returns the time remaining before the given absolute deadline, with a one-millisecond
+	 * floor so timeout-based APIs receive a positive value and expire immediately once the
+	 * deadline has passed.
+	 *
+	 * @param deadlineMs the absolute deadline, epoch milliseconds
+	 * @return the remaining duration in milliseconds, at least 1
+	 */
+	private static long remainingMillis(final long deadlineMs) {
+		return Math.max(1, deadlineMs - System.currentTimeMillis());
+	}
+
+	/**
 	 * Closes a stream best-effort, used by the download deadline watchdog.
 	 *
 	 * @param stream the stream to close
@@ -206,8 +218,10 @@ public class PackageDownloader {
 		try {
 			Files.createDirectories(targetFile.getParent());
 
+			// One absolute deadline bounds the whole attempt: redirect hops, headers and body
+			final long deadlineMs = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(config.getDownloadTimeout());
 			final HttpClient httpClient = createHttpClient(config);
-			final HttpResponse<InputStream> response = sendFollowingRedirects(httpClient, offer, config, uri);
+			final HttpResponse<InputStream> response = sendFollowingRedirects(httpClient, offer, config, uri, deadlineMs);
 			if (response.statusCode() != 200) {
 				throw new UpgradeException("The package repository answered with HTTP status " + response.statusCode());
 			}
@@ -224,13 +238,13 @@ public class PackageDownloader {
 			}
 
 			// The request timeout only bounds the exchange up to the response headers: a watchdog
-			// closes the body stream at the download deadline so a repository stalling mid-body
-			// cannot block the upgrade worker forever.
+			// closes the body stream at the remaining attempt deadline so a repository stalling
+			// mid-body cannot block the upgrade worker forever.
 			final InputStream body = response.body();
 			final ScheduledFuture<?> watchdog = BODY_WATCHDOG.schedule(
 				() -> closeQuietly(body),
-				config.getDownloadTimeout(),
-				TimeUnit.SECONDS
+				remainingMillis(deadlineMs),
+				TimeUnit.MILLISECONDS
 			);
 			final byte[] actualSha256;
 			try {
@@ -272,6 +286,7 @@ public class PackageDownloader {
 	 * @param offer      the package offer
 	 * @param config     the upgrade configuration
 	 * @param initialUri the validated initial download URI
+	 * @param deadlineMs the absolute deadline (epoch milliseconds) of the whole download attempt
 	 * @return the final, non-redirect response
 	 * @throws UpgradeException     when a redirect hop is not acceptable or too many hops occur
 	 * @throws IOException          on I/O failure
@@ -281,14 +296,15 @@ public class PackageDownloader {
 		final HttpClient httpClient,
 		final PackageOffer offer,
 		final UpgradeConfig config,
-		final URI initialUri
+		final URI initialUri,
+		final long deadlineMs
 	) throws UpgradeException, IOException, InterruptedException {
 		final String offeredHost = initialUri.getHost();
 		URI currentUri = initialUri;
 		for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
 			final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
 				.uri(currentUri)
-				.timeout(Duration.ofSeconds(config.getDownloadTimeout()))
+				.timeout(Duration.ofMillis(remainingMillis(deadlineMs)))
 				.GET();
 			if (currentUri.getHost() != null && currentUri.getHost().equalsIgnoreCase(offeredHost)) {
 				offer.headers().forEach(requestBuilder::header);

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
@@ -59,6 +59,7 @@ public class PackageDownloader {
 	private static final int BUFFER_SIZE = 64 * 1024;
 	private static final long PROGRESS_EMIT_INTERVAL_MS = 1000;
 	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
+	private static final int MAX_REDIRECTS = 5;
 
 	/**
 	 * Downloads the offered package into the given directory, retrying up to the configured
@@ -179,16 +180,7 @@ public class PackageDownloader {
 			Files.createDirectories(targetFile.getParent());
 
 			final HttpClient httpClient = createHttpClient(config);
-			final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-				.uri(uri)
-				.timeout(Duration.ofSeconds(config.getDownloadTimeout()))
-				.GET();
-			offer.headers().forEach(requestBuilder::header);
-
-			final HttpResponse<InputStream> response = httpClient.send(
-				requestBuilder.build(),
-				HttpResponse.BodyHandlers.ofInputStream()
-			);
+			final HttpResponse<InputStream> response = sendFollowingRedirects(httpClient, offer, config, uri);
 			if (response.statusCode() != 200) {
 				throw new UpgradeException("The package repository answered with HTTP status " + response.statusCode());
 			}
@@ -227,6 +219,91 @@ public class PackageDownloader {
 				log.debug("Cannot delete the partial download {}: {}", partFile, cleanupError.getMessage());
 			}
 		}
+	}
+
+	/**
+	 * Sends the download request, following redirects manually so every hop is re-validated
+	 * against the HTTPS requirement and the configured host allowlist (automatic redirects would
+	 * allow an approved host to bounce the client to an arbitrary destination). The offer headers
+	 * (e.g. repository credentials) are only sent to the originally offered host.
+	 *
+	 * @param httpClient the HTTP client (configured with {@code Redirect.NEVER})
+	 * @param offer      the package offer
+	 * @param config     the upgrade configuration
+	 * @param initialUri the validated initial download URI
+	 * @return the final, non-redirect response
+	 * @throws UpgradeException     when a redirect hop is not acceptable or too many hops occur
+	 * @throws IOException          on I/O failure
+	 * @throws InterruptedException when the downloading thread is interrupted
+	 */
+	private static HttpResponse<InputStream> sendFollowingRedirects(
+		final HttpClient httpClient,
+		final PackageOffer offer,
+		final UpgradeConfig config,
+		final URI initialUri
+	) throws UpgradeException, IOException, InterruptedException {
+		final String offeredHost = initialUri.getHost();
+		URI currentUri = initialUri;
+		for (int hop = 0; hop <= MAX_REDIRECTS; hop++) {
+			final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+				.uri(currentUri)
+				.timeout(Duration.ofSeconds(config.getDownloadTimeout()))
+				.GET();
+			if (currentUri.getHost() != null && currentUri.getHost().equalsIgnoreCase(offeredHost)) {
+				offer.headers().forEach(requestBuilder::header);
+			}
+
+			final HttpResponse<InputStream> response = httpClient.send(
+				requestBuilder.build(),
+				HttpResponse.BodyHandlers.ofInputStream()
+			);
+			if (!isRedirect(response.statusCode())) {
+				return response;
+			}
+
+			try (InputStream discarded = response.body()) {
+				// Drop the redirect body
+			}
+			final String location = response
+				.headers()
+				.firstValue("Location")
+				.orElseThrow(() ->
+					new UpgradeException("The package repository answered a redirect without a Location header")
+				);
+			currentUri = validateRedirectTarget(currentUri.resolve(location), config);
+			log.debug("Package download redirected to {}.", currentUri);
+		}
+		throw new UpgradeException("The package download exceeded " + MAX_REDIRECTS + " redirects");
+	}
+
+	/**
+	 * Indicates whether the given HTTP status code is a redirect.
+	 *
+	 * @param statusCode the HTTP status code
+	 * @return {@code true} for 301, 302, 303, 307 and 308
+	 */
+	private static boolean isRedirect(final int statusCode) {
+		return statusCode == 301 || statusCode == 302 || statusCode == 303 || statusCode == 307 || statusCode == 308;
+	}
+
+	/**
+	 * Validates a redirect target against the same restrictions as the initial download source.
+	 *
+	 * @param target the redirect target URI
+	 * @param config the upgrade configuration
+	 * @return the validated target
+	 * @throws UpgradeException when the target is not acceptable
+	 */
+	private static URI validateRedirectTarget(final URI target, final UpgradeConfig config) throws UpgradeException {
+		final String scheme = target.getScheme() == null ? "" : target.getScheme().toLowerCase(Locale.ROOT);
+		final String host = target.getHost() == null ? "" : target.getHost();
+		if (!"https".equals(scheme) && !("http".equals(scheme) && isLoopback(host))) {
+			throw new UpgradeException("The package download was redirected to a non-HTTPS location: " + target);
+		}
+		if (!config.getHostAllowlist().isEmpty() && config.getHostAllowlist().stream().noneMatch(host::equalsIgnoreCase)) {
+			throw new UpgradeException("The package download was redirected to a host outside the allowlist: " + host);
+		}
+		return target;
 	}
 
 	/**
@@ -309,9 +386,11 @@ public class PackageDownloader {
 	 */
 	private static HttpClient createHttpClient(final UpgradeConfig config) throws UpgradeException {
 		try {
+			// Redirects are followed manually so every hop is re-validated against the HTTPS
+			// requirement and the host allowlist
 			final HttpClient.Builder builder = HttpClient.newBuilder()
 				.connectTimeout(CONNECT_TIMEOUT)
-				.followRedirects(HttpClient.Redirect.NORMAL);
+				.followRedirects(HttpClient.Redirect.NEVER);
 			final String certificateFile = config.getTrustedCertificateFile();
 			if (certificateFile != null && !certificateFile.isBlank()) {
 				builder.sslContext(createSslContext(certificateFile));

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/download/PackageDownloader.java
@@ -41,6 +41,10 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Locale;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -60,6 +64,15 @@ public class PackageDownloader {
 	private static final long PROGRESS_EMIT_INTERVAL_MS = 1000;
 	private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(30);
 	private static final int MAX_REDIRECTS = 5;
+
+	/**
+	 * Watchdog closing body streams whose download exceeded the configured deadline.
+	 */
+	private static final ScheduledExecutorService BODY_WATCHDOG = Executors.newSingleThreadScheduledExecutor(runnable -> {
+		final Thread thread = new Thread(runnable, "metricshub-upgrade-download-watchdog");
+		thread.setDaemon(true);
+		return thread;
+	});
 
 	/**
 	 * Downloads the offered package into the given directory, retrying up to the configured
@@ -121,6 +134,20 @@ public class PackageDownloader {
 			throw new UpgradeException("Package download host is not in the configured allowlist: " + host);
 		}
 		return uri;
+	}
+
+	/**
+	 * Closes a stream best-effort, used by the download deadline watchdog.
+	 *
+	 * @param stream the stream to close
+	 */
+	private static void closeQuietly(final InputStream stream) {
+		try {
+			log.warn("The package download exceeded the configured timeout; aborting the transfer.");
+			stream.close();
+		} catch (IOException e) {
+			log.debug("Cannot close the timed-out download stream: {}", e.getMessage());
+		}
 	}
 
 	/**
@@ -196,7 +223,21 @@ public class PackageDownloader {
 				);
 			}
 
-			final byte[] actualSha256 = streamToFile(response.body(), partFile, contentLength, config, progressListener);
+			// The request timeout only bounds the exchange up to the response headers: a watchdog
+			// closes the body stream at the download deadline so a repository stalling mid-body
+			// cannot block the upgrade worker forever.
+			final InputStream body = response.body();
+			final ScheduledFuture<?> watchdog = BODY_WATCHDOG.schedule(
+				() -> closeQuietly(body),
+				config.getDownloadTimeout(),
+				TimeUnit.SECONDS
+			);
+			final byte[] actualSha256;
+			try {
+				actualSha256 = streamToFile(body, partFile, contentLength, config, progressListener);
+			} finally {
+				watchdog.cancel(false);
+			}
 
 			if (offer.sha256() == null || offer.sha256().length == 0) {
 				throw new UpgradeException("The package offer does not carry the mandatory SHA-256 content hash");
@@ -261,7 +302,7 @@ public class PackageDownloader {
 				return response;
 			}
 
-			try (InputStream discarded = response.body()) {
+			try (var _ = response.body()) {
 				// Drop the redirect body
 			}
 			final String location = response

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
@@ -1,0 +1,165 @@
+package org.metricshub.agent.upgrade.opamp;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.agent.upgrade.UpgradeManager;
+import org.metricshub.agent.upgrade.UpgradeState;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.api.UpgradeEvent;
+import org.metricshub.opamp.client.packages.OpampPackagesHandler;
+import org.metricshub.opamp.client.packages.PackageDownloadContext;
+import org.metricshub.opamp.client.packages.PackageStatusSink;
+import org.metricshub.opamp.proto.DownloadableFile;
+import org.metricshub.opamp.proto.Header;
+import org.metricshub.opamp.proto.PackageAvailable;
+import org.metricshub.opamp.proto.PackageDownloadDetails;
+import org.metricshub.opamp.proto.PackageStatus;
+import org.metricshub.opamp.proto.PackageStatusEnum;
+import org.metricshub.opamp.proto.PackageStatuses;
+import org.metricshub.opamp.proto.PackagesAvailable;
+
+/**
+ * Bridges the OpAMP client and the {@link UpgradeManager}: translates {@code PackagesAvailable}
+ * offers into {@link PackageOffer}s and converts upgrade lifecycle events back into OpAMP package
+ * status reports.
+ */
+@Slf4j
+public class OpampUpgradeAdapter implements OpampPackagesHandler {
+
+	private final UpgradeManager upgradeManager;
+	private volatile PackageStatusSink statusSink;
+
+	/**
+	 * Creates the adapter and registers it as the upgrade status listener.
+	 *
+	 * @param upgradeManager the upgrade manager
+	 */
+	public OpampUpgradeAdapter(final UpgradeManager upgradeManager) {
+		this.upgradeManager = upgradeManager;
+		upgradeManager.setStatusListener(this::forwardEvent);
+	}
+
+	@Override
+	public void onPackagesAvailable(
+		final PackagesAvailable packagesAvailable,
+		final PackageStatusSink sink,
+		final PackageDownloadContext downloadContext
+	) {
+		this.statusSink = sink;
+		final PackageAvailable offered = packagesAvailable.getPackagesOrDefault(UpgradeManager.PACKAGE_NAME, null);
+		if (offered == null) {
+			log.warn(
+				"The OpAMP package offer does not contain the {} package; the offer is ignored.",
+				UpgradeManager.PACKAGE_NAME
+			);
+			return;
+		}
+		final DownloadableFile file = offered.getFile();
+		final Map<String, String> headers = new HashMap<>();
+		for (final Header header : file.getHeaders().getHeadersList()) {
+			headers.put(header.getKey(), header.getValue());
+		}
+		upgradeManager.onPackageOffer(
+			new PackageOffer(
+				UpgradeManager.PACKAGE_NAME,
+				offered.getVersion(),
+				file.getDownloadUrl(),
+				file.getContentHash().toByteArray(),
+				headers
+			)
+		);
+	}
+
+	@Override
+	public PackageStatuses currentPackageStatuses() {
+		return PackageStatuses.newBuilder()
+			.putPackages(UpgradeManager.PACKAGE_NAME, toPackageStatus(upgradeManager.getCurrentSnapshot()))
+			.build();
+	}
+
+	/**
+	 * Forwards an upgrade event to the OpAMP status sink: download progress rides on the
+	 * dedicated progress channel, other transitions replace the package status.
+	 *
+	 * @param event the upgrade event
+	 */
+	private void forwardEvent(final UpgradeEvent event) {
+		final PackageStatusSink sink = statusSink;
+		if (sink == null) {
+			return;
+		}
+		if (
+			event.state() == UpgradeState.DOWNLOADING && (event.downloadPercent() > 0 || event.downloadBytesPerSecond() > 0)
+		) {
+			sink.reportDownloadProgress(
+				UpgradeManager.PACKAGE_NAME,
+				PackageDownloadDetails.newBuilder()
+					.setDownloadPercent(event.downloadPercent())
+					.setDownloadBytesPerSecond(event.downloadBytesPerSecond())
+					.build()
+			);
+			return;
+		}
+		sink.report(toPackageStatus(event));
+	}
+
+	/**
+	 * Converts an upgrade event into an OpAMP package status.
+	 *
+	 * @param event the upgrade event
+	 * @return the corresponding package status
+	 */
+	static PackageStatus toPackageStatus(final UpgradeEvent event) {
+		final PackageStatus.Builder builder = PackageStatus.newBuilder()
+			.setName(UpgradeManager.PACKAGE_NAME)
+			.setStatus(toPackageStatusEnum(event.state()));
+		if (event.currentVersion() != null && !event.currentVersion().isBlank()) {
+			builder.setAgentHasVersion(event.currentVersion());
+		}
+		if (event.targetVersion() != null && !event.targetVersion().isBlank()) {
+			builder.setServerOfferedVersion(event.targetVersion());
+		}
+		if (event.errorMessage() != null && !event.errorMessage().isBlank()) {
+			builder.setErrorMessage(event.errorMessage());
+		}
+		return builder.build();
+	}
+
+	/**
+	 * Maps the fine-grained upgrade state onto the OpAMP package status enumeration.
+	 *
+	 * @param state the upgrade state
+	 * @return the OpAMP package status
+	 */
+	static PackageStatusEnum toPackageStatusEnum(final UpgradeState state) {
+		return switch (state) {
+			case IDLE, SUCCEEDED -> PackageStatusEnum.PackageStatusEnum_Installed;
+			case UPDATE_AVAILABLE, READY_TO_INSTALL -> PackageStatusEnum.PackageStatusEnum_InstallPending;
+			case DOWNLOADING, VALIDATING -> PackageStatusEnum.PackageStatusEnum_Downloading;
+			case INSTALLING, RESTARTING, VERIFYING -> PackageStatusEnum.PackageStatusEnum_Installing;
+			case FAILED -> PackageStatusEnum.PackageStatusEnum_InstallFailed;
+		};
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
@@ -79,7 +79,7 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 	 * upgrade transition occurring during the handoff could otherwise be overwritten by that
 	 * older snapshot.
 	 */
-	public void republishSnapshot() {
+	public synchronized void republishSnapshot() {
 		final PackageStatusSink sink = statusSink;
 		if (sink != null) {
 			sink.report(toPackageStatus(upgradeManager.getCurrentSnapshot()));
@@ -131,7 +131,7 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 	 *
 	 * @param event the upgrade event
 	 */
-	private void forwardEvent(final UpgradeEvent event) {
+	private synchronized void forwardEvent(final UpgradeEvent event) {
 		final PackageStatusSink sink = statusSink;
 		if (sink == null) {
 			return;

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
@@ -21,6 +21,7 @@ package org.metricshub.agent.upgrade.opamp;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import com.google.protobuf.ByteString;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +62,17 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 		upgradeManager.setStatusListener(this::forwardEvent);
 	}
 
+	/**
+	 * Binds the sink of the currently active OpAMP client. Called whenever the OpAMP client is
+	 * (re)created, so upgrade transitions occurring between a client rebuild and the next package
+	 * offer are still delivered to the live client.
+	 *
+	 * @param sink the status sink of the active client
+	 */
+	public void bindSink(final PackageStatusSink sink) {
+		this.statusSink = sink;
+	}
+
 	@Override
 	public void onPackagesAvailable(
 		final PackagesAvailable packagesAvailable,
@@ -87,6 +99,7 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 				offered.getVersion(),
 				file.getDownloadUrl(),
 				file.getContentHash().toByteArray(),
+				offered.getHash().toByteArray(),
 				headers
 			)
 		);
@@ -140,6 +153,16 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 		}
 		if (event.targetVersion() != null && !event.targetVersion().isBlank()) {
 			builder.setServerOfferedVersion(event.targetVersion());
+		}
+		final byte[] targetHash = event.targetHash();
+		if (targetHash != null && targetHash.length > 0) {
+			// The offered package identity hash is required by the OpAMP specification for
+			// statuses of an offer-initiated installation; once installed, the agent has that
+			// same package.
+			builder.setServerOfferedHash(ByteString.copyFrom(targetHash));
+			if (event.state() == UpgradeState.SUCCEEDED) {
+				builder.setAgentHasHash(ByteString.copyFrom(targetHash));
+			}
 		}
 		if (event.errorMessage() != null && !event.errorMessage().isBlank()) {
 			builder.setErrorMessage(event.errorMessage());

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapter.java
@@ -73,6 +73,19 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 		this.statusSink = sink;
 	}
 
+	/**
+	 * Re-reports the latest upgrade snapshot through the bound sink. Called after a new OpAMP
+	 * client has started: the client seeds its status from a snapshot taken before startup, so an
+	 * upgrade transition occurring during the handoff could otherwise be overwritten by that
+	 * older snapshot.
+	 */
+	public void republishSnapshot() {
+		final PackageStatusSink sink = statusSink;
+		if (sink != null) {
+			sink.report(toPackageStatus(upgradeManager.getCurrentSnapshot()));
+		}
+	}
+
 	@Override
 	public void onPackagesAvailable(
 		final PackagesAvailable packagesAvailable,
@@ -150,6 +163,12 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 			.setStatus(toPackageStatusEnum(event.state()));
 		if (event.currentVersion() != null && !event.currentVersion().isBlank()) {
 			builder.setAgentHasVersion(event.currentVersion());
+			// The identity hash of the installed package accompanies agent_has_version whenever
+			// the agent knows it (learned from a previous OpAMP-driven installation)
+			final byte[] currentHash = event.currentHash();
+			if (currentHash != null && currentHash.length > 0) {
+				builder.setAgentHasHash(ByteString.copyFrom(currentHash));
+			}
 		}
 		if (event.targetVersion() != null && !event.targetVersion().isBlank()) {
 			builder.setServerOfferedVersion(event.targetVersion());
@@ -157,12 +176,8 @@ public class OpampUpgradeAdapter implements OpampPackagesHandler {
 		final byte[] targetHash = event.targetHash();
 		if (targetHash != null && targetHash.length > 0) {
 			// The offered package identity hash is required by the OpAMP specification for
-			// statuses of an offer-initiated installation; once installed, the agent has that
-			// same package.
+			// statuses of an offer-initiated installation
 			builder.setServerOfferedHash(ByteString.copyFrom(targetHash));
-			if (event.state() == UpgradeState.SUCCEEDED) {
-				builder.setAgentHasHash(ByteString.copyFrom(targetHash));
-			}
 		}
 		if (event.errorMessage() != null && !event.errorMessage().isBlank()) {
 			builder.setErrorMessage(event.errorMessage());

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/DeploymentDetector.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/DeploymentDetector.java
@@ -1,0 +1,149 @@
+package org.metricshub.agent.upgrade.runner;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.metricshub.engine.common.helpers.LocalOsHandler;
+
+/**
+ * Detects how MetricsHub was deployed on this host: Debian/RPM package, Windows MSI, extracted
+ * archive or container image. The result drives whether the {@code AcceptsPackages} OpAMP
+ * capability is advertised. Detection runs once and is cached.
+ */
+@Slf4j
+public class DeploymentDetector {
+
+	/**
+	 * Environment variable stamped in the official MetricsHub container image.
+	 */
+	static final String DEPLOYMENT_ENVIRONMENT_VARIABLE = "METRICSHUB_DEPLOYMENT";
+
+	/**
+	 * Name of the dpkg/rpm package owning the MetricsHub installation.
+	 */
+	static final String LINUX_PACKAGE_NAME = "metricshub";
+
+	/**
+	 * Windows service registry key of the MetricsHub Community service.
+	 */
+	static final String WINDOWS_SERVICE_REGISTRY_KEY = "HKLM\\SYSTEM\\CurrentControlSet\\Services\\MetricsHub Community";
+
+	/**
+	 * Runs a probe command and reports whether it succeeded, so tests can substitute a fake.
+	 */
+	@FunctionalInterface
+	public interface ProcessProbe {
+		/**
+		 * Runs the given command and waits for its completion.
+		 *
+		 * @param command the command and its arguments
+		 * @return {@code true} when the command completed with exit code 0
+		 */
+		boolean succeeds(String... command);
+	}
+
+	private final ProcessProbe probe;
+	private volatile DeploymentKind detected;
+
+	/**
+	 * Creates a detector using real process probes.
+	 */
+	public DeploymentDetector() {
+		this(DeploymentDetector::runProbe);
+	}
+
+	/**
+	 * Creates a detector with a caller-provided probe (used by tests).
+	 *
+	 * @param probe the process probe
+	 */
+	public DeploymentDetector(final ProcessProbe probe) {
+		this.probe = probe;
+	}
+
+	/**
+	 * Detects the deployment kind, caching the result.
+	 *
+	 * @return the detected deployment kind
+	 */
+	public DeploymentKind detect() {
+		DeploymentKind result = detected;
+		if (result == null) {
+			result = doDetect();
+			detected = result;
+			log.info("Detected MetricsHub deployment kind: {}.", result);
+		}
+		return result;
+	}
+
+	/**
+	 * Performs the actual detection.
+	 *
+	 * @return the detected deployment kind
+	 */
+	private DeploymentKind doDetect() {
+		if (
+			"docker".equalsIgnoreCase(System.getenv(DEPLOYMENT_ENVIRONMENT_VARIABLE)) || Files.exists(Path.of("/.dockerenv"))
+		) {
+			return DeploymentKind.DOCKER;
+		}
+		if (LocalOsHandler.isWindows()) {
+			return probe.succeeds("reg", "query", WINDOWS_SERVICE_REGISTRY_KEY) ? DeploymentKind.MSI : DeploymentKind.ARCHIVE;
+		}
+		if (probe.succeeds("dpkg", "-s", LINUX_PACKAGE_NAME)) {
+			return DeploymentKind.DEB;
+		}
+		if (probe.succeeds("rpm", "-q", LINUX_PACKAGE_NAME)) {
+			return DeploymentKind.RPM;
+		}
+		return DeploymentKind.ARCHIVE;
+	}
+
+	/**
+	 * Runs a probe command with a short timeout, discarding its output.
+	 *
+	 * @param command the command and its arguments
+	 * @return {@code true} when the command completed with exit code 0
+	 */
+	private static boolean runProbe(final String... command) {
+		try {
+			final Process process = new ProcessBuilder(command)
+				.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+				.redirectErrorStream(false)
+				.start();
+			if (!process.waitFor(10, TimeUnit.SECONDS)) {
+				process.destroyForcibly();
+				return false;
+			}
+			return process.exitValue() == 0;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		} catch (Exception e) {
+			log.debug("Deployment probe {} failed: {}", String.join(" ", command), e.getMessage());
+			return false;
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/DeploymentKind.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/DeploymentKind.java
@@ -1,0 +1,74 @@
+package org.metricshub.agent.upgrade.runner;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * How MetricsHub was deployed on this host. Only package-manager based deployments
+ * ({@code DEB}, {@code RPM}, {@code MSI}) support automatic in-place upgrades.
+ */
+public enum DeploymentKind {
+	/**
+	 * Installed through a Debian package.
+	 */
+	DEB(".deb"),
+	/**
+	 * Installed through an RPM package.
+	 */
+	RPM(".rpm"),
+	/**
+	 * Installed through a Windows MSI package.
+	 */
+	MSI(".msi"),
+	/**
+	 * Extracted from a tar.gz/zip application image: no package manager, no automatic upgrade.
+	 */
+	ARCHIVE(null),
+	/**
+	 * Running inside a container image: upgrades are image redeployments, not package installs.
+	 */
+	DOCKER(null);
+
+	private final String packageExtension;
+
+	DeploymentKind(final String packageExtension) {
+		this.packageExtension = packageExtension;
+	}
+
+	/**
+	 * Returns the package file extension expected for this deployment kind.
+	 *
+	 * @return the extension including the leading dot, or {@code null} when in-place upgrades are
+	 *         not supported
+	 */
+	public String getPackageExtension() {
+		return packageExtension;
+	}
+
+	/**
+	 * Indicates whether this deployment kind supports automatic in-place upgrades.
+	 *
+	 * @return {@code true} for package-manager based deployments
+	 */
+	public boolean isUpgradable() {
+		return packageExtension != null;
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/RunnerLauncher.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/RunnerLauncher.java
@@ -1,0 +1,44 @@
+package org.metricshub.agent.upgrade.runner;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.nio.file.Path;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
+
+/**
+ * Launches the detached upgrade runner that stops the agent service, installs the staged package
+ * and restarts the service. The runner must survive the agent process being stopped:
+ * platform-specific implementations use a systemd transient unit on Linux and a one-shot
+ * scheduled task on Windows.
+ */
+public interface RunnerLauncher {
+	/**
+	 * Launches the detached upgrade runner. Returns once the runner process is successfully
+	 * started; the installation itself completes after the agent has been stopped.
+	 *
+	 * @param transaction      the persisted upgrade transaction
+	 * @param stagedPackage    the validated, staged package file
+	 * @param stagingDirectory the upgrade staging directory (runner logs and markers live there)
+	 * @throws Exception when the runner cannot be launched
+	 */
+	void launch(UpgradeTransaction transaction, Path stagedPackage, Path stagingDirectory) throws Exception;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/RunnerMarkers.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/RunnerMarkers.java
@@ -1,0 +1,98 @@
+package org.metricshub.agent.upgrade.runner;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Marker files written by the detached upgrade runner in the staging directory. The runner is the
+ * only writer; the agent reads the result during startup reconciliation — in particular for
+ * same-version hotfix installations, where comparing versions cannot prove that the installer
+ * actually ran.
+ */
+@Slf4j
+public class RunnerMarkers {
+
+	/**
+	 * Name of the result marker file written by the runner
+	 * ({@code INSTALL_OK} or {@code INSTALL_FAILED ...}).
+	 */
+	public static final String RESULT_FILE_NAME = "runner.result";
+
+	/**
+	 * First token of the result marker when the installation succeeded.
+	 */
+	public static final String INSTALL_OK = "INSTALL_OK";
+
+	private RunnerMarkers() {}
+
+	/**
+	 * Reads the runner result marker.
+	 *
+	 * @param stagingDirectory the upgrade staging directory
+	 * @return the trimmed marker content, when present and readable
+	 */
+	public static Optional<String> readResult(final Path stagingDirectory) {
+		final Path resultFile = stagingDirectory.resolve(RESULT_FILE_NAME);
+		if (!Files.isRegularFile(resultFile)) {
+			return Optional.empty();
+		}
+		try {
+			return Optional.of(Files.readString(resultFile, StandardCharsets.UTF_8).trim());
+		} catch (IOException e) {
+			log.warn("Cannot read the upgrade runner result marker {}: {}", resultFile, e.getMessage());
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Indicates whether the runner reported a successful installation.
+	 *
+	 * @param stagingDirectory the upgrade staging directory
+	 * @return {@code true} when the result marker starts with {@code INSTALL_OK}
+	 */
+	public static boolean installSucceeded(final Path stagingDirectory) {
+		return readResult(stagingDirectory)
+			.map(result -> result.toUpperCase(Locale.ROOT).startsWith(INSTALL_OK))
+			.orElse(false);
+	}
+
+	/**
+	 * Deletes the runner marker files after reconciliation, so a stale marker can never influence
+	 * the next upgrade.
+	 *
+	 * @param stagingDirectory the upgrade staging directory
+	 */
+	public static void clear(final Path stagingDirectory) {
+		try {
+			Files.deleteIfExists(stagingDirectory.resolve(RESULT_FILE_NAME));
+		} catch (IOException e) {
+			log.warn("Cannot delete the upgrade runner result marker: {}", e.getMessage());
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/UnsupportedRunnerLauncher.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/runner/UnsupportedRunnerLauncher.java
@@ -1,0 +1,42 @@
+package org.metricshub.agent.upgrade.runner;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.nio.file.Path;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
+
+/**
+ * Placeholder launcher used until the platform-specific detached runners ship
+ * (EPIC-OpAMP-04): downloading and validating packages already works end-to-end, and the
+ * installation step fails with an explicit message.
+ */
+public class UnsupportedRunnerLauncher implements RunnerLauncher {
+
+	@Override
+	public void launch(final UpgradeTransaction transaction, final Path stagedPackage, final Path stagingDirectory)
+		throws Exception {
+		throw new UnsupportedOperationException(
+			"The detached upgrade runner is not available yet on this platform; the package was downloaded and validated at " +
+				stagedPackage
+		);
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransaction.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransaction.java
@@ -1,0 +1,127 @@
+package org.metricshub.agent.upgrade.transaction;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static com.fasterxml.jackson.annotation.Nulls.SKIP;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.metricshub.agent.upgrade.UpgradeState;
+
+/**
+ * Persistent record of an upgrade attempt. Written by the agent (the only writer) before the
+ * detached installer stops the process, and read back at the next startup to reconcile the
+ * outcome. Serialized as JSON in the upgrade staging directory, which survives the package
+ * upgrade on all platforms.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpgradeTransaction {
+
+	/**
+	 * Current schema version of the transaction file.
+	 */
+	public static final int CURRENT_SCHEMA_VERSION = 1;
+
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private int schemaVersion = CURRENT_SCHEMA_VERSION;
+
+	/**
+	 * Unique identifier of the upgrade attempt.
+	 */
+	private String upgradeId;
+
+	/**
+	 * Name of the package being upgraded.
+	 */
+	private String packageName;
+
+	/**
+	 * Version the agent was running when the upgrade started.
+	 */
+	private String fromVersion;
+
+	/**
+	 * Version offered by the OpAMP server.
+	 */
+	private String toVersion;
+
+	/**
+	 * URL the package was downloaded from.
+	 */
+	private String downloadUrl;
+
+	/**
+	 * Absolute path of the staged package file.
+	 */
+	private String packageFile;
+
+	/**
+	 * Expected SHA-256 of the package content, hexadecimal.
+	 */
+	private String sha256;
+
+	/**
+	 * Detected deployment kind (deb, rpm, msi).
+	 */
+	private String deploymentKind;
+
+	/**
+	 * Current upgrade state.
+	 */
+	private UpgradeState state;
+
+	/**
+	 * Failure cause when the state is {@code FAILED}.
+	 */
+	private String error;
+
+	/**
+	 * Creation timestamp, epoch milliseconds.
+	 */
+	private long createdAt;
+
+	/**
+	 * Last update timestamp, epoch milliseconds.
+	 */
+	private long updatedAt;
+
+	/**
+	 * Timestamp at which the detached installer was launched, epoch milliseconds; 0 before the
+	 * installation phase.
+	 */
+	private long installStartedAt;
+
+	/**
+	 * Installation timeout in seconds, captured from the configuration when the upgrade started.
+	 */
+	private long installTimeoutSeconds;
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransaction.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransaction.java
@@ -90,6 +90,12 @@ public class UpgradeTransaction {
 	private String sha256;
 
 	/**
+	 * Offered package identity hash ({@code PackageAvailable.hash}), hexadecimal; echoed back in
+	 * the package statuses as required by the OpAMP specification.
+	 */
+	private String packageHash;
+
+	/**
 	 * Detected deployment kind (deb, rpm, msi).
 	 */
 	private String deploymentKind;

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStore.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStore.java
@@ -1,0 +1,148 @@
+package org.metricshub.agent.upgrade.transaction;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reads and writes the {@link UpgradeTransaction} JSON file in the upgrade staging directory.
+ * Writes are atomic (temporary file then move) so a crash can never leave a half-written
+ * transaction behind.
+ */
+@Slf4j
+public class UpgradeTransactionStore {
+
+	/**
+	 * Name of the transaction file in the staging directory.
+	 */
+	public static final String TRANSACTION_FILE_NAME = "upgrade-transaction.json";
+
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final Path stagingDirectory;
+	private final Path transactionFile;
+
+	/**
+	 * Creates a store backed by the given staging directory.
+	 *
+	 * @param stagingDirectory the upgrade staging directory
+	 */
+	public UpgradeTransactionStore(final Path stagingDirectory) {
+		this.stagingDirectory = stagingDirectory;
+		this.transactionFile = stagingDirectory.resolve(TRANSACTION_FILE_NAME);
+	}
+
+	/**
+	 * Reads the pending transaction.
+	 *
+	 * @return the transaction, or {@code null} when none exists or the file is corrupt (a corrupt
+	 *         file is archived with a {@code .corrupt} suffix)
+	 */
+	public UpgradeTransaction read() {
+		if (!Files.isRegularFile(transactionFile)) {
+			return null;
+		}
+		try {
+			return OBJECT_MAPPER.readValue(
+				Files.readString(transactionFile, StandardCharsets.UTF_8),
+				UpgradeTransaction.class
+			);
+		} catch (IOException e) {
+			log.error("Corrupt upgrade transaction file {}: {}", transactionFile, e.getMessage());
+			archiveCorrupt();
+			return null;
+		}
+	}
+
+	/**
+	 * Persists the transaction atomically, updating its {@code updatedAt} timestamp.
+	 *
+	 * @param transaction the transaction to persist
+	 * @throws IOException when the transaction cannot be written
+	 */
+	public void write(final UpgradeTransaction transaction) throws IOException {
+		transaction.setUpdatedAt(System.currentTimeMillis());
+		Files.createDirectories(stagingDirectory);
+		final Path temporaryFile = Files.createTempFile(stagingDirectory, TRANSACTION_FILE_NAME, ".tmp");
+		try {
+			Files.writeString(
+				temporaryFile,
+				OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(transaction),
+				StandardCharsets.UTF_8
+			);
+			try {
+				Files.move(temporaryFile, transactionFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			} catch (AtomicMoveNotSupportedException e) {
+				Files.move(temporaryFile, transactionFile, StandardCopyOption.REPLACE_EXISTING);
+			}
+		} finally {
+			Files.deleteIfExists(temporaryFile);
+		}
+	}
+
+	/**
+	 * Archives the current transaction file with a suffix carrying the upgrade identifier, so the
+	 * last outcomes remain available for troubleshooting.
+	 *
+	 * @param transaction the transaction being archived
+	 */
+	public void archive(final UpgradeTransaction transaction) {
+		if (!Files.isRegularFile(transactionFile)) {
+			return;
+		}
+		final String suffix =
+			transaction != null && transaction.getUpgradeId() != null
+				? transaction.getUpgradeId()
+				: String.valueOf(System.currentTimeMillis());
+		try {
+			Files.move(
+				transactionFile,
+				stagingDirectory.resolve(TRANSACTION_FILE_NAME + "." + suffix),
+				StandardCopyOption.REPLACE_EXISTING
+			);
+		} catch (IOException e) {
+			log.warn("Cannot archive the upgrade transaction file {}: {}", transactionFile, e.getMessage());
+		}
+	}
+
+	/**
+	 * Renames a corrupt transaction file so it does not block subsequent upgrades.
+	 */
+	private void archiveCorrupt() {
+		try {
+			Files.move(
+				transactionFile,
+				stagingDirectory.resolve(TRANSACTION_FILE_NAME + ".corrupt"),
+				StandardCopyOption.REPLACE_EXISTING
+			);
+		} catch (IOException e) {
+			log.warn("Cannot archive the corrupt upgrade transaction file {}: {}", transactionFile, e.getMessage());
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStore.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStore.java
@@ -132,6 +132,62 @@ public class UpgradeTransactionStore {
 	}
 
 	/**
+	 * Identity of the currently installed package as learned from a completed OpAMP upgrade.
+	 *
+	 * @param version     the installed version
+	 * @param packageHash the installed package identity hash, hexadecimal
+	 */
+	public record InstalledPackageRecord(String version, String packageHash) {}
+
+	/**
+	 * Name of the file recording the installed package identity.
+	 */
+	public static final String INSTALLED_PACKAGE_FILE_NAME = "installed-package.json";
+
+	/**
+	 * Reads the installed package identity record.
+	 *
+	 * @return the record, or {@code null} when none exists or it cannot be parsed
+	 */
+	public InstalledPackageRecord readInstalledPackage() {
+		final Path file = stagingDirectory.resolve(INSTALLED_PACKAGE_FILE_NAME);
+		if (!Files.isRegularFile(file)) {
+			return null;
+		}
+		try {
+			return OBJECT_MAPPER.readValue(Files.readString(file, StandardCharsets.UTF_8), InstalledPackageRecord.class);
+		} catch (IOException e) {
+			log.warn("Cannot read the installed package record {}: {}", file, e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * Persists the installed package identity record atomically.
+	 *
+	 * @param record the record to persist
+	 */
+	public void writeInstalledPackage(final InstalledPackageRecord record) {
+		final Path file = stagingDirectory.resolve(INSTALLED_PACKAGE_FILE_NAME);
+		try {
+			Files.createDirectories(stagingDirectory);
+			final Path temporaryFile = Files.createTempFile(stagingDirectory, INSTALLED_PACKAGE_FILE_NAME, ".tmp");
+			try {
+				Files.writeString(temporaryFile, OBJECT_MAPPER.writeValueAsString(record), StandardCharsets.UTF_8);
+				try {
+					Files.move(temporaryFile, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+				} catch (AtomicMoveNotSupportedException e) {
+					Files.move(temporaryFile, file, StandardCopyOption.REPLACE_EXISTING);
+				}
+			} finally {
+				Files.deleteIfExists(temporaryFile);
+			}
+		} catch (IOException e) {
+			log.warn("Cannot persist the installed package record {}: {}", file, e.getMessage());
+		}
+	}
+
+	/**
 	 * Renames a corrupt transaction file so it does not block subsequent upgrades.
 	 */
 	private void archiveCorrupt() {

--- a/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/validate/PackageValidator.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/upgrade/validate/PackageValidator.java
@@ -1,0 +1,192 @@
+package org.metricshub.agent.upgrade.validate;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Locale;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.UpgradeException;
+import org.metricshub.agent.upgrade.VersionHelper;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.runner.DeploymentKind;
+import org.metricshub.engine.common.helpers.LocalOsHandler;
+
+/**
+ * Validates package offers and staged packages: source package type against the deployment kind,
+ * version applicability (downgrade policy), mandatory SHA-256, size bounds and disk-space
+ * preflight.
+ */
+public class PackageValidator {
+
+	/**
+	 * Free disk space safety margin kept on top of the package size (200 MiB).
+	 */
+	static final long DISK_SPACE_MARGIN_BYTES = 200L * 1024 * 1024;
+
+	/**
+	 * Validates a package offer before downloading anything.
+	 *
+	 * @param offer          the package offer
+	 * @param currentVersion the version the agent currently runs
+	 * @param config         the upgrade configuration
+	 * @param deploymentKind the detected deployment kind
+	 * @throws UpgradeException when the offer must be rejected
+	 */
+	public void validateOffer(
+		final PackageOffer offer,
+		final String currentVersion,
+		final UpgradeConfig config,
+		final DeploymentKind deploymentKind
+	) throws UpgradeException {
+		if (!deploymentKind.isUpgradable()) {
+			throw new UpgradeException(
+				"Automatic upgrade is not supported for " + deploymentKind.name().toLowerCase(Locale.ROOT) + " deployments"
+			);
+		}
+		if (offer.version() == null || offer.version().isBlank()) {
+			throw new UpgradeException("The package offer does not carry a version");
+		}
+		if (offer.downloadUrl() == null || offer.downloadUrl().isBlank()) {
+			throw new UpgradeException("The package offer does not carry a download URL");
+		}
+		if (offer.sha256() == null || offer.sha256().length == 0) {
+			throw new UpgradeException("The package offer does not carry the mandatory SHA-256 content hash");
+		}
+
+		final String expectedExtension = deploymentKind.getPackageExtension();
+		final String urlPath = offer.downloadUrl().toLowerCase(Locale.ROOT);
+		final int queryIndex = urlPath.indexOf('?');
+		final String pathWithoutQuery = queryIndex >= 0 ? urlPath.substring(0, queryIndex) : urlPath;
+		if (!pathWithoutQuery.endsWith(expectedExtension)) {
+			throw new UpgradeException(
+				"The offered package type does not match this deployment: expected a " +
+					expectedExtension +
+					" package for a " +
+					deploymentKind.name().toLowerCase(Locale.ROOT) +
+					" installation"
+			);
+		}
+
+		final int comparison = VersionHelper.compare(offer.version(), currentVersion);
+		if (comparison < 0) {
+			if (deploymentKind == DeploymentKind.MSI) {
+				throw new UpgradeException("Downgrades are not supported on Windows MSI installations");
+			}
+			if (!config.isAllowDowngrade()) {
+				throw new UpgradeException(
+					"The offered version " +
+						offer.version() +
+						" is older than the running version " +
+						currentVersion +
+						" and downgrades are disabled (upgrade.allowDowngrade)"
+				);
+			}
+		}
+	}
+
+	/**
+	 * Validates the staged package file: existence, size bounds, SHA-256 recomputed from disk and
+	 * free disk space for the installation.
+	 *
+	 * @param stagedPackage the staged package file
+	 * @param offer         the package offer
+	 * @param config        the upgrade configuration
+	 * @throws UpgradeException when the staged package must be rejected
+	 */
+	public void validateStagedPackage(final Path stagedPackage, final PackageOffer offer, final UpgradeConfig config)
+		throws UpgradeException {
+		try {
+			if (!Files.isRegularFile(stagedPackage)) {
+				throw new UpgradeException("The staged package file is missing: " + stagedPackage);
+			}
+			final long size = Files.size(stagedPackage);
+			if (size == 0) {
+				throw new UpgradeException("The staged package file is empty: " + stagedPackage);
+			}
+			if (size > config.getMaxPackageSizeBytes()) {
+				throw new UpgradeException(
+					"The staged package size (" +
+						size +
+						" bytes) exceeds the configured maximum of " +
+						config.getMaxPackageSizeBytes() +
+						" bytes"
+				);
+			}
+			if (!MessageDigest.isEqual(offer.sha256(), sha256Of(stagedPackage))) {
+				throw new UpgradeException("The staged package SHA-256 does not match the offered content hash");
+			}
+			final long usableSpace = Files.getFileStore(stagedPackage).getUsableSpace();
+			final long requiredSpace = requiredFreeSpace(size);
+			if (usableSpace < requiredSpace) {
+				throw new UpgradeException(
+					"Not enough free disk space to install the package: " +
+						usableSpace +
+						" bytes available, " +
+						requiredSpace +
+						" bytes required"
+				);
+			}
+		} catch (IOException e) {
+			throw new UpgradeException("Cannot validate the staged package: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Computes the free space required to safely install a package of the given size.
+	 *
+	 * @param packageSize the staged package size in bytes
+	 * @return the required free space in bytes
+	 */
+	static long requiredFreeSpace(final long packageSize) {
+		final long multiplied = LocalOsHandler.isWindows() ? packageSize * 3 : packageSize * 2;
+		return multiplied + DISK_SPACE_MARGIN_BYTES;
+	}
+
+	/**
+	 * Computes the SHA-256 of a file.
+	 *
+	 * @param file the file to hash
+	 * @return the SHA-256 digest
+	 * @throws IOException on I/O failure
+	 */
+	static byte[] sha256Of(final Path file) throws IOException {
+		try {
+			final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			try (InputStream input = Files.newInputStream(file)) {
+				final byte[] buffer = new byte[64 * 1024];
+				int read;
+				while ((read = input.read(buffer)) >= 0) {
+					digest.update(buffer, 0, read);
+				}
+			}
+			return digest.digest();
+		} catch (IOException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new IllegalStateException("SHA-256 is not available", e);
+		}
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/opamp/OpAmpServiceTest.java
@@ -200,6 +200,48 @@ class OpAmpServiceTest {
 	}
 
 	@Test
+	void upgradeAdapterSinkShouldBeReboundOnEveryClientBuild() {
+		final org.metricshub.agent.upgrade.UpgradeManager upgradeManager = mock(
+			org.metricshub.agent.upgrade.UpgradeManager.class
+		);
+		final org.metricshub.agent.upgrade.opamp.OpampUpgradeAdapter adapter =
+			new org.metricshub.agent.upgrade.opamp.OpampUpgradeAdapter(upgradeManager);
+		final org.metricshub.opamp.client.packages.PackageStatusSink clientSink = mock(
+			org.metricshub.opamp.client.packages.PackageStatusSink.class
+		);
+		when(client.packageStatusSink()).thenReturn(clientSink);
+
+		final OpAmpService service = new OpAmpService(agentContextHolder, adapter, settings -> {
+			factoryInvocations++;
+			return client;
+		});
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+
+		service.supervise();
+
+		verify(client).setPackagesHandler(adapter);
+		verify(client).packageStatusSink();
+	}
+
+	@Test
+	void packagesHandlerShouldNotBeRegisteredWhenUpgradesAreDisabled() {
+		final org.metricshub.opamp.client.packages.OpampPackagesHandler handler = mock(
+			org.metricshub.opamp.client.packages.OpampPackagesHandler.class
+		);
+		final OpAmpService service = new OpAmpService(agentContextHolder, handler, settings -> {
+			factoryInvocations++;
+			return client;
+		});
+		agentConfig.setOpamp(enabledConfig(ENDPOINT));
+		agentConfig.setUpgrade(org.metricshub.agent.config.UpgradeConfig.builder().enabled(false).build());
+
+		service.supervise();
+
+		verify(client, never()).setPackagesHandler(any());
+		verify(client, times(1)).start();
+	}
+
+	@Test
 	void buildSettingsShouldMapTheConfiguration() {
 		final OpAmpConfig config = OpAmpConfig.builder()
 			.enabled(true)

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeLockTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeLockTest.java
@@ -1,0 +1,41 @@
+package org.metricshub.agent.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class UpgradeLockTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void lockShouldBeExclusive() {
+		final UpgradeLock lock = new UpgradeLock(tempDir);
+
+		assertTrue(lock.tryAcquire());
+		assertFalse(lock.tryAcquire());
+		assertTrue(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+
+		lock.release();
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+		assertTrue(lock.tryAcquire());
+	}
+
+	@Test
+	void staleLockFileShouldBlockUntilReleased() throws Exception {
+		Files.createDirectories(tempDir);
+		Files.createFile(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME));
+		final UpgradeLock lock = new UpgradeLock(tempDir);
+
+		// The stale file left by a previous process blocks acquisition
+		assertFalse(lock.tryAcquire());
+
+		lock.releaseStale();
+		assertTrue(lock.tryAcquire());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
@@ -152,7 +152,35 @@ class UpgradeManagerTest {
 	}
 
 	@Test
-	void sameVersionOfferShouldReportInstalledWithoutUpgrading() throws Exception {
+	void sameVersionOfferWithoutIdentityShouldReportInstalled() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+		final CountDownLatch idle = expectState(manager, UpgradeState.IDLE);
+
+		// An offer without a package identity hash: version equality is the only evidence
+		manager.onPackageOffer(
+			new PackageOffer(
+				UpgradeManager.PACKAGE_NAME,
+				CURRENT_VERSION,
+				"https://repo.example.com/metricshub.pkg",
+				new byte[] { 1 },
+				new byte[0],
+				Map.of()
+			)
+		);
+
+		assertTrue(idle.await(10, TimeUnit.SECONDS));
+		assertEquals(0, launches.get());
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+	}
+
+	@Test
+	void sameVersionOfferMatchingInstalledIdentityShouldReportInstalled() throws Exception {
+		// The installed identity is known and matches the offered hash {7, 7}
+		new UpgradeTransactionStore(tempDir).writeInstalledPackage(
+			new UpgradeTransactionStore.InstalledPackageRecord(CURRENT_VERSION, "0707")
+		);
 		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
 			launches.incrementAndGet()
 		);
@@ -162,7 +190,6 @@ class UpgradeManagerTest {
 
 		assertTrue(idle.await(10, TimeUnit.SECONDS));
 		assertEquals(0, launches.get());
-		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
 	}
 
 	@Test
@@ -218,29 +245,32 @@ class UpgradeManagerTest {
 	}
 
 	@Test
-	void sameVersionOfferWithDifferentIdentityShouldTriggerTheUpgrade() throws Exception {
+	void sameVersionOfferWithUnknownIdentityShouldInstall() throws Exception {
 		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
 			launches.incrementAndGet()
 		);
 
-		// First same-version offer: the unknown installed identity adopts the offered hash
-		final CountDownLatch idle = expectState(manager, UpgradeState.IDLE);
-		manager.onPackageOffer(offer(CURRENT_VERSION));
-		assertTrue(idle.await(10, TimeUnit.SECONDS));
-		assertEquals(0, launches.get());
-
-		// Second same-version offer with a DIFFERENT identity hash: a hotfix must be installed
+		// The offer carries an identity hash but the installed identity is unknown (the normal
+		// state of an agent whose package was never installed through OpAMP): the package must be
+		// installed, not assumed present
 		final CountDownLatch restarting = expectState(manager, UpgradeState.RESTARTING);
-		manager.onPackageOffer(
-			new PackageOffer(
-				UpgradeManager.PACKAGE_NAME,
-				CURRENT_VERSION,
-				"https://repo.example.com/metricshub.pkg",
-				new byte[] { 1 },
-				new byte[] { 9, 9 },
-				Map.of()
-			)
+		manager.onPackageOffer(offer(CURRENT_VERSION));
+		assertTrue(restarting.await(10, TimeUnit.SECONDS));
+		assertEquals(1, launches.get());
+	}
+
+	@Test
+	void sameVersionOfferWithDifferentIdentityShouldTriggerTheUpgrade() throws Exception {
+		// The installed identity is known but differs from the offered hash {7, 7}: a hotfix
+		new UpgradeTransactionStore(tempDir).writeInstalledPackage(
+			new UpgradeTransactionStore.InstalledPackageRecord(CURRENT_VERSION, "0909")
 		);
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+
+		final CountDownLatch restarting = expectState(manager, UpgradeState.RESTARTING);
+		manager.onPackageOffer(offer(CURRENT_VERSION));
 		assertTrue(restarting.await(10, TimeUnit.SECONDS));
 		assertEquals(1, launches.get());
 	}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
@@ -99,6 +99,7 @@ class UpgradeManagerTest {
 			version,
 			"https://repo.example.com/metricshub.pkg",
 			new byte[] { 1 },
+			new byte[] { 7, 7 },
 			Map.of()
 		);
 	}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
@@ -1,0 +1,247 @@
+package org.metricshub.agent.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.api.UpgradeEvent;
+import org.metricshub.agent.upgrade.download.DownloadProgressListener;
+import org.metricshub.agent.upgrade.download.PackageDownloader;
+import org.metricshub.agent.upgrade.runner.DeploymentDetector;
+import org.metricshub.agent.upgrade.runner.RunnerLauncher;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransactionStore;
+import org.metricshub.agent.upgrade.validate.PackageValidator;
+import org.metricshub.engine.common.helpers.LocalOsHandler;
+
+class UpgradeManagerTest {
+
+	private static final String CURRENT_VERSION = "3.9.05";
+	private static final String TARGET_VERSION = "3.10.00";
+
+	@TempDir
+	Path tempDir;
+
+	private final List<UpgradeEvent> events = new CopyOnWriteArrayList<>();
+	private final AtomicInteger launches = new AtomicInteger();
+	private UpgradeConfig config = UpgradeConfig.builder().build();
+
+	/**
+	 * Downloader test double staging a fixed file without any network access.
+	 */
+	private class FakeDownloader extends PackageDownloader {
+
+		@Override
+		public Path download(
+			final PackageOffer offer,
+			final UpgradeConfig upgradeConfig,
+			final Path targetDirectory,
+			final DownloadProgressListener progressListener
+		) throws UpgradeException {
+			try {
+				Files.createDirectories(targetDirectory);
+				final Path staged = targetDirectory.resolve("staged.pkg");
+				Files.writeString(staged, "package");
+				progressListener.onProgress(50, 1024);
+				progressListener.onProgress(100, 2048);
+				return staged;
+			} catch (Exception e) {
+				throw new UpgradeException(e.getMessage(), e);
+			}
+		}
+	}
+
+	/**
+	 * Validator test double accepting everything.
+	 */
+	private static class AcceptingValidator extends PackageValidator {
+
+		@Override
+		public void validateOffer(
+			final PackageOffer offer,
+			final String currentVersion,
+			final UpgradeConfig config,
+			final org.metricshub.agent.upgrade.runner.DeploymentKind deploymentKind
+		) {}
+
+		@Override
+		public void validateStagedPackage(final Path stagedPackage, final PackageOffer offer, final UpgradeConfig config) {}
+	}
+
+	private UpgradeManager newManager(final RunnerLauncher launcher) {
+		return new UpgradeManager(
+			() -> CURRENT_VERSION,
+			() -> config,
+			tempDir,
+			new FakeDownloader(),
+			new AcceptingValidator(),
+			new DeploymentDetector(command -> true),
+			launcher
+		);
+	}
+
+	private static PackageOffer offer(final String version) {
+		return new PackageOffer(
+			UpgradeManager.PACKAGE_NAME,
+			version,
+			"https://repo.example.com/metricshub.pkg",
+			new byte[] { 1 },
+			Map.of()
+		);
+	}
+
+	private CountDownLatch expectState(final UpgradeManager manager, final UpgradeState expected) {
+		final CountDownLatch latch = new CountDownLatch(1);
+		manager.setStatusListener(event -> {
+			events.add(event);
+			if (event.state() == expected) {
+				latch.countDown();
+			}
+		});
+		return latch;
+	}
+
+	@Test
+	void successfulPipelineShouldReachRestarting() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+		final CountDownLatch restarting = expectState(manager, UpgradeState.RESTARTING);
+
+		manager.onPackageOffer(offer(TARGET_VERSION));
+
+		assertTrue(restarting.await(10, TimeUnit.SECONDS));
+		assertEquals(1, launches.get());
+
+		final List<UpgradeState> states = events.stream().map(UpgradeEvent::state).distinct().toList();
+		assertEquals(
+			List.of(
+				UpgradeState.UPDATE_AVAILABLE,
+				UpgradeState.DOWNLOADING,
+				UpgradeState.VALIDATING,
+				UpgradeState.READY_TO_INSTALL,
+				UpgradeState.INSTALLING,
+				UpgradeState.RESTARTING
+			),
+			states
+		);
+
+		// The transaction and the lock survive for the post-restart reconciliation
+		final UpgradeTransaction transaction = new UpgradeTransactionStore(tempDir).read();
+		assertNotNull(transaction);
+		assertEquals(UpgradeState.RESTARTING, transaction.getState());
+		assertEquals(TARGET_VERSION, transaction.getToVersion());
+		assertTrue(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+
+		// Download progress was published
+		assertTrue(events.stream().anyMatch(event -> event.downloadPercent() == 50));
+	}
+
+	@Test
+	void sameVersionOfferShouldReportInstalledWithoutUpgrading() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+		final CountDownLatch idle = expectState(manager, UpgradeState.IDLE);
+
+		manager.onPackageOffer(offer(CURRENT_VERSION));
+
+		assertTrue(idle.await(10, TimeUnit.SECONDS));
+		assertEquals(0, launches.get());
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+	}
+
+	@Test
+	void launcherFailureShouldFailTheUpgradeAndReleaseTheLock() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) -> {
+			throw new UnsupportedOperationException("No runner on this platform");
+		});
+		final CountDownLatch failed = expectState(manager, UpgradeState.FAILED);
+
+		manager.onPackageOffer(offer(TARGET_VERSION));
+
+		assertTrue(failed.await(10, TimeUnit.SECONDS));
+		final UpgradeEvent last = events.get(events.size() - 1);
+		assertEquals(UpgradeState.FAILED, last.state());
+		assertTrue(last.errorMessage().contains("No runner"));
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+		// The staged file was cleaned up
+		assertFalse(Files.exists(tempDir.resolve("staged.pkg")));
+	}
+
+	@Test
+	void concurrentOfferShouldBeIgnoredWhileAnUpgradeIsInFlight() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+		final CountDownLatch restarting = expectState(manager, UpgradeState.RESTARTING);
+
+		manager.onPackageOffer(offer(TARGET_VERSION));
+		assertTrue(restarting.await(10, TimeUnit.SECONDS));
+
+		final int eventCountAfterFirstUpgrade = events.size();
+		manager.onPackageOffer(offer("3.11.00"));
+		// Give the worker a moment to (not) process the second offer
+		Thread.sleep(300);
+
+		assertEquals(1, launches.get());
+		assertEquals(eventCountAfterFirstUpgrade, events.size());
+	}
+
+	@Test
+	void disabledConfigurationShouldRejectOffers() throws Exception {
+		config = UpgradeConfig.builder().enabled(false).build();
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+		final CountDownLatch failed = expectState(manager, UpgradeState.FAILED);
+
+		manager.onPackageOffer(offer(TARGET_VERSION));
+
+		assertTrue(failed.await(10, TimeUnit.SECONDS));
+		assertEquals(0, launches.get());
+		assertTrue(events.get(events.size() - 1).errorMessage().contains("disabled"));
+	}
+
+	@Test
+	void upgradeSupportShouldFollowTheDeploymentKind() {
+		assertTrue(newManager((t, p, s) -> {}).isPackageUpgradeSupported());
+
+		final UpgradeManager archiveManager = new UpgradeManager(
+			() -> CURRENT_VERSION,
+			() -> config,
+			tempDir,
+			new FakeDownloader(),
+			new AcceptingValidator(),
+			new DeploymentDetector(command -> false),
+			(t, p, s) -> {}
+		);
+		assertFalse(archiveManager.isPackageUpgradeSupported());
+	}
+
+	@Test
+	void snapshotShouldStartIdleWithTheCurrentVersion() {
+		final UpgradeManager manager = newManager((t, p, s) -> {});
+
+		final UpgradeEvent snapshot = manager.getCurrentSnapshot();
+
+		assertEquals(UpgradeState.IDLE, snapshot.state());
+		assertEquals(CURRENT_VERSION, snapshot.currentVersion());
+		// LocalOsHandler is exercised transitively by the detector; reference it to document the
+		// platform-dependence of the detection tests
+		assertNotNull(LocalOsHandler.getOS());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeManagerTest.java
@@ -218,6 +218,34 @@ class UpgradeManagerTest {
 	}
 
 	@Test
+	void sameVersionOfferWithDifferentIdentityShouldTriggerTheUpgrade() throws Exception {
+		final UpgradeManager manager = newManager((transaction, stagedPackage, stagingDirectory) ->
+			launches.incrementAndGet()
+		);
+
+		// First same-version offer: the unknown installed identity adopts the offered hash
+		final CountDownLatch idle = expectState(manager, UpgradeState.IDLE);
+		manager.onPackageOffer(offer(CURRENT_VERSION));
+		assertTrue(idle.await(10, TimeUnit.SECONDS));
+		assertEquals(0, launches.get());
+
+		// Second same-version offer with a DIFFERENT identity hash: a hotfix must be installed
+		final CountDownLatch restarting = expectState(manager, UpgradeState.RESTARTING);
+		manager.onPackageOffer(
+			new PackageOffer(
+				UpgradeManager.PACKAGE_NAME,
+				CURRENT_VERSION,
+				"https://repo.example.com/metricshub.pkg",
+				new byte[] { 1 },
+				new byte[] { 9, 9 },
+				Map.of()
+			)
+		);
+		assertTrue(restarting.await(10, TimeUnit.SECONDS));
+		assertEquals(1, launches.get());
+	}
+
+	@Test
 	void upgradeSupportShouldFollowTheDeploymentKind() {
 		assertTrue(newManager((t, p, s) -> {}).isPackageUpgradeSupported());
 

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
@@ -1,0 +1,149 @@
+package org.metricshub.agent.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.api.UpgradeEvent;
+import org.metricshub.agent.upgrade.download.PackageDownloader;
+import org.metricshub.agent.upgrade.runner.DeploymentDetector;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransaction;
+import org.metricshub.agent.upgrade.transaction.UpgradeTransactionStore;
+import org.metricshub.agent.upgrade.validate.PackageValidator;
+
+class UpgradeReconciliationTest {
+
+	@TempDir
+	Path tempDir;
+
+	private final List<UpgradeEvent> events = new CopyOnWriteArrayList<>();
+
+	private UpgradeManager newManager(final String runningVersion) {
+		final UpgradeManager manager = new UpgradeManager(
+			() -> runningVersion,
+			() -> UpgradeConfig.builder().build(),
+			tempDir,
+			new PackageDownloader(),
+			new PackageValidator(),
+			new DeploymentDetector(command -> true),
+			(transaction, stagedPackage, stagingDirectory) -> {}
+		);
+		manager.setStatusListener(events::add);
+		return manager;
+	}
+
+	private UpgradeTransaction pendingTransaction(final UpgradeState state, final Path stagedFile) throws IOException {
+		final UpgradeTransaction transaction = UpgradeTransaction.builder()
+			.upgradeId("pending")
+			.packageName(UpgradeManager.PACKAGE_NAME)
+			.fromVersion("3.9.05")
+			.toVersion("3.10.00")
+			.state(state)
+			.createdAt(System.currentTimeMillis())
+			.installStartedAt(System.currentTimeMillis())
+			.installTimeoutSeconds(1800)
+			.packageFile(stagedFile != null ? stagedFile.toString() : null)
+			.build();
+		new UpgradeTransactionStore(tempDir).write(transaction);
+		return transaction;
+	}
+
+	@Test
+	void versionMatchAfterRestartShouldSucceed() throws IOException {
+		final Path stagedFile = tempDir.resolve("staged.pkg");
+		Files.writeString(stagedFile, "package");
+		pendingTransaction(UpgradeState.RESTARTING, stagedFile);
+		Files.createFile(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME));
+
+		final UpgradeManager manager = newManager("3.10.00");
+		manager.reconcileOnStartup();
+
+		final UpgradeEvent verdict = events.get(events.size() - 1);
+		assertEquals(UpgradeState.SUCCEEDED, verdict.state());
+		assertEquals("3.10.00", verdict.currentVersion());
+
+		// Transaction archived, staged file cleaned, lock released
+		assertNull(new UpgradeTransactionStore(tempDir).read());
+		assertFalse(Files.exists(stagedFile));
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+
+		// The verdict is part of the snapshot for the first OpAMP report
+		assertEquals(UpgradeState.SUCCEEDED, manager.getCurrentSnapshot().state());
+	}
+
+	@Test
+	void versionMismatchAfterRestartShouldFail() throws IOException {
+		pendingTransaction(UpgradeState.INSTALLING, null);
+
+		final UpgradeManager manager = newManager("3.9.05");
+		manager.reconcileOnStartup();
+
+		final UpgradeEvent verdict = events.get(events.size() - 1);
+		assertEquals(UpgradeState.FAILED, verdict.state());
+		assertTrue(verdict.errorMessage().contains("3.10.00"));
+		assertNull(new UpgradeTransactionStore(tempDir).read());
+	}
+
+	@Test
+	void snapshotVersionShouldIgnoreQualifiers() throws IOException {
+		pendingTransaction(UpgradeState.RESTARTING, null);
+
+		final UpgradeManager manager = newManager("3.10.00-SNAPSHOT");
+		manager.reconcileOnStartup();
+
+		assertEquals(UpgradeState.SUCCEEDED, events.get(events.size() - 1).state());
+	}
+
+	@Test
+	void preInstallInterruptionShouldFail() throws IOException {
+		pendingTransaction(UpgradeState.DOWNLOADING, null);
+
+		final UpgradeManager manager = newManager("3.9.05");
+		manager.reconcileOnStartup();
+
+		final UpgradeEvent verdict = events.get(events.size() - 1);
+		assertEquals(UpgradeState.FAILED, verdict.state());
+		assertTrue(verdict.errorMessage().contains("interrupted"));
+	}
+
+	@Test
+	void terminalTransactionShouldBeRepublishedAndArchived() throws IOException {
+		final UpgradeTransaction transaction = pendingTransaction(UpgradeState.SUCCEEDED, null);
+		transaction.setState(UpgradeState.SUCCEEDED);
+		new UpgradeTransactionStore(tempDir).write(transaction);
+
+		final UpgradeManager manager = newManager("3.10.00");
+		manager.reconcileOnStartup();
+
+		assertEquals(UpgradeState.SUCCEEDED, events.get(events.size() - 1).state());
+		assertNull(new UpgradeTransactionStore(tempDir).read());
+	}
+
+	@Test
+	void missingTransactionShouldLeaveTheManagerIdle() {
+		final UpgradeManager manager = newManager("3.9.05");
+		manager.reconcileOnStartup();
+
+		assertTrue(events.isEmpty());
+		assertEquals(UpgradeState.IDLE, manager.getCurrentSnapshot().state());
+	}
+
+	@Test
+	void staleLockWithoutTransactionShouldBeReleased() throws IOException {
+		Files.createDirectories(tempDir);
+		Files.createFile(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME));
+
+		newManager("3.9.05").reconcileOnStartup();
+
+		assertFalse(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.metricshub.agent.config.UpgradeConfig;
@@ -42,6 +43,14 @@ class UpgradeReconciliationTest {
 	}
 
 	private UpgradeTransaction pendingTransaction(final UpgradeState state, final Path stagedFile) throws IOException {
+		return pendingTransaction(state, stagedFile, System.currentTimeMillis() - TimeUnit.HOURS.toMillis(2));
+	}
+
+	private UpgradeTransaction pendingTransaction(
+		final UpgradeState state,
+		final Path stagedFile,
+		final long installStartedAt
+	) throws IOException {
 		final UpgradeTransaction transaction = UpgradeTransaction.builder()
 			.upgradeId("pending")
 			.packageName(UpgradeManager.PACKAGE_NAME)
@@ -49,8 +58,8 @@ class UpgradeReconciliationTest {
 			.toVersion("3.10.00")
 			.packageHash("0506")
 			.state(state)
-			.createdAt(System.currentTimeMillis())
-			.installStartedAt(System.currentTimeMillis())
+			.createdAt(installStartedAt)
+			.installStartedAt(installStartedAt)
 			.installTimeoutSeconds(1800)
 			.packageFile(stagedFile != null ? stagedFile.toString() : null)
 			.build();
@@ -127,6 +136,48 @@ class UpgradeReconciliationTest {
 	}
 
 	@Test
+	void pendingInstallationWithinDeadlineShouldBeDeferred() throws IOException {
+		// The runner started moments ago and its deadline has not elapsed: no verdict yet
+		pendingTransaction(UpgradeState.INSTALLING, null, System.currentTimeMillis());
+		Files.createDirectories(tempDir);
+		Files.createFile(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME));
+
+		final UpgradeManager manager = newManager("3.9.05");
+		manager.reconcileOnStartup();
+
+		final UpgradeEvent last = events.get(events.size() - 1);
+		assertEquals(UpgradeState.INSTALLING, last.state());
+		// The transaction and the lock are retained while the installation may still complete
+		org.junit.jupiter.api.Assertions.assertNotNull(new UpgradeTransactionStore(tempDir).read());
+		assertTrue(Files.exists(tempDir.resolve(UpgradeLock.LOCK_FILE_NAME)));
+	}
+
+	@Test
+	void deferredVerdictShouldResolveOnceTheMarkerArrives() throws IOException {
+		final UpgradeTransaction transaction = pendingTransaction(
+			UpgradeState.RESTARTING,
+			null,
+			System.currentTimeMillis()
+		);
+		transaction.setFromVersion("3.10.00");
+		transaction.setToVersion("3.10.00");
+		new UpgradeTransactionStore(tempDir).write(transaction);
+
+		final UpgradeManager manager = newManager("3.10.00");
+		manager.reconcileOnStartup();
+		assertEquals(UpgradeState.INSTALLING, events.get(events.size() - 1).state());
+
+		// The runner finishes and writes its result: the next check resolves the verdict
+		Files.writeString(
+			tempDir.resolve(org.metricshub.agent.upgrade.runner.RunnerMarkers.RESULT_FILE_NAME),
+			"INSTALL_OK"
+		);
+		manager.reconcileOnStartup();
+
+		assertEquals(UpgradeState.SUCCEEDED, events.get(events.size() - 1).state());
+	}
+
+	@Test
 	void sameVersionHotfixShouldSucceedWithTheRunnerMarker() throws IOException {
 		final UpgradeTransaction transaction = pendingTransaction(UpgradeState.RESTARTING, null);
 		transaction.setFromVersion("3.10.00");
@@ -171,12 +222,20 @@ class UpgradeReconciliationTest {
 	}
 
 	@Test
-	void missingTransactionShouldLeaveTheManagerIdle() {
+	void missingTransactionShouldLeaveTheManagerIdle() throws IOException {
+		Files.createDirectories(tempDir);
+		Files.writeString(
+			tempDir.resolve(org.metricshub.agent.upgrade.runner.RunnerMarkers.RESULT_FILE_NAME),
+			"INSTALL_OK"
+		);
+
 		final UpgradeManager manager = newManager("3.9.05");
 		manager.reconcileOnStartup();
 
 		assertTrue(events.isEmpty());
 		assertEquals(UpgradeState.IDLE, manager.getCurrentSnapshot().state());
+		// A stale runner marker is cleared so it can never bless a later installation
+		assertFalse(Files.exists(tempDir.resolve(org.metricshub.agent.upgrade.runner.RunnerMarkers.RESULT_FILE_NAME)));
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
@@ -47,6 +47,7 @@ class UpgradeReconciliationTest {
 			.packageName(UpgradeManager.PACKAGE_NAME)
 			.fromVersion("3.9.05")
 			.toVersion("3.10.00")
+			.packageHash("0506")
 			.state(state)
 			.createdAt(System.currentTimeMillis())
 			.installStartedAt(System.currentTimeMillis())
@@ -70,6 +71,11 @@ class UpgradeReconciliationTest {
 		final UpgradeEvent verdict = events.get(events.size() - 1);
 		assertEquals(UpgradeState.SUCCEEDED, verdict.state());
 		assertEquals("3.10.00", verdict.currentVersion());
+		org.junit.jupiter.api.Assertions.assertArrayEquals(
+			new byte[] { 5, 6 },
+			verdict.targetHash(),
+			"The verdict must carry the offered package hash persisted in the transaction"
+		);
 
 		// Transaction archived, staged file cleaned, lock released
 		assertNull(new UpgradeTransactionStore(tempDir).read());

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/UpgradeReconciliationTest.java
@@ -110,6 +110,42 @@ class UpgradeReconciliationTest {
 	}
 
 	@Test
+	void sameVersionHotfixShouldRequireTheRunnerMarker() throws IOException {
+		final UpgradeTransaction transaction = pendingTransaction(UpgradeState.RESTARTING, null);
+		transaction.setFromVersion("3.10.00");
+		transaction.setToVersion("3.10.00");
+		new UpgradeTransactionStore(tempDir).write(transaction);
+
+		// The running version is identical before and after: without the runner marker the
+		// installation cannot be considered successful
+		final UpgradeManager manager = newManager("3.10.00");
+		manager.reconcileOnStartup();
+
+		final UpgradeEvent verdict = events.get(events.size() - 1);
+		assertEquals(UpgradeState.FAILED, verdict.state());
+		assertTrue(verdict.errorMessage().contains("could not be verified"));
+	}
+
+	@Test
+	void sameVersionHotfixShouldSucceedWithTheRunnerMarker() throws IOException {
+		final UpgradeTransaction transaction = pendingTransaction(UpgradeState.RESTARTING, null);
+		transaction.setFromVersion("3.10.00");
+		transaction.setToVersion("3.10.00");
+		new UpgradeTransactionStore(tempDir).write(transaction);
+		Files.writeString(
+			tempDir.resolve(org.metricshub.agent.upgrade.runner.RunnerMarkers.RESULT_FILE_NAME),
+			"INSTALL_OK"
+		);
+
+		final UpgradeManager manager = newManager("3.10.00");
+		manager.reconcileOnStartup();
+
+		assertEquals(UpgradeState.SUCCEEDED, events.get(events.size() - 1).state());
+		// The marker is cleared so it can never influence the next upgrade
+		assertFalse(Files.exists(tempDir.resolve(org.metricshub.agent.upgrade.runner.RunnerMarkers.RESULT_FILE_NAME)));
+	}
+
+	@Test
 	void preInstallInterruptionShouldFail() throws IOException {
 		pendingTransaction(UpgradeState.DOWNLOADING, null);
 

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/VersionHelperTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/VersionHelperTest.java
@@ -1,0 +1,32 @@
+package org.metricshub.agent.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class VersionHelperTest {
+
+	@Test
+	void normalizeShouldStripQualifiers() {
+		assertEquals("3.9.05", VersionHelper.normalize("3.9.05-SNAPSHOT"));
+		assertEquals("3.9.05", VersionHelper.normalize(" 3.9.05 "));
+		assertEquals("", VersionHelper.normalize(null));
+	}
+
+	@Test
+	void isSameVersionShouldIgnoreQualifiers() {
+		assertTrue(VersionHelper.isSameVersion("3.9.05-SNAPSHOT", "3.9.05"));
+		assertFalse(VersionHelper.isSameVersion("3.9.05", "3.9.06"));
+	}
+
+	@Test
+	void compareShouldOrderNumerically() {
+		assertTrue(VersionHelper.compare("3.10.00", "3.9.06") > 0);
+		assertTrue(VersionHelper.compare("3.9.06", "3.10.00") < 0);
+		assertEquals(0, VersionHelper.compare("3.9.05-SNAPSHOT", "3.9.05"));
+		assertTrue(VersionHelper.compare("3.9.05.1", "3.9.05") > 0);
+		assertTrue(VersionHelper.compare("3.9", "3.9.01") < 0);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
@@ -53,6 +53,16 @@ class PackageDownloaderTest {
 			exchange.sendResponseHeaders(404, -1);
 			exchange.close();
 		});
+		server.createContext("/redirect-same-host/", exchange -> {
+			exchange.getResponseHeaders().set("Location", baseUrl() + "/repo/metricshub-redirected.deb");
+			exchange.sendResponseHeaders(302, -1);
+			exchange.close();
+		});
+		server.createContext("/redirect-other-host/", exchange -> {
+			exchange.getResponseHeaders().set("Location", "https://evil.example.com/metricshub.deb");
+			exchange.sendResponseHeaders(302, -1);
+			exchange.close();
+		});
 		server.start();
 	}
 
@@ -66,7 +76,7 @@ class PackageDownloaderTest {
 	}
 
 	private PackageOffer offer(final String url, final byte[] sha256) {
-		return new PackageOffer("metricshub", "3.10.00", url, sha256, Map.of());
+		return new PackageOffer("metricshub", "3.10.00", url, sha256, new byte[] { 7 }, Map.of());
 	}
 
 	private UpgradeConfig config() {
@@ -120,6 +130,37 @@ class PackageDownloaderTest {
 		);
 
 		assertTrue(failure.getMessage().contains("maximum"));
+	}
+
+	@Test
+	void redirectWithinTheAllowedHostShouldBeFollowed() throws Exception {
+		final Path staged = downloader.download(
+			offer(baseUrl() + "/redirect-same-host/metricshub.deb", packageSha256),
+			config(),
+			tempDir,
+			(p, r) -> {}
+		);
+
+		assertArrayEquals(packageContent, Files.readAllBytes(staged));
+	}
+
+	@Test
+	void redirectOutsideTheAllowlistShouldBeRejected() {
+		final UpgradeConfig allowlisted = UpgradeConfig.builder()
+			.hostAllowlist(java.util.List.of("127.0.0.1"))
+			.downloadRetries(1)
+			.build();
+
+		final UpgradeException failure = assertThrows(UpgradeException.class, () ->
+			downloader.download(
+				offer(baseUrl() + "/redirect-other-host/metricshub.deb", packageSha256),
+				allowlisted,
+				tempDir,
+				(p, r) -> {}
+			)
+		);
+
+		assertTrue(failure.getMessage().contains("redirected"));
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
@@ -63,6 +63,18 @@ class PackageDownloaderTest {
 			exchange.sendResponseHeaders(302, -1);
 			exchange.close();
 		});
+		server.createContext("/stall/", exchange -> {
+			// Send the headers and a partial body, then stall without closing (long enough for
+			// the 2-second download deadline of the test to fire first)
+			exchange.sendResponseHeaders(200, packageContent.length);
+			exchange.getResponseBody().write(packageContent, 0, 1024);
+			exchange.getResponseBody().flush();
+			try {
+				Thread.sleep(8_000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		});
 		server.start();
 	}
 
@@ -130,6 +142,27 @@ class PackageDownloaderTest {
 		);
 
 		assertTrue(failure.getMessage().contains("maximum"));
+	}
+
+	@Test
+	void stalledBodyShouldBeAbortedAtTheDownloadDeadline() {
+		final UpgradeConfig shortTimeout = UpgradeConfig.builder().downloadTimeout(2).downloadRetries(1).build();
+
+		final long startedMs = System.currentTimeMillis();
+		assertThrows(UpgradeException.class, () ->
+			downloader.download(
+				offer(baseUrl() + "/stall/metricshub.deb", packageSha256),
+				shortTimeout,
+				tempDir,
+				(p, r) -> {}
+			)
+		);
+
+		final long elapsedMs = System.currentTimeMillis() - startedMs;
+		assertTrue(
+			elapsedMs < 30_000,
+			"The stalled download must be aborted at the deadline, but took " + elapsedMs + " ms"
+		);
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/download/PackageDownloaderTest.java
@@ -1,0 +1,156 @@
+package org.metricshub.agent.upgrade.download;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.UpgradeException;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+
+class PackageDownloaderTest {
+
+	@TempDir
+	Path tempDir;
+
+	private HttpServer server;
+	private byte[] packageContent;
+	private byte[] packageSha256;
+	private final PackageDownloader downloader = new PackageDownloader();
+	private final AtomicInteger requestCount = new AtomicInteger();
+
+	@BeforeEach
+	void setUp() throws Exception {
+		packageContent = new byte[256 * 1024];
+		for (int i = 0; i < packageContent.length; i++) {
+			packageContent[i] = (byte) (i % 251);
+		}
+		packageSha256 = MessageDigest.getInstance("SHA-256").digest(packageContent);
+
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/repo/", exchange -> {
+			requestCount.incrementAndGet();
+			exchange.sendResponseHeaders(200, packageContent.length);
+			try (OutputStream output = exchange.getResponseBody()) {
+				output.write(packageContent);
+			}
+		});
+		server.createContext("/missing/", exchange -> {
+			exchange.sendResponseHeaders(404, -1);
+			exchange.close();
+		});
+		server.start();
+	}
+
+	@AfterEach
+	void tearDown() {
+		server.stop(0);
+	}
+
+	private String baseUrl() {
+		return "http://127.0.0.1:" + server.getAddress().getPort();
+	}
+
+	private PackageOffer offer(final String url, final byte[] sha256) {
+		return new PackageOffer("metricshub", "3.10.00", url, sha256, Map.of());
+	}
+
+	private UpgradeConfig config() {
+		return UpgradeConfig.builder().downloadRetries(2).build();
+	}
+
+	@Test
+	void downloadShouldStageAndVerifyThePackage() throws Exception {
+		final double[] lastPercent = { -1 };
+		final Path staged = downloader.download(
+			offer(baseUrl() + "/repo/metricshub-3.10.00.deb", packageSha256),
+			config(),
+			tempDir,
+			(percent, rate) -> lastPercent[0] = percent
+		);
+
+		assertEquals("metricshub-3.10.00.deb", staged.getFileName().toString());
+		assertArrayEquals(packageContent, Files.readAllBytes(staged));
+		assertEquals(100, lastPercent[0]);
+		assertTrue(Files.notExists(staged.resolveSibling(staged.getFileName() + ".part")));
+	}
+
+	@Test
+	void hashMismatchShouldFailAfterRetries() {
+		final UpgradeException failure = assertThrows(UpgradeException.class, () ->
+			downloader.download(
+				offer(baseUrl() + "/repo/metricshub.deb", new byte[] { 9, 9, 9 }),
+				config(),
+				tempDir,
+				(p, r) -> {}
+			)
+		);
+
+		assertTrue(failure.getMessage().contains("SHA-256"));
+		assertEquals(2, requestCount.get(), "The download must be retried");
+	}
+
+	@Test
+	void httpErrorShouldFail() {
+		assertThrows(UpgradeException.class, () ->
+			downloader.download(offer(baseUrl() + "/missing/metricshub.deb", packageSha256), config(), tempDir, (p, r) -> {})
+		);
+	}
+
+	@Test
+	void oversizedPackageShouldBeRejected() {
+		final UpgradeConfig tinyCap = UpgradeConfig.builder().maxPackageSizeBytes(1024).downloadRetries(1).build();
+
+		final UpgradeException failure = assertThrows(UpgradeException.class, () ->
+			downloader.download(offer(baseUrl() + "/repo/metricshub.deb", packageSha256), tinyCap, tempDir, (p, r) -> {})
+		);
+
+		assertTrue(failure.getMessage().contains("maximum"));
+	}
+
+	@Test
+	void plainHttpShouldBeRejectedForNonLoopbackHosts() {
+		assertThrows(UpgradeException.class, () ->
+			PackageDownloader.validateSource(offer("http://repo.example.com/metricshub.deb", packageSha256), config())
+		);
+	}
+
+	@Test
+	void hostAllowlistShouldBeEnforced() {
+		final UpgradeConfig allowlisted = UpgradeConfig.builder()
+			.hostAllowlist(java.util.List.of("repo.metricshub.com"))
+			.build();
+
+		assertThrows(UpgradeException.class, () ->
+			PackageDownloader.validateSource(offer("https://evil.example.com/metricshub.deb", packageSha256), allowlisted)
+		);
+		org.junit.jupiter.api.Assertions.assertDoesNotThrow(() ->
+			PackageDownloader.validateSource(offer("https://repo.metricshub.com/metricshub.deb", packageSha256), allowlisted)
+		);
+	}
+
+	@Test
+	void fileNamesShouldBeSanitized() {
+		final PackageOffer offer = offer("https://repo/a%20b/pack%20age.deb", packageSha256);
+		final String name = PackageDownloader.sanitizedFileName(URI.create(offer.downloadUrl()), offer);
+		assertEquals("pack_age.deb", name);
+
+		final PackageOffer noName = offer("https://repo.example.com/", packageSha256);
+		final String fallback = PackageDownloader.sanitizedFileName(URI.create(noName.downloadUrl()), noName);
+		assertEquals("metricshub-3.10.00", fallback);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
@@ -1,0 +1,198 @@
+package org.metricshub.agent.upgrade.opamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.protobuf.ByteString;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.metricshub.agent.upgrade.UpgradeManager;
+import org.metricshub.agent.upgrade.UpgradeState;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.api.UpgradeEvent;
+import org.metricshub.agent.upgrade.api.UpgradeStatusListener;
+import org.metricshub.opamp.client.packages.PackageDownloadContext;
+import org.metricshub.opamp.client.packages.PackageStatusSink;
+import org.metricshub.opamp.proto.DownloadableFile;
+import org.metricshub.opamp.proto.Header;
+import org.metricshub.opamp.proto.Headers;
+import org.metricshub.opamp.proto.PackageAvailable;
+import org.metricshub.opamp.proto.PackageDownloadDetails;
+import org.metricshub.opamp.proto.PackageStatus;
+import org.metricshub.opamp.proto.PackageStatusEnum;
+import org.metricshub.opamp.proto.PackagesAvailable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpampUpgradeAdapterTest {
+
+	@Mock
+	private UpgradeManager upgradeManager;
+
+	@Mock
+	private PackageStatusSink sink;
+
+	@Mock
+	private PackageDownloadContext downloadContext;
+
+	private OpampUpgradeAdapter newAdapter() {
+		return new OpampUpgradeAdapter(upgradeManager);
+	}
+
+	private UpgradeStatusListener capturedListener() {
+		final ArgumentCaptor<UpgradeStatusListener> captor = ArgumentCaptor.forClass(UpgradeStatusListener.class);
+		verify(upgradeManager).setStatusListener(captor.capture());
+		return captor.getValue();
+	}
+
+	@Test
+	void offersShouldBeTranslatedAndForwarded() {
+		final OpampUpgradeAdapter adapter = newAdapter();
+		final PackagesAvailable offer = PackagesAvailable.newBuilder()
+			.putPackages(
+				UpgradeManager.PACKAGE_NAME,
+				PackageAvailable.newBuilder()
+					.setVersion("3.10.00")
+					.setFile(
+						DownloadableFile.newBuilder()
+							.setDownloadUrl("https://repo.metricshub.com/metricshub.deb")
+							.setContentHash(ByteString.copyFrom(new byte[] { 1, 2 }))
+							.setHeaders(
+								Headers.newBuilder().addHeaders(Header.newBuilder().setKey("Authorization").setValue("Bearer t"))
+							)
+					)
+					.build()
+			)
+			.build();
+
+		adapter.onPackagesAvailable(offer, sink, downloadContext);
+
+		final ArgumentCaptor<PackageOffer> captor = ArgumentCaptor.forClass(PackageOffer.class);
+		verify(upgradeManager).onPackageOffer(captor.capture());
+		final PackageOffer translated = captor.getValue();
+		assertEquals("3.10.00", translated.version());
+		assertEquals("https://repo.metricshub.com/metricshub.deb", translated.downloadUrl());
+		assertEquals(Map.of("Authorization", "Bearer t"), translated.headers());
+		assertEquals("0102", translated.sha256Hex());
+	}
+
+	@Test
+	void offersWithoutTheTopLevelPackageShouldBeIgnored() {
+		final OpampUpgradeAdapter adapter = newAdapter();
+
+		adapter.onPackagesAvailable(PackagesAvailable.getDefaultInstance(), sink, downloadContext);
+
+		verify(upgradeManager, never()).onPackageOffer(any());
+	}
+
+	@Test
+	void stateTransitionsShouldBeReportedAsPackageStatuses() {
+		final OpampUpgradeAdapter adapter = newAdapter();
+		final UpgradeStatusListener listener = capturedListener();
+		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
+
+		listener.onUpgradeEvent(
+			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.FAILED, "3.9.05", "3.10.00", "boom")
+		);
+
+		final ArgumentCaptor<PackageStatus> captor = ArgumentCaptor.forClass(PackageStatus.class);
+		verify(sink).report(captor.capture());
+		final PackageStatus status = captor.getValue();
+		assertEquals(PackageStatusEnum.PackageStatusEnum_InstallFailed, status.getStatus());
+		assertEquals("3.9.05", status.getAgentHasVersion());
+		assertEquals("3.10.00", status.getServerOfferedVersion());
+		assertEquals("boom", status.getErrorMessage());
+	}
+
+	@Test
+	void downloadProgressShouldUseTheProgressChannel() {
+		final OpampUpgradeAdapter adapter = newAdapter();
+		final UpgradeStatusListener listener = capturedListener();
+		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
+
+		listener.onUpgradeEvent(
+			new UpgradeEvent(UpgradeManager.PACKAGE_NAME, UpgradeState.DOWNLOADING, "3.9.05", "3.10.00", null, 42, 1024)
+		);
+
+		final ArgumentCaptor<PackageDownloadDetails> captor = ArgumentCaptor.forClass(PackageDownloadDetails.class);
+		verify(sink).reportDownloadProgress(org.mockito.ArgumentMatchers.eq(UpgradeManager.PACKAGE_NAME), captor.capture());
+		assertEquals(42, captor.getValue().getDownloadPercent());
+		verify(sink, never()).report(any());
+	}
+
+	@Test
+	void statusMappingShouldCoverAllStates() {
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Installed,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.IDLE)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Installed,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.SUCCEEDED)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_InstallPending,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.UPDATE_AVAILABLE)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_InstallPending,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.READY_TO_INSTALL)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Downloading,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.DOWNLOADING)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Downloading,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.VALIDATING)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Installing,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.INSTALLING)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Installing,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.RESTARTING)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_Installing,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.VERIFYING)
+		);
+		assertEquals(
+			PackageStatusEnum.PackageStatusEnum_InstallFailed,
+			OpampUpgradeAdapter.toPackageStatusEnum(UpgradeState.FAILED)
+		);
+	}
+
+	@Test
+	void currentPackageStatusesShouldReflectTheSnapshot() {
+		when(upgradeManager.getCurrentSnapshot()).thenReturn(
+			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.SUCCEEDED, "3.10.00", "3.10.00", null)
+		);
+		final OpampUpgradeAdapter adapter = newAdapter();
+
+		final var statuses = adapter.currentPackageStatuses();
+
+		final PackageStatus status = statuses.getPackagesOrThrow(UpgradeManager.PACKAGE_NAME);
+		assertEquals(PackageStatusEnum.PackageStatusEnum_Installed, status.getStatus());
+		assertEquals("3.10.00", status.getAgentHasVersion());
+		assertTrue(status.getErrorMessage().isEmpty());
+	}
+
+	private static PackagesAvailable offerWithPackage() {
+		return PackagesAvailable.newBuilder()
+			.putPackages(UpgradeManager.PACKAGE_NAME, PackageAvailable.newBuilder().setVersion("3.10.00").build())
+			.build();
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
@@ -109,6 +109,7 @@ class OpampUpgradeAdapterTest {
 				UpgradeManager.PACKAGE_NAME,
 				UpgradeState.FAILED,
 				"3.9.05",
+				new byte[] { 1, 1 },
 				"3.10.00",
 				new byte[] { 5, 6 },
 				"boom"
@@ -122,7 +123,11 @@ class OpampUpgradeAdapterTest {
 		assertEquals("3.9.05", status.getAgentHasVersion());
 		assertEquals("3.10.00", status.getServerOfferedVersion());
 		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getServerOfferedHash());
-		assertTrue(status.getAgentHasHash().isEmpty(), "A failed upgrade must not claim the offered package");
+		assertEquals(
+			ByteString.copyFrom(new byte[] { 1, 1 }),
+			status.getAgentHasHash(),
+			"A failed upgrade must keep reporting the installed package identity, not the offered one"
+		);
 		assertEquals("boom", status.getErrorMessage());
 	}
 
@@ -133,6 +138,7 @@ class OpampUpgradeAdapterTest {
 				UpgradeManager.PACKAGE_NAME,
 				UpgradeState.SUCCEEDED,
 				"3.10.00",
+				new byte[] { 5, 6 },
 				"3.10.00",
 				new byte[] { 5, 6 },
 				null
@@ -141,6 +147,29 @@ class OpampUpgradeAdapterTest {
 
 		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getServerOfferedHash());
 		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getAgentHasHash());
+	}
+
+	@Test
+	void republishSnapshotShouldReportThroughTheBoundSink() {
+		when(upgradeManager.getCurrentSnapshot()).thenReturn(
+			UpgradeEvent.of(
+				UpgradeManager.PACKAGE_NAME,
+				UpgradeState.SUCCEEDED,
+				"3.10.00",
+				new byte[] { 5, 6 },
+				"3.10.00",
+				new byte[] { 5, 6 },
+				null
+			)
+		);
+		final OpampUpgradeAdapter adapter = newAdapter();
+		adapter.bindSink(sink);
+
+		adapter.republishSnapshot();
+
+		final ArgumentCaptor<PackageStatus> captor = ArgumentCaptor.forClass(PackageStatus.class);
+		verify(sink).report(captor.capture());
+		assertEquals(PackageStatusEnum.PackageStatusEnum_Installed, captor.getValue().getStatus());
 	}
 
 	@Test
@@ -153,7 +182,7 @@ class OpampUpgradeAdapterTest {
 		adapter.bindSink(newSink);
 
 		listener.onUpgradeEvent(
-			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.FAILED, "3.9.05", "3.10.00", null, "boom")
+			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.FAILED, "3.9.05", null, "3.10.00", null, "boom")
 		);
 
 		verify(sink, never()).report(any());
@@ -167,7 +196,17 @@ class OpampUpgradeAdapterTest {
 		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
 
 		listener.onUpgradeEvent(
-			new UpgradeEvent(UpgradeManager.PACKAGE_NAME, UpgradeState.DOWNLOADING, "3.9.05", "3.10.00", null, null, 42, 1024)
+			new UpgradeEvent(
+				UpgradeManager.PACKAGE_NAME,
+				UpgradeState.DOWNLOADING,
+				"3.9.05",
+				null,
+				"3.10.00",
+				null,
+				null,
+				42,
+				1024
+			)
 		);
 
 		final ArgumentCaptor<PackageDownloadDetails> captor = ArgumentCaptor.forClass(PackageDownloadDetails.class);
@@ -227,6 +266,7 @@ class OpampUpgradeAdapterTest {
 				UpgradeManager.PACKAGE_NAME,
 				UpgradeState.SUCCEEDED,
 				"3.10.00",
+				new byte[] { 5, 6 },
 				"3.10.00",
 				new byte[] { 5, 6 },
 				null

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/opamp/OpampUpgradeAdapterTest.java
@@ -64,6 +64,7 @@ class OpampUpgradeAdapterTest {
 				UpgradeManager.PACKAGE_NAME,
 				PackageAvailable.newBuilder()
 					.setVersion("3.10.00")
+					.setHash(ByteString.copyFrom(new byte[] { 3, 4 }))
 					.setFile(
 						DownloadableFile.newBuilder()
 							.setDownloadUrl("https://repo.metricshub.com/metricshub.deb")
@@ -85,6 +86,7 @@ class OpampUpgradeAdapterTest {
 		assertEquals("https://repo.metricshub.com/metricshub.deb", translated.downloadUrl());
 		assertEquals(Map.of("Authorization", "Bearer t"), translated.headers());
 		assertEquals("0102", translated.sha256Hex());
+		assertEquals("0304", translated.packageHashHex());
 	}
 
 	@Test
@@ -103,7 +105,14 @@ class OpampUpgradeAdapterTest {
 		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
 
 		listener.onUpgradeEvent(
-			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.FAILED, "3.9.05", "3.10.00", "boom")
+			UpgradeEvent.of(
+				UpgradeManager.PACKAGE_NAME,
+				UpgradeState.FAILED,
+				"3.9.05",
+				"3.10.00",
+				new byte[] { 5, 6 },
+				"boom"
+			)
 		);
 
 		final ArgumentCaptor<PackageStatus> captor = ArgumentCaptor.forClass(PackageStatus.class);
@@ -112,7 +121,43 @@ class OpampUpgradeAdapterTest {
 		assertEquals(PackageStatusEnum.PackageStatusEnum_InstallFailed, status.getStatus());
 		assertEquals("3.9.05", status.getAgentHasVersion());
 		assertEquals("3.10.00", status.getServerOfferedVersion());
+		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getServerOfferedHash());
+		assertTrue(status.getAgentHasHash().isEmpty(), "A failed upgrade must not claim the offered package");
 		assertEquals("boom", status.getErrorMessage());
+	}
+
+	@Test
+	void succeededStatusShouldCarryBothHashes() {
+		final PackageStatus status = OpampUpgradeAdapter.toPackageStatus(
+			UpgradeEvent.of(
+				UpgradeManager.PACKAGE_NAME,
+				UpgradeState.SUCCEEDED,
+				"3.10.00",
+				"3.10.00",
+				new byte[] { 5, 6 },
+				null
+			)
+		);
+
+		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getServerOfferedHash());
+		assertEquals(ByteString.copyFrom(new byte[] { 5, 6 }), status.getAgentHasHash());
+	}
+
+	@Test
+	void bindSinkShouldRedirectEventDelivery() {
+		final OpampUpgradeAdapter adapter = newAdapter();
+		final UpgradeStatusListener listener = capturedListener();
+		final PackageStatusSink newSink = mock(PackageStatusSink.class);
+
+		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
+		adapter.bindSink(newSink);
+
+		listener.onUpgradeEvent(
+			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.FAILED, "3.9.05", "3.10.00", null, "boom")
+		);
+
+		verify(sink, never()).report(any());
+		verify(newSink).report(any());
 	}
 
 	@Test
@@ -122,7 +167,7 @@ class OpampUpgradeAdapterTest {
 		adapter.onPackagesAvailable(offerWithPackage(), sink, downloadContext);
 
 		listener.onUpgradeEvent(
-			new UpgradeEvent(UpgradeManager.PACKAGE_NAME, UpgradeState.DOWNLOADING, "3.9.05", "3.10.00", null, 42, 1024)
+			new UpgradeEvent(UpgradeManager.PACKAGE_NAME, UpgradeState.DOWNLOADING, "3.9.05", "3.10.00", null, null, 42, 1024)
 		);
 
 		final ArgumentCaptor<PackageDownloadDetails> captor = ArgumentCaptor.forClass(PackageDownloadDetails.class);
@@ -178,7 +223,14 @@ class OpampUpgradeAdapterTest {
 	@Test
 	void currentPackageStatusesShouldReflectTheSnapshot() {
 		when(upgradeManager.getCurrentSnapshot()).thenReturn(
-			UpgradeEvent.of(UpgradeManager.PACKAGE_NAME, UpgradeState.SUCCEEDED, "3.10.00", "3.10.00", null)
+			UpgradeEvent.of(
+				UpgradeManager.PACKAGE_NAME,
+				UpgradeState.SUCCEEDED,
+				"3.10.00",
+				"3.10.00",
+				new byte[] { 5, 6 },
+				null
+			)
 		);
 		final OpampUpgradeAdapter adapter = newAdapter();
 

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/runner/DeploymentDetectorTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/runner/DeploymentDetectorTest.java
@@ -1,0 +1,65 @@
+package org.metricshub.agent.upgrade.runner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.metricshub.engine.common.helpers.LocalOsHandler;
+
+class DeploymentDetectorTest {
+
+	@Test
+	void packageManagerDeploymentsShouldBeDetected() {
+		final DeploymentDetector detector = new DeploymentDetector(command -> true);
+
+		final DeploymentKind kind = detector.detect();
+
+		if (LocalOsHandler.isWindows()) {
+			assertEquals(DeploymentKind.MSI, kind);
+		} else {
+			assertEquals(DeploymentKind.DEB, kind);
+		}
+		assertTrue(kind.isUpgradable());
+	}
+
+	@Test
+	void archiveDeploymentShouldBeDetectedWhenNoPackageOwnsTheInstallation() {
+		final DeploymentDetector detector = new DeploymentDetector(command -> false);
+
+		final DeploymentKind kind = detector.detect();
+
+		assertEquals(DeploymentKind.ARCHIVE, kind);
+		assertFalse(kind.isUpgradable());
+	}
+
+	@Test
+	void rpmShouldBeProbedWhenDpkgIsAbsent() {
+		org.junit.jupiter.api.Assumptions.assumeFalse(LocalOsHandler.isWindows());
+		final List<String> probes = new ArrayList<>();
+		final DeploymentDetector detector = new DeploymentDetector(command -> {
+			probes.add(command[0]);
+			return "rpm".equals(command[0]);
+		});
+
+		assertEquals(DeploymentKind.RPM, detector.detect());
+		assertEquals(List.of("dpkg", "rpm"), probes);
+	}
+
+	@Test
+	void detectionShouldBeCached() {
+		final List<String> probes = new ArrayList<>();
+		final DeploymentDetector detector = new DeploymentDetector(command -> {
+			probes.add(command[0]);
+			return true;
+		});
+
+		detector.detect();
+		final int probesAfterFirstDetection = probes.size();
+		detector.detect();
+
+		assertEquals(probesAfterFirstDetection, probes.size());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStoreTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/transaction/UpgradeTransactionStoreTest.java
@@ -1,0 +1,73 @@
+package org.metricshub.agent.upgrade.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.upgrade.UpgradeState;
+
+class UpgradeTransactionStoreTest {
+
+	@TempDir
+	Path tempDir;
+
+	private UpgradeTransaction transaction() {
+		return UpgradeTransaction.builder()
+			.upgradeId("test-upgrade")
+			.packageName("metricshub")
+			.fromVersion("3.9.05")
+			.toVersion("3.10.00")
+			.downloadUrl("https://repo.example.com/metricshub.deb")
+			.sha256("abcd")
+			.deploymentKind("DEB")
+			.state(UpgradeState.DOWNLOADING)
+			.createdAt(123L)
+			.installTimeoutSeconds(1800)
+			.build();
+	}
+
+	@Test
+	void writeAndReadShouldRoundTrip() throws IOException {
+		final UpgradeTransactionStore store = new UpgradeTransactionStore(tempDir);
+		store.write(transaction());
+
+		final UpgradeTransaction read = store.read();
+
+		assertEquals("test-upgrade", read.getUpgradeId());
+		assertEquals(UpgradeState.DOWNLOADING, read.getState());
+		assertEquals("3.10.00", read.getToVersion());
+		assertTrue(read.getUpdatedAt() > 0);
+	}
+
+	@Test
+	void readShouldReturnNullWhenNoTransactionExists() {
+		assertNull(new UpgradeTransactionStore(tempDir).read());
+	}
+
+	@Test
+	void corruptTransactionShouldBeArchivedAndIgnored() throws IOException {
+		final UpgradeTransactionStore store = new UpgradeTransactionStore(tempDir);
+		Files.writeString(tempDir.resolve(UpgradeTransactionStore.TRANSACTION_FILE_NAME), "{not json");
+
+		assertNull(store.read());
+		assertTrue(Files.exists(tempDir.resolve(UpgradeTransactionStore.TRANSACTION_FILE_NAME + ".corrupt")));
+		assertNull(store.read());
+	}
+
+	@Test
+	void archiveShouldRenameTheTransactionFile() throws IOException {
+		final UpgradeTransactionStore store = new UpgradeTransactionStore(tempDir);
+		final UpgradeTransaction transaction = transaction();
+		store.write(transaction);
+
+		store.archive(transaction);
+
+		assertNull(store.read());
+		assertTrue(Files.exists(tempDir.resolve(UpgradeTransactionStore.TRANSACTION_FILE_NAME + ".test-upgrade")));
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/validate/PackageValidatorTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/validate/PackageValidatorTest.java
@@ -26,7 +26,7 @@ class PackageValidatorTest {
 	private final UpgradeConfig config = UpgradeConfig.builder().build();
 
 	private static PackageOffer offer(final String version, final String url) {
-		return new PackageOffer("metricshub", version, url, new byte[] { 1, 2, 3 }, Map.of());
+		return new PackageOffer("metricshub", version, url, new byte[] { 1, 2, 3 }, new byte[] { 7 }, Map.of());
 	}
 
 	@Test
@@ -79,7 +79,14 @@ class PackageValidatorTest {
 
 	@Test
 	void missingHashShouldBeRejected() {
-		final PackageOffer offer = new PackageOffer("metricshub", "3.10.00", "https://repo/m.deb", new byte[0], Map.of());
+		final PackageOffer offer = new PackageOffer(
+			"metricshub",
+			"3.10.00",
+			"https://repo/m.deb",
+			new byte[0],
+			new byte[] { 7 },
+			Map.of()
+		);
 		assertThrows(UpgradeException.class, () ->
 			validator.validateOffer(offer, CURRENT_VERSION, config, DeploymentKind.DEB)
 		);
@@ -130,7 +137,14 @@ class PackageValidatorTest {
 		Files.write(stagedPackage, content);
 		final byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(content);
 
-		final PackageOffer matching = new PackageOffer("metricshub", "3.10.00", "https://repo/m.deb", sha256, Map.of());
+		final PackageOffer matching = new PackageOffer(
+			"metricshub",
+			"3.10.00",
+			"https://repo/m.deb",
+			sha256,
+			new byte[] { 7 },
+			Map.of()
+		);
 		assertDoesNotThrow(() -> validator.validateStagedPackage(stagedPackage, matching, config));
 
 		final PackageOffer mismatching = offer("3.10.00", "https://repo/m.deb");

--- a/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/validate/PackageValidatorTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/upgrade/validate/PackageValidatorTest.java
@@ -1,0 +1,155 @@
+package org.metricshub.agent.upgrade.validate;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.agent.config.UpgradeConfig;
+import org.metricshub.agent.upgrade.UpgradeException;
+import org.metricshub.agent.upgrade.api.PackageOffer;
+import org.metricshub.agent.upgrade.runner.DeploymentKind;
+
+class PackageValidatorTest {
+
+	private static final String CURRENT_VERSION = "3.9.05";
+
+	@TempDir
+	Path tempDir;
+
+	private final PackageValidator validator = new PackageValidator();
+	private final UpgradeConfig config = UpgradeConfig.builder().build();
+
+	private static PackageOffer offer(final String version, final String url) {
+		return new PackageOffer("metricshub", version, url, new byte[] { 1, 2, 3 }, Map.of());
+	}
+
+	@Test
+	void validOfferShouldPass() {
+		assertDoesNotThrow(() ->
+			validator.validateOffer(
+				offer("3.10.00", "https://repo/metricshub.deb"),
+				CURRENT_VERSION,
+				config,
+				DeploymentKind.DEB
+			)
+		);
+	}
+
+	@Test
+	void unsupportedDeploymentShouldBeRejected() {
+		assertThrows(UpgradeException.class, () ->
+			validator.validateOffer(
+				offer("3.10.00", "https://repo/metricshub.deb"),
+				CURRENT_VERSION,
+				config,
+				DeploymentKind.DOCKER
+			)
+		);
+	}
+
+	@Test
+	void mismatchedPackageTypeShouldBeRejected() {
+		assertThrows(UpgradeException.class, () ->
+			validator.validateOffer(
+				offer("3.10.00", "https://repo/metricshub.rpm"),
+				CURRENT_VERSION,
+				config,
+				DeploymentKind.DEB
+			)
+		);
+	}
+
+	@Test
+	void queryStringShouldNotDefeatTheExtensionCheck() {
+		assertDoesNotThrow(() ->
+			validator.validateOffer(
+				offer("3.10.00", "https://repo/metricshub.deb?token=abc"),
+				CURRENT_VERSION,
+				config,
+				DeploymentKind.DEB
+			)
+		);
+	}
+
+	@Test
+	void missingHashShouldBeRejected() {
+		final PackageOffer offer = new PackageOffer("metricshub", "3.10.00", "https://repo/m.deb", new byte[0], Map.of());
+		assertThrows(UpgradeException.class, () ->
+			validator.validateOffer(offer, CURRENT_VERSION, config, DeploymentKind.DEB)
+		);
+	}
+
+	@Test
+	void downgradeShouldBeRejectedByDefault() {
+		assertThrows(UpgradeException.class, () ->
+			validator.validateOffer(
+				offer("3.9.00", "https://repo/metricshub.deb"),
+				CURRENT_VERSION,
+				config,
+				DeploymentKind.DEB
+			)
+		);
+	}
+
+	@Test
+	void downgradeShouldBeAcceptedWhenAllowed() {
+		final UpgradeConfig allowing = UpgradeConfig.builder().allowDowngrade(true).build();
+		assertDoesNotThrow(() ->
+			validator.validateOffer(
+				offer("3.9.00", "https://repo/metricshub.deb"),
+				CURRENT_VERSION,
+				allowing,
+				DeploymentKind.DEB
+			)
+		);
+	}
+
+	@Test
+	void msiDowngradeShouldAlwaysBeRejected() {
+		final UpgradeConfig allowing = UpgradeConfig.builder().allowDowngrade(true).build();
+		assertThrows(UpgradeException.class, () ->
+			validator.validateOffer(
+				offer("3.9.00", "https://repo/metricshub.msi"),
+				CURRENT_VERSION,
+				allowing,
+				DeploymentKind.MSI
+			)
+		);
+	}
+
+	@Test
+	void stagedPackageValidationShouldVerifyTheHash() throws Exception {
+		final Path stagedPackage = tempDir.resolve("metricshub.deb");
+		final byte[] content = "package-content".getBytes();
+		Files.write(stagedPackage, content);
+		final byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(content);
+
+		final PackageOffer matching = new PackageOffer("metricshub", "3.10.00", "https://repo/m.deb", sha256, Map.of());
+		assertDoesNotThrow(() -> validator.validateStagedPackage(stagedPackage, matching, config));
+
+		final PackageOffer mismatching = offer("3.10.00", "https://repo/m.deb");
+		final UpgradeException failure = assertThrows(UpgradeException.class, () ->
+			validator.validateStagedPackage(stagedPackage, mismatching, config)
+		);
+		assertTrue(failure.getMessage().contains("SHA-256"));
+	}
+
+	@Test
+	void missingOrEmptyStagedPackageShouldBeRejected() throws Exception {
+		final PackageOffer offer = offer("3.10.00", "https://repo/m.deb");
+
+		assertThrows(UpgradeException.class, () ->
+			validator.validateStagedPackage(tempDir.resolve("missing.deb"), offer, config)
+		);
+
+		final Path empty = tempDir.resolve("empty.deb");
+		Files.createFile(empty);
+		assertThrows(UpgradeException.class, () -> validator.validateStagedPackage(empty, offer, config));
+	}
+}

--- a/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
@@ -22,6 +22,13 @@ otel:
 #   # pollInterval: 30s
 #   # reportHealth: true
 
+# Automatic upgrade policy (honored when OpAMP is enabled)
+# upgrade:
+#   enabled: true
+#   allowDowngrade: false
+#   hostAllowlist: [ repo.metricshub.com ]
+#   # trustedCertificateFile: /opt/metricshub/security/repo-ca.pem # Trusted certificate (PEM) for the package repository
+
 # Simple resource configuration
 resources:
 

--- a/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
@@ -22,6 +22,13 @@ otel:
 #   # pollInterval: 30s
 #   # reportHealth: true
 
+# Automatic upgrade policy (honored when OpAMP is enabled)
+# upgrade:
+#   enabled: true
+#   allowDowngrade: false
+#   hostAllowlist: [ repo.metricshub.com ]
+#   # trustedCertificateFile: C:\ProgramData\MetricsHub\security\repo-ca.pem # Trusted certificate (PEM) for the package repository
+
 # Simple resource configuration
 resources:
 


### PR DESCRIPTION
Part of **EPIC #1286 — MetricsHub / OpAMP**. Closes #1282. Base branch: `EPIC-OpAMP`. Builds on EPIC-OpAMP-01/02.

## What

The transactional upgrade engine behind the OpAMP `AcceptsPackages` capability. On package-manager based deployments (deb/rpm/msi), the agent now processes OpAMP package offers end-to-end up to the installation handoff, and reconciles the outcome after the restart.

### Pipeline (`org.metricshub.agent.upgrade`)

`IDLE → UPDATE_AVAILABLE → DOWNLOADING → VALIDATING → READY_TO_INSTALL → INSTALLING → RESTARTING → VERIFYING → SUCCEEDED|FAILED`

- **`UpgradeManager`** — single worker thread, one upgrade at a time (`UpgradeLock`: in-memory flag + lock file, exclusive across restarts). Same-version offers are answered idempotently (`Installed`); concurrent offers are ignored while one is in flight.
- **`PackageDownloader`** — HTTPS-only (loopback tolerated for dev/test), optional `hostAllowlist` + private CA (`trustedCertificateFile`), size cap enforced on both Content-Length and the streamed count, SHA-256 computed while streaming, `.part` staging + atomic rename, bounded retries, throttled progress forwarded as OpAMP `PackageDownloadDetails`.
- **`PackageValidator`** — package-type gate per deployment kind (query strings can't defeat the extension check), mandatory content hash re-verified from disk after staging, downgrade policy (`upgrade.allowDowngrade`, always refused on MSI where the installer forbids it), disk-space preflight.
- **`UpgradeTransaction` + store** — atomic JSON persistence in a staging directory that survives the upgrade (`%ProgramData%\MetricsHub\upgrade` on Windows, `<install>/lib/upgrade` elsewhere); corrupt files archived, terminal transactions archived with history.
- **`DeploymentDetector`** — docker marker/`.dockerenv`, `dpkg -s metricshub`, `rpm -q metricshub`, Windows service registry key; archive and container deployments never advertise `AcceptsPackages`.
- **Startup reconciliation** — runs in `MetricsHubAgentApplication.run()` before the OpAMP client starts: running version vs transaction target → `SUCCEEDED`/`FAILED`, staged files cleaned, stale locks released, verdict held as the first OpAMP report.
- **`OpampUpgradeAdapter`** — implements `OpampPackagesHandler`: translates the `metricshub` top-level package offer into the engine's `PackageOffer` and maps `UpgradeEvent`s onto `PackageStatusEnum` (Installed / InstallPending / Downloading / Installing / InstallFailed).

### Configuration

New top-level `upgrade:` section (honored when `opamp:` is enabled): `enabled` (true), `allowDowngrade` (false), `maxPackageSizeBytes` (1 GiB), `downloadTimeout` (30 m), `downloadRetries` (3), `installTimeout` (30 m), `hostAllowlist`, `trustedCertificateFile`. Wired into `AgentConfig` + `ReloadService`; `OpAmpService` re-gates the capability when `upgrade.enabled` toggles.

### Deliberately out of scope (EPIC-OpAMP-04)

`RunnerLauncher` is the platform hook for the detached installers (systemd transient unit / Windows scheduled task). Until they ship, the installation step fails with an explicit `InstallFailed` status after a successful download + validation — honest, testable behavior documented in the README.

## Validation

- `mvn prettier:write` ✅ / `mvn license:check-file-header` ✅ / `mvn checkstyle:check` ✅
- `mvn verify` on `metricshub-agent` ✅ — **770 tests, 0 failures** (4 skips: 3 pre-existing + 1 Linux-only probe test skipped by assumption on Windows)
- 45 new tests: full pipeline via scripted collaborators (state sequence, transaction + lock survival for reconciliation, progress publication), reconciliation truth table (version match/mismatch/qualifiers/pre-install interruption/terminal republish/stale lock), downloader against a loopback HTTP server (staging + hash, retry on mismatch, HTTP error, size cap, allowlist, plain-HTTP rejection, filename sanitization), validator matrix, detector probes, transaction store round-trip/corruption/archive, adapter proto mapping for every state

Affected modules: `metricshub-agent`, `metricshub-assets` (example configs), README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
