### PR TITLE
EPIC-OpAMP-07: Harden the OpAMP client against malformed input and failing callbacks

### DIFF
--- a/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/OpampClientSettings.java
+++ b/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/OpampClientSettings.java
@@ -113,7 +113,7 @@ public class OpampClientSettings {
 	 * @param instanceUidFile the file persisting the agent instance UID
 	 * @param reportHealth    whether the agent health is reported
 	 */
-	OpampClientSettings(
+	public OpampClientSettings(
 		@NonNull final URI endpoint,
 		final Map<String, String> headers,
 		final String certificateFile,

--- a/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/OpampClientSettings.java
+++ b/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/OpampClientSettings.java
@@ -98,4 +98,38 @@ public class OpampClientSettings {
 	 */
 	@Builder.Default
 	boolean reportHealth = true;
+
+	/**
+	 * Creates the settings, storing an immutable copy of the headers so a caller-supplied mutable
+	 * map can neither be mutated after construction (silently dropping authentication from later
+	 * requests) nor be mutated concurrently while a request iterates it.
+	 *
+	 * @param endpoint        the OpAMP server endpoint
+	 * @param headers         the headers sent with every request; {@code null} means none
+	 * @param certificateFile the trusted certificate (PEM) path, or {@code null}
+	 * @param pollInterval    the interval between two polls
+	 * @param requestTimeout  the timeout of one HTTP exchange
+	 * @param maxBackoff      the maximum backoff delay
+	 * @param instanceUidFile the file persisting the agent instance UID
+	 * @param reportHealth    whether the agent health is reported
+	 */
+	OpampClientSettings(
+		@NonNull final URI endpoint,
+		final Map<String, String> headers,
+		final String certificateFile,
+		final Duration pollInterval,
+		final Duration requestTimeout,
+		final Duration maxBackoff,
+		@NonNull final Path instanceUidFile,
+		final boolean reportHealth
+	) {
+		this.endpoint = endpoint;
+		this.headers = headers == null ? Map.of() : Map.copyOf(headers);
+		this.certificateFile = certificateFile;
+		this.pollInterval = pollInterval;
+		this.requestTimeout = requestTimeout;
+		this.maxBackoff = maxBackoff;
+		this.instanceUidFile = instanceUidFile;
+		this.reportHealth = reportHealth;
+	}
 }

--- a/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/impl/HttpPollingOpampClient.java
+++ b/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/impl/HttpPollingOpampClient.java
@@ -68,6 +68,11 @@ public class HttpPollingOpampClient implements OpampClient {
 	private static final String POLLING_THREAD_NAME = "metricshub-opamp-client";
 	private static final Duration DISCONNECT_TIMEOUT = Duration.ofSeconds(5);
 
+	/**
+	 * Required length in bytes of an OpAMP agent instance UID.
+	 */
+	private static final int INSTANCE_UID_LENGTH = 16;
+
 	private final OpampClientSettings settings;
 	private final OpampClientCallbacks callbacks;
 	private final OpampTransport transport;
@@ -322,7 +327,7 @@ public class HttpPollingOpampClient implements OpampClient {
 		retrySchedule.reset();
 		if (!connected) {
 			connected = true;
-			callbacks.onConnect();
+			safely("onConnect", callbacks::onConnect);
 		}
 
 		if (response.hasAgentIdentification()) {
@@ -341,7 +346,7 @@ public class HttpPollingOpampClient implements OpampClient {
 			dispatchPackagesAvailable(response);
 		}
 
-		callbacks.onMessage(response);
+		safely("onMessage", () -> callbacks.onMessage(response));
 		return nextDelay;
 	}
 
@@ -354,7 +359,7 @@ public class HttpPollingOpampClient implements OpampClient {
 	 */
 	private Duration processErrorResponse(final ServerErrorResponse errorResponse) {
 		log.warn("The OpAMP server reported an error: {} - {}", errorResponse.getType(), errorResponse.getErrorMessage());
-		callbacks.onErrorResponse(errorResponse);
+		safely("onErrorResponse", () -> callbacks.onErrorResponse(errorResponse));
 		if (errorResponse.getType() == ServerErrorResponseType.ServerErrorResponseType_Unavailable) {
 			final Duration floor = errorResponse.hasRetryInfo()
 				? Duration.ofNanos(errorResponse.getRetryInfo().getRetryAfterNanoseconds())
@@ -365,12 +370,22 @@ public class HttpPollingOpampClient implements OpampClient {
 	}
 
 	/**
-	 * Adopts the new instance UID assigned by the server and persists it.
+	 * Adopts the new instance UID assigned by the server and persists it. A malformed UID (the
+	 * OpAMP specification requires exactly 16 bytes) is rejected without touching the in-memory or
+	 * the persisted identity, so a bad server response cannot permanently poison the client.
 	 *
-	 * @param newInstanceUid the new instance UID; empty values are ignored
+	 * @param newInstanceUid the new instance UID; empty and malformed values are ignored
 	 */
 	private void adoptNewInstanceUid(final ByteString newInstanceUid) {
 		if (newInstanceUid.isEmpty()) {
+			return;
+		}
+		if (newInstanceUid.size() != INSTANCE_UID_LENGTH) {
+			log.warn(
+				"The OpAMP server assigned a malformed instance UID of {} bytes ({} expected); it is ignored.",
+				newInstanceUid.size(),
+				INSTANCE_UID_LENGTH
+			);
 			return;
 		}
 		// The new identity must be used for all further communication even when persisting it
@@ -433,8 +448,25 @@ public class HttpPollingOpampClient implements OpampClient {
 		connected = false;
 		final Duration delay = retrySchedule.nextDelayAfterFailure(floor);
 		log.warn("OpAMP exchange failed ({}); next attempt in {} seconds.", error.getMessage(), delay.toSeconds());
-		callbacks.onConnectFailed(error, delay);
+		safely("onConnectFailed", () -> callbacks.onConnectFailed(error, delay));
 		return delay;
+	}
+
+	/**
+	 * Invokes a client callback, containing any failure it may throw: a consumer callback must
+	 * never be able to break the polling chain (a failure escaping the poll loop's catch block
+	 * would skip the rescheduling and stop the client permanently).
+	 *
+	 * @param name     the callback name, used for logging
+	 * @param callback the callback invocation
+	 */
+	private static void safely(final String name, final Runnable callback) {
+		try {
+			callback.run();
+		} catch (Exception e) {
+			log.error("The OpAMP client callback {} failed: {}", name, e.getMessage());
+			log.debug("The OpAMP client callback {} failed:", name, e);
+		}
 	}
 
 	/**

--- a/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/impl/HttpPollingOpampClient.java
+++ b/metricshub-opamp-client/src/main/java/org/metricshub/opamp/client/impl/HttpPollingOpampClient.java
@@ -455,7 +455,9 @@ public class HttpPollingOpampClient implements OpampClient {
 	/**
 	 * Invokes a client callback, containing any failure it may throw: a consumer callback must
 	 * never be able to break the polling chain (a failure escaping the poll loop's catch block
-	 * would skip the rescheduling and stop the client permanently).
+	 * would skip the rescheduling and stop the client permanently). Errors such as
+	 * {@link AssertionError} are contained too; only {@link VirtualMachineError}s (e.g.
+	 * {@link OutOfMemoryError}) are rethrown, as the JVM is no longer trustworthy.
 	 *
 	 * @param name     the callback name, used for logging
 	 * @param callback the callback invocation
@@ -463,7 +465,9 @@ public class HttpPollingOpampClient implements OpampClient {
 	private static void safely(final String name, final Runnable callback) {
 		try {
 			callback.run();
-		} catch (Exception e) {
+		} catch (VirtualMachineError e) {
+			throw e;
+		} catch (Throwable e) {
 			log.error("The OpAMP client callback {} failed: {}", name, e.getMessage());
 			log.debug("The OpAMP client callback {} failed:", name, e);
 		}

--- a/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/OpampClientSettingsTest.java
+++ b/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/OpampClientSettingsTest.java
@@ -1,0 +1,46 @@
+package org.metricshub.opamp.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpampClientSettingsTest {
+
+	private static OpampClientSettings.OpampClientSettingsBuilder builder() {
+		return OpampClientSettings.builder()
+			.withEndpoint(URI.create("https://opamp.example.com/v1/opamp"))
+			.withInstanceUidFile(Path.of("instance-uid"));
+	}
+
+	@Test
+	void headersShouldBeDefensivelyCopied() {
+		final Map<String, String> mutable = new HashMap<>();
+		mutable.put("Authorization", "Bearer token");
+
+		final OpampClientSettings settings = builder().withHeaders(mutable).build();
+
+		// Mutating the caller's map must not affect the settings: dropping the Authorization
+		// header after construction would silently unauthenticate every later request
+		mutable.remove("Authorization");
+		mutable.put("X-Injected", "value");
+
+		assertEquals(Map.of("Authorization", "Bearer token"), settings.getHeaders());
+	}
+
+	@Test
+	void exposedHeadersShouldBeImmutable() {
+		final OpampClientSettings settings = builder().withHeaders(Map.of("Authorization", "Bearer token")).build();
+
+		assertThrows(UnsupportedOperationException.class, () -> settings.getHeaders().put("X-Injected", "value"));
+	}
+
+	@Test
+	void headersShouldDefaultToAnEmptyMap() {
+		assertEquals(Map.of(), builder().build().getHeaders());
+	}
+}

--- a/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/impl/HttpPollingOpampClientTest.java
+++ b/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/impl/HttpPollingOpampClientTest.java
@@ -283,6 +283,68 @@ class HttpPollingOpampClientTest {
 	}
 
 	@Test
+	void malformedNewInstanceUidShouldBeIgnored() throws Exception {
+		newClient(null, null);
+		transport.enqueue(
+			RecordingTransport.ScriptedReply.ok(
+				ServerToAgent.newBuilder()
+					.setAgentIdentification(
+						AgentIdentification.newBuilder().setNewInstanceUid(ByteString.copyFrom(new byte[] { 1, 2, 3 })).build()
+					)
+					.build()
+			)
+		);
+		client.start();
+
+		final AgentToServer first = transport.awaitRequest(AWAIT);
+		final AgentToServer second = transport.awaitRequest(AWAIT);
+
+		// A UID that is not 16 bytes long is rejected: the client keeps its own identity and the
+		// persisted identity is untouched
+		assertEquals(first.getInstanceUid(), second.getInstanceUid());
+		assertEquals(16, second.getInstanceUid().size());
+		assertEquals(
+			UuidV7.toCanonicalString(first.getInstanceUid().toByteArray()),
+			Files.readString(tempDir.resolve("instance-uid")).trim()
+		);
+	}
+
+	@Test
+	void failingCallbacksShouldNotBreakThePollingChain() throws Exception {
+		final CountDownLatch pollsAfterFailure = new CountDownLatch(3);
+		final OpampClientCallbacks throwingCallbacks = new OpampClientCallbacks() {
+			@Override
+			public void onConnect() {
+				throw new IllegalStateException("Simulated onConnect failure");
+			}
+
+			@Override
+			public void onConnectFailed(final Throwable error, final Duration nextAttemptDelay) {
+				throw new IllegalStateException("Simulated onConnectFailed failure");
+			}
+
+			@Override
+			public void onMessage(final ServerToAgent message) {
+				throw new IllegalStateException("Simulated onMessage failure");
+			}
+		};
+
+		newClient(throwingCallbacks, null);
+		// First exchange fails at the transport level (onConnectFailed throws), the rest succeed
+		// (onConnect and onMessage throw)
+		transport.enqueue(RecordingTransport.ScriptedReply.networkFailure());
+		client.start();
+
+		// The polling chain must survive every callback failure
+		for (int i = 0; i < 3; i++) {
+			transport.awaitRequest(AWAIT);
+			pollsAfterFailure.countDown();
+		}
+		assertEquals(0, pollsAfterFailure.getCount());
+		assertTrue(client.isStarted());
+	}
+
+	@Test
 	void stopShouldSendAgentDisconnect() throws Exception {
 		newClient(null, null);
 		client.start();

--- a/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/impl/HttpPollingOpampClientTest.java
+++ b/metricshub-opamp-client/src/test/java/org/metricshub/opamp/client/impl/HttpPollingOpampClientTest.java
@@ -345,6 +345,25 @@ class HttpPollingOpampClientTest {
 	}
 
 	@Test
+	void errorThrowingCallbacksShouldNotBreakThePollingChain() throws Exception {
+		final OpampClientCallbacks throwingCallbacks = new OpampClientCallbacks() {
+			@Override
+			public void onConnect() {
+				throw new AssertionError("Simulated onConnect assertion failure");
+			}
+		};
+
+		newClient(throwingCallbacks, null);
+		client.start();
+
+		// The polling chain must survive callbacks throwing Errors, not only Exceptions
+		for (int i = 0; i < 3; i++) {
+			transport.awaitRequest(AWAIT);
+		}
+		assertTrue(client.isStarted());
+	}
+
+	@Test
 	void stopShouldSendAgentDisconnect() throws Exception {
 		newClient(null, null);
 		client.start();


### PR DESCRIPTION
Part of **EPIC #1286 — MetricsHub / OpAMP**. Base branch: `EPIC-OpAMP`.

Addresses the three Codex findings on the epic-integration PR #1288, all in the `metricshub-opamp-client` foundation module. All three are genuine robustness bugs rather than style points, so they are fixed rather than declined.

## Fixes

**1. Malformed server-assigned instance UID poisoned the client permanently** — `adoptNewInstanceUid` set the assembler's UID before persisting it. For a `new_instance_uid` that is not 16 bytes, `InstanceUidStore.store()` then threw an unchecked `IllegalArgumentException`, which the poll loop treated as a transport failure — but the assembler had already adopted the malformed UID, so *every* subsequent request carried an invalid identity and no later valid response could recover it. The length is now validated (the OpAMP specification requires exactly 16 bytes) before either the in-memory or the persisted identity is touched; a malformed UID is logged and ignored.

**2. A throwing callback could kill the polling chain forever** — `onTransportFailure` invoked `onConnectFailed` from inside `pollOnce`'s catch block. An unchecked exception from a consumer callback therefore escaped that catch block, skipped `scheduleNext(...)`, and stopped the client permanently — no reconnection, no further polls. All four callback invocations (`onConnect`, `onConnectFailed`, `onErrorResponse`, `onMessage`) now go through a `safely(...)` wrapper that logs and swallows callback failures. A consumer bug can no longer disable remote management.

**3. Request headers were not defensively copied** — `OpampClientSettings` is documented (and annotated `@Value`) as immutable, and `PackageDownloadContext.headers()` promises an immutable map, but Lombok's generated constructor retained and exposed the caller's map. Mutating it after construction could silently remove authentication from later requests, and concurrent mutation while `send()` iterates it could fail exchanges repeatedly. An explicit constructor now stores `Map.copyOf(headers)` (empty map when null).

## Validation

- `mvn prettier:write` ✅ / `mvn license:check-file-header` ✅ / `mvn checkstyle:check` ✅
- `mvn verify` on `metricshub-opamp-client` ✅ — **49 unit tests + 4 ITs**, 0 failures, coverage gate met
- 5 new tests: malformed UID ignored (identity and persisted file untouched), polling chain survives callbacks throwing on connect/failure/message, header defensive copy, exposed-map immutability, empty-map default

Affected module: `metricshub-opamp-client` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
