### PR TITLE
WinRM Fixes: Trust All TLS Certificates

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/cli/WinRmCli.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/WinRmCli.java
@@ -23,6 +23,7 @@ package org.metricshub.cli;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -160,14 +161,23 @@ public class WinRmCli implements IQuery, Callable<Integer> {
 	private String namespace;
 
 	@Option(
-		names = { "-h", "-?", "--help" },
+		names = "--trust-all-certificates",
 		order = 9,
+		paramLabel = "true|false",
+		arity = "1",
+		description = "Trusts all server certificates and skips hostname verification over HTTPS (default: true)"
+	)
+	private Boolean trustAllCertificates;
+
+	@Option(
+		names = { "-h", "-?", "--help" },
+		order = 10,
 		usageHelp = true,
 		description = "Shows this help message and exits"
 	)
 	boolean usageHelpRequested;
 
-	@Option(names = "-v", order = 10, description = "Verbose mode (repeat the option to increase verbosity)")
+	@Option(names = "-v", order = 11, description = "Verbose mode (repeat the option to increase verbosity)")
 	boolean[] verbose;
 
 	PrintWriter printWriter;
@@ -296,6 +306,10 @@ public class WinRmCli implements IQuery, Callable<Integer> {
 						final ArrayNode authenticationsNode = JsonNodeFactory.instance.arrayNode();
 						authentications.stream().forEach(authenticationsNode::add);
 						configurationNode.set("authentications", authenticationsNode);
+					}
+
+					if (trustAllCertificates != null) {
+						configurationNode.set("trustAllCertificates", BooleanNode.valueOf(trustAllCertificates));
 					}
 
 					// Build an IConfiguration from the configuration ObjectNode

--- a/metricshub-agent/src/main/java/org/metricshub/cli/service/protocol/WinRmConfigCli.java
+++ b/metricshub-agent/src/main/java/org/metricshub/cli/service/protocol/WinRmConfigCli.java
@@ -22,6 +22,7 @@ package org.metricshub.cli.service.protocol;
  */
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -123,6 +124,15 @@ public class WinRmConfigCli extends AbstractTransportProtocolCli {
 	@Option(names = "--winrm-hostname", order = 9, paramLabel = "HOSTNAME", description = "Hostname for WinRM")
 	private String hostname;
 
+	@Option(
+		names = "--winrm-trust-all-certificates",
+		order = 10,
+		paramLabel = "true|false",
+		arity = "1",
+		description = "Trusts all server certificates and skips hostname verification over HTTPS (default: true)"
+	)
+	private Boolean trustAllCertificates;
+
 	/**
 	 * @param defaultUsername Username specified at the top level of the CLI (with the --username option)
 	 * @param defaultPassword Password specified at the top level of the CLI (with the --password option)
@@ -147,6 +157,9 @@ public class WinRmConfigCli extends AbstractTransportProtocolCli {
 		configuration.set("protocol", new TextNode(protocol));
 		configuration.set("authentications", getAuthentications());
 		configuration.set("timeout", new TextNode(timeout));
+		if (trustAllCertificates != null) {
+			configuration.set("trustAllCertificates", BooleanNode.valueOf(trustAllCertificates));
+		}
 		IProtocolConfigCli.setIfNotNull(configuration, "hostname", hostname);
 
 		return CliExtensionManager.getExtensionManagerSingleton()

--- a/metricshub-agent/src/test/java/org/metricshub/cli/WinRmCliTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/cli/WinRmCliTest.java
@@ -2,6 +2,7 @@ package org.metricshub.cli;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,6 +63,20 @@ public class WinRmCliTest {
 		assertTrue(parameterException.getMessage().contains("Invalid authentication schema"));
 		winRmCli.setAuthentications(List.of("NTLM", "KERBEROS"));
 		assertDoesNotThrow(() -> winRmCli.validate());
+	}
+
+	@Test
+	void testTrustAllCertificatesOption() {
+		initCli();
+		// Not specified: left undefined so that the extension's own default (true) applies
+		commandLine.parseArgs("host", "--query", WINRM_TEST_QUERY);
+		assertNull(winRmCli.getTrustAllCertificates());
+
+		commandLine.parseArgs("host", "--query", WINRM_TEST_QUERY, "--trust-all-certificates", "false");
+		assertEquals(Boolean.FALSE, winRmCli.getTrustAllCertificates());
+
+		commandLine.parseArgs("host", "--query", WINRM_TEST_QUERY, "--trust-all-certificates", "true");
+		assertEquals(Boolean.TRUE, winRmCli.getTrustAllCertificates());
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/metricshub/cli/service/protocol/WinRmConfigCliTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/cli/service/protocol/WinRmConfigCliTest.java
@@ -1,7 +1,9 @@
 package org.metricshub.cli.service.protocol;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -63,6 +65,13 @@ class WinRmConfigCliTest {
 				.build();
 			// Check the resulting WinRm configuration
 			assertEquals(expected, winRmConfiguration);
+
+			// Certificates are trusted unless the CLI explicitly opts out
+			assertTrue(winRmConfiguration.isTrustAllCertificates());
+			winRmConfigCli.setTrustAllCertificates(false);
+			winRmConfiguration = (WinRmConfiguration) winRmConfigCli.toConfiguration(null, null);
+			assertFalse(winRmConfiguration.isTrustAllCertificates());
+			winRmConfigCli.setTrustAllCertificates(null);
 
 			// Check null password and null username
 			winRmConfigCli.setPassword(null);

--- a/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
@@ -232,6 +232,8 @@ resourceGroups:
       #       port: 5985
       #       protocol: http
       #       authentications: [ntlm, kerberos]
+      #       # Trusts all server certificates and skips hostname verification over HTTPS (default: true)
+      #       trustAllCertificates: true
 
       #═══════════════════════════════════════════════════
       # ESXi Host Configuration through WBEM service

--- a/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
@@ -232,6 +232,8 @@ resourceGroups:
       #       port: 5985
       #       protocol: http
       #       authentications: [ntlm, kerberos]
+      #       # Trusts all server certificates and skips hostname verification over HTTPS (default: true)
+      #       trustAllCertificates: true
 
       #═══════════════════════════════════════════════════
       # ESXi Host Configuration through WBEM service

--- a/metricshub-web/react/src/components/hosts/protocol-definitions.js
+++ b/metricshub-web/react/src/components/hosts/protocol-definitions.js
@@ -304,6 +304,7 @@ export const PROTOCOL_DEFAULTS = {
 		timeout: 30,
 		namespace: "",
 		authentications: "NTLM",
+		trustAllCertificates: true,
 		hostname: "",
 	},
 	wbem: {
@@ -570,6 +571,18 @@ export const PROTOCOL_FIELDS = {
 				{ value: WINRM_AUTH_KERBEROS, label: "Kerberos" },
 				{ value: WINRM_AUTH_BOTH, label: "NTLM and Kerberos" },
 			],
+		},
+		{
+			name: "trustAllCertificates",
+			label: "Trust all certificates",
+			type: "boolean",
+			advanced: true,
+			helperText:
+				"Trusts all server certificates and skips hostname verification over HTTPS (default: true)",
+			showIf: (values) =>
+				String(values.protocol ?? "")
+					.trim()
+					.toUpperCase() === "HTTPS",
 		},
 		{ name: "namespace", label: "Force namespace", type: "text", advanced: true },
 	],
@@ -966,6 +979,10 @@ export const buildProtocolConfigFromForm = (protocol, values) => {
 				if (!isDefaultNtlm) {
 					config.authentications = auths;
 				}
+			}
+			// The engine trusts all certificates by default: only an explicit opt-out is written.
+			if (raw.trustAllCertificates === false || raw.trustAllCertificates === "false") {
+				config.trustAllCertificates = false;
 			}
 			break;
 		case "wbem":

--- a/metricshub-web/react/src/components/hosts/protocol-definitions.js
+++ b/metricshub-web/react/src/components/hosts/protocol-definitions.js
@@ -547,7 +547,7 @@ export const PROTOCOL_FIELDS = {
 			type: "select",
 			required: true,
 			options: [
-				{ value: "HTTP", label: "HTTP" },
+				{ value: "HTTP", label: "HTTP (Encrypted)" },
 				{ value: "HTTPS", label: "HTTPS" },
 			],
 		},

--- a/metricshub-web/react/src/components/hosts/protocol-definitions.js
+++ b/metricshub-web/react/src/components/hosts/protocol-definitions.js
@@ -577,8 +577,7 @@ export const PROTOCOL_FIELDS = {
 			label: "Trust all certificates",
 			type: "boolean",
 			advanced: true,
-			helperText:
-				"Trusts all server certificates and skips hostname verification over HTTPS (default: true)",
+			helperText: "Trusts all server certificates and skips hostname verification over HTTPS",
 			showIf: (values) =>
 				String(values.protocol ?? "")
 					.trim()

--- a/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmConfiguration.java
+++ b/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmConfiguration.java
@@ -79,6 +79,20 @@ public class WinRmConfiguration implements IWinConfiguration {
 	@JsonDeserialize(using = TimeDeserializer.class)
 	private Long timeout = 120L;
 
+	/**
+	 * Whether to trust all the server certificates and skip the hostname verification when
+	 * connecting over HTTPS. Enabled by default: WinRM services are commonly exposed with the
+	 * self-signed certificate Windows generates for them. Set it to {@code false} to have the
+	 * certificate chain validated and the hostname verified during the handshake: the certificate,
+	 * or its issuing CA, must then be present in the trust store of the runtime embedded in
+	 * MetricsHub - {@code C:\Program Files\MetricsHub\runtime\lib\security\cacerts} on Windows,
+	 * {@code /opt/metricshub/lib/runtime/lib/security/cacerts} on Linux - or in the store designated
+	 * by {@code -Djavax.net.ssl.trustStore}.
+	 */
+	@Default
+	@JsonSetter(nulls = SKIP)
+	private boolean trustAllCertificates = true;
+
 	@Override
 	public void validateConfiguration(String resourceKey) throws InvalidConfigurationException {
 		StringHelper.validateConfigurationAttribute(
@@ -138,6 +152,7 @@ public class WinRmConfiguration implements IWinConfiguration {
 			.port(port)
 			.protocol(protocol)
 			.timeout(timeout)
+			.trustAllCertificates(trustAllCertificates)
 			.username(username)
 			.hostname(hostname)
 			.build();
@@ -159,6 +174,8 @@ public class WinRmConfiguration implements IWinConfiguration {
 				return getProtocol().toString();
 			case "timeout":
 				return getTimeout().toString();
+			case "trustallcertificates":
+				return String.valueOf(isTrustAllCertificates());
 			case "username":
 				return getUsername();
 			case "hostname":

--- a/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmExtension.java
+++ b/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmExtension.java
@@ -95,6 +95,7 @@ public class WinRmExtension implements IProtocolExtension {
 	 * Creates a new instance of the {@link WinRmExtension} implementation.
 	 */
 	public WinRmExtension() {
+		System.setProperty("org.metricshub.winrm.tls.insecure", "true");
 		winRmRequestExecutor = new WinRmRequestExecutor();
 		wmiDetectionService = new WmiDetectionService(winRmRequestExecutor);
 		winCommandService = new WinCommandService(winRmRequestExecutor);

--- a/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmExtension.java
+++ b/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmExtension.java
@@ -95,7 +95,6 @@ public class WinRmExtension implements IProtocolExtension {
 	 * Creates a new instance of the {@link WinRmExtension} implementation.
 	 */
 	public WinRmExtension() {
-		System.setProperty("org.metricshub.winrm.tls.insecure", "true");
 		winRmRequestExecutor = new WinRmRequestExecutor();
 		wmiDetectionService = new WmiDetectionService(winRmRequestExecutor);
 		winCommandService = new WinCommandService(winRmRequestExecutor);

--- a/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmRequestExecutor.java
+++ b/metricshub-winrm-extension/src/main/java/org/metricshub/extension/winrm/WinRmRequestExecutor.java
@@ -23,10 +23,9 @@ package org.metricshub.extension.winrm;
 
 import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.metricshub.engine.common.exception.ClientException;
@@ -37,13 +36,18 @@ import org.metricshub.engine.configuration.TransportProtocols;
 import org.metricshub.extension.win.IWinConfiguration;
 import org.metricshub.extension.win.IWinRequestExecutor;
 import org.metricshub.extension.win.WmiRecorder;
+import org.metricshub.winrm.AuthScheme;
+import org.metricshub.winrm.CommandResult;
+import org.metricshub.winrm.WinRMClient;
 import org.metricshub.winrm.WinRMHttpProtocolEnum;
-import org.metricshub.winrm.WindowsRemoteCommandResult;
-import org.metricshub.winrm.command.WinRMCommandExecutor;
+import org.metricshub.winrm.WqlRequest;
+import org.metricshub.winrm.WqlResult;
+import org.metricshub.winrm.WqlRow;
+import org.metricshub.winrm.exceptions.WinRMFaultException;
 import org.metricshub.winrm.exceptions.WindowsRemoteException;
 import org.metricshub.winrm.exceptions.WqlQuerySyntaxException;
+import org.metricshub.winrm.exceptions.WqlSyntaxException;
 import org.metricshub.winrm.service.client.auth.AuthenticationEnum;
-import org.metricshub.winrm.wql.WinRMWqlExecutor;
 
 /**
  * The WinRmRequestExecutor class provides utility methods for executing
@@ -51,6 +55,51 @@ import org.metricshub.winrm.wql.WinRMWqlExecutor;
  */
 @Slf4j
 public class WinRmRequestExecutor implements IWinRequestExecutor {
+
+	/**
+	 * Build the {@link WinRMClient} that carries out a request on the given host: transport, port,
+	 * credentials, authentication schemes, timeout and TLS trust policy all come from the WinRM
+	 * configuration. Nothing is connected yet: the first operation authenticates and, when several
+	 * operations run on the same client, they share that single authenticated connection.
+	 *
+	 * @param hostname           The hostname of the device where the WinRM service is running
+	 * @param winRmConfiguration WinRM Protocol configuration (credentials, timeout, ...)
+	 * @return A new client, to be closed once the operation is over
+	 */
+	static WinRMClient newClient(final String hostname, final WinRmConfiguration winRmConfiguration) {
+		final WinRMClient.Builder builder = WinRMClient.builder(hostname)
+			.credentials(winRmConfiguration.getUsername(), winRmConfiguration.getPassword())
+			.timeout(Duration.ofSeconds(winRmConfiguration.getTimeout()));
+
+		if (TransportProtocols.HTTP.equals(winRmConfiguration.getProtocol())) {
+			builder.http();
+		} else {
+			builder.https();
+		}
+
+		final Integer port = winRmConfiguration.getPort();
+		if (port != null) {
+			builder.port(port);
+		}
+
+		final List<AuthenticationEnum> authentications = winRmConfiguration.getAuthentications();
+		if (authentications != null && !authentications.isEmpty()) {
+			builder.authentication(
+				authentications
+					.stream()
+					.map(authentication ->
+						AuthenticationEnum.KERBEROS.equals(authentication) ? AuthScheme.KERBEROS : AuthScheme.NTLM
+					)
+					.toArray(AuthScheme[]::new)
+			);
+		}
+
+		if (winRmConfiguration.isTrustAllCertificates()) {
+			builder.trustAllCertificates();
+		}
+
+		return builder.build();
+	}
 
 	/**
 	 * Execute a WinRM query
@@ -102,29 +151,28 @@ public class WinRmRequestExecutor implements IWinRequestExecutor {
 		try {
 			final long startTime = System.currentTimeMillis();
 
-			WinRMWqlExecutor result = WinRMWqlExecutor.executeWql(
-				httpProtocol,
-				hostname,
-				port,
-				username,
-				winRmConfiguration.getPassword(),
-				namespace,
-				query,
-				timeout * 1000L,
-				null,
-				authentications
-			);
+			final WqlResult result;
+			try (WinRMClient client = newClient(hostname, winRmConfiguration)) {
+				final WqlRequest request = client.wql(query);
+				if (!namespace.isBlank()) {
+					request.namespace(namespace);
+				}
+				result = request.execute();
+			}
 
 			final long responseTime = System.currentTimeMillis() - startTime;
 
 			// The engine's compute steps mutate the result in place (add columns, transform rows,
-			// ...): deep-copy the executor's unmodifiable (and possibly null) rows into mutable lists.
-			// List.of() is only the stream source; the collector always yields a mutable ArrayList.
-			final List<List<String>> table = Optional.ofNullable(result.getRows())
-				.orElseGet(List::of)
-				.stream()
-				.map(row -> (List<String>) new ArrayList<>(row))
-				.collect(Collectors.toCollection(ArrayList::new));
+			// ...): build mutable lists, with the columns in the order the query declares them.
+			final List<String> columns = result.columns();
+			final List<List<String>> table = new ArrayList<>(result.size());
+			for (final WqlRow row : result) {
+				final List<String> values = new ArrayList<>(columns.size());
+				for (final String column : columns) {
+					values.add(row.string(column));
+				}
+				table.add(values);
+			}
 
 			LoggingHelper.trace(() ->
 				log.trace(
@@ -160,10 +208,15 @@ public class WinRmRequestExecutor implements IWinRequestExecutor {
 			return false;
 		}
 
-		if (t instanceof WindowsRemoteException) {
+		if (t instanceof WinRMFaultException winRmFaultException) {
+			// The provider-level detail is where WMI reports its WBEM_E_* mnemonics; the fault message
+			// repeats it, and is the only place it shows up on a fault carrying no detail element.
+			final String faultDetail = winRmFaultException.getFaultDetail();
+			return IWinRequestExecutor.isAcceptableWmiComError(faultDetail == null ? t.getMessage() : faultDetail);
+		} else if (t instanceof WindowsRemoteException) {
 			final String message = t.getMessage();
 			return IWinRequestExecutor.isAcceptableWmiComError(message);
-		} else if (t instanceof WqlQuerySyntaxException) {
+		} else if (t instanceof WqlQuerySyntaxException || t instanceof WqlSyntaxException) {
 			return true;
 		}
 
@@ -226,28 +279,19 @@ public class WinRmRequestExecutor implements IWinRequestExecutor {
 		try {
 			final long startTime = System.currentTimeMillis();
 
-			WindowsRemoteCommandResult result = WinRMCommandExecutor.execute(
-				command,
-				httpProtocol,
-				hostname,
-				port,
-				username,
-				winRmConfiguration.getPassword(),
-				null,
-				timeout * 1000L,
-				null,
-				null,
-				authentications
-			);
+			final CommandResult result;
+			try (WinRMClient client = newClient(hostname, winRmConfiguration)) {
+				result = client.command(command).execute();
+			}
 
 			final long responseTime = System.currentTimeMillis() - startTime;
 
 			// If the command returns an error
-			if (result.getStatusCode() != 0) {
-				throw new ClientException(String.format("WinRM remote command failed on %s: %s", hostname, result.getStderr()));
+			if (result.exitCode() != 0) {
+				throw new ClientException(String.format("WinRM remote command failed on %s: %s", hostname, result.stderr()));
 			}
 
-			final String resultStdout = result.getStdout();
+			final String resultStdout = result.stdout();
 
 			LoggingHelper.trace(() ->
 				log.trace(

--- a/metricshub-winrm-extension/src/test/java/org/metricshub/extension/winrm/WinRmConfigurationTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/metricshub/extension/winrm/WinRmConfigurationTest.java
@@ -51,6 +51,13 @@ class WinRmConfigurationTest {
 	}
 
 	@Test
+	void testTrustAllCertificatesDefaultsToTrue() {
+		assertTrue(new WinRmConfiguration().isTrustAllCertificates());
+		assertTrue(WinRmConfiguration.builder().build().isTrustAllCertificates());
+		assertFalse(WinRmConfiguration.builder().trustAllCertificates(false).build().isTrustAllCertificates());
+	}
+
+	@Test
 	void testCopy() {
 		final WinRmConfiguration winRmConfiguration = WinRmConfiguration.builder()
 			.authentications(List.of(AuthenticationEnum.KERBEROS))
@@ -59,6 +66,7 @@ class WinRmConfigurationTest {
 			.port(100)
 			.protocol(TransportProtocols.HTTPS)
 			.timeout(100L)
+			.trustAllCertificates(false)
 			.username("username")
 			.build();
 
@@ -95,6 +103,7 @@ class WinRmConfigurationTest {
 		assertEquals("myUsername", winRmConfiguration.getProperty("username"));
 		assertEquals("100", winRmConfiguration.getProperty("timeout"));
 		assertEquals("myHostname", winRmConfiguration.getProperty("hostname"));
+		assertEquals("true", winRmConfiguration.getProperty("trustAllCertificates"));
 	}
 
 	@Test

--- a/metricshub-winrm-extension/src/test/java/org/metricshub/extension/winrm/WinRmRequestExecutorTest.java
+++ b/metricshub-winrm-extension/src/test/java/org/metricshub/extension/winrm/WinRmRequestExecutorTest.java
@@ -1,11 +1,18 @@
 package org.metricshub.extension.winrm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.metricshub.engine.configuration.TransportProtocols;
+import org.metricshub.winrm.WinRMClient;
+import org.metricshub.winrm.exceptions.WinRMFaultException;
 import org.metricshub.winrm.exceptions.WindowsRemoteException;
 import org.metricshub.winrm.exceptions.WqlQuerySyntaxException;
+import org.metricshub.winrm.exceptions.WqlSyntaxException;
+import org.metricshub.winrm.service.client.auth.AuthenticationEnum;
 
 class WinRmRequestExecutorTest {
 
@@ -31,5 +38,78 @@ class WinRmRequestExecutorTest {
 			)
 		);
 		assertTrue(winRmRequestExecutor.isAcceptableException(new RuntimeException(new WqlQuerySyntaxException(""))));
+	}
+
+	@Test
+	void testIsAcceptableExceptionWithFluentApiExceptions() {
+		final WinRmRequestExecutor winRmRequestExecutor = new WinRmRequestExecutor();
+
+		// The WBEM_E_* mnemonic is reported in the provider-level fault detail
+		assertTrue(
+			winRmRequestExecutor.isAcceptableException(
+				new WinRMFaultException("Fault", 500, "2150858778", "reason", "WBEM_E_INVALID_NAMESPACE")
+			)
+		);
+		// ... or only in the message, when the remote service left the detail out
+		assertTrue(
+			winRmRequestExecutor.isAcceptableException(
+				new RuntimeException(new WinRMFaultException("WBEM_E_INVALID_CLASS", 500, null, null, null))
+			)
+		);
+		assertFalse(
+			winRmRequestExecutor.isAcceptableException(new WinRMFaultException("Fault", 500, null, "reason", "other"))
+		);
+
+		assertTrue(winRmRequestExecutor.isAcceptableException(new WqlSyntaxException("bad query", new Exception())));
+	}
+
+	/**
+	 * Building a client establishes no connection, so the whole configuration-to-client mapping can
+	 * be exercised offline.
+	 */
+	@Test
+	void testNewClient() {
+		// HTTP with the configuration defaults: port 5985, NTLM, trust all certificates
+		try (
+			WinRMClient client = WinRmRequestExecutor.newClient(
+				"host",
+				WinRmConfiguration.builder().username("user").password("pass".toCharArray()).timeout(30L).build()
+			)
+		) {
+			assertEquals("host", client.hostname());
+		}
+
+		// HTTPS with no port (the library deduces 5986), Kerberos first, and certificate validation on
+		try (
+			WinRMClient client = WinRmRequestExecutor.newClient(
+				"host",
+				WinRmConfiguration.builder()
+					.username("DOMAIN\\user")
+					.password("pass".toCharArray())
+					.protocol(TransportProtocols.HTTPS)
+					.port(null)
+					.authentications(List.of(AuthenticationEnum.KERBEROS, AuthenticationEnum.NTLM))
+					.trustAllCertificates(false)
+					.timeout(30L)
+					.build()
+			)
+		) {
+			assertEquals("host", client.hostname());
+		}
+
+		// An empty authentication list leaves the library's own default (NTLM) in place
+		try (
+			WinRMClient client = WinRmRequestExecutor.newClient(
+				"host",
+				WinRmConfiguration.builder()
+					.username("user")
+					.password("pass".toCharArray())
+					.authentications(List.of())
+					.timeout(30L)
+					.build()
+			)
+		) {
+			assertEquals("host", client.hostname());
+		}
 	}
 }


### PR DESCRIPTION
UI: Added '(Encrypted)' to the HTTP protocol for WinRM option

Added support for trustAllCertificates option in WinRM configuration
to allow connections to servers with self-signed or untrusted certificates.
This change includes updates to the CLI, configuration classes, and test
cases to ensure proper handling of this new option.