### PR TITLE
EPIC-OpAMP-05: CI upgrade scenarios for the detached runners

### DIFF
--- a/.github/scripts/upgrade-test-linux.sh
+++ b/.github/scripts/upgrade-test-linux.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Drives the detached upgrade runner end-to-end inside a systemd container, exactly as the
+# MetricsHub agent launches it (systemd-run transient one-shot unit), and asserts the outcome.
+#
+# Scenarios (per package type):
+#   corrupted  - a corrupted staged package with the pristine hash: the runner must fail with
+#                exit 10 (hash re-check) and leave the installed service untouched
+#   upgrade    - deb only: a baseline repacked as version 1.0.0 is upgraded to the built package
+#                (released N-1 deb/rpm packages are not retrievable: GitHub releases only carry
+#                archives, so the baseline is derived from the built package itself)
+#   reinstall  - rpm only: the built package is force-reinstalled over itself, the same-version
+#                hotfix path (--mode reinstall)
+#
+# Usage: upgrade-test-linux.sh <idPrefix> <osLabel> <deb|rpm> <packagePattern>
+
+set -euo pipefail
+
+ID_PREFIX="$1"
+OS_LABEL="$2"
+PACKAGE_TYPE="$3"
+PACKAGE_PATTERN="$4"
+
+ARCH="amd64"
+CONTAINER="metricshub-upgrade-${PACKAGE_TYPE}"
+RUNNER_SCRIPT="metricshub-assets/src/main/resources/linux/upgrade-runner/metricshub-upgrade-runner.sh"
+STAGING="/opt/metricshub/lib/upgrade"
+RESULTS_DIR="results"
+FAILURES=0
+
+mkdir -p "${RESULTS_DIR}"
+
+log() {
+	printf '=== %s\n' "$1"
+}
+
+record() {
+	local scenario="$1" status="$2" details="$3"
+	jq -n \
+		--arg scenario "${scenario}" \
+		--arg os "${OS_LABEL}" \
+		--arg packageType "${PACKAGE_TYPE}" \
+		--arg arch "${ARCH}" \
+		--arg status "${status}" \
+		--arg details "${details}" \
+		'{scenario: $scenario, os: $os, packageType: $packageType, arch: $arch, status: $status, details: $details}' \
+		> "${RESULTS_DIR}/${scenario}.json"
+	if [ "${status}" != "passed" ]; then
+		FAILURES=$((FAILURES + 1))
+		log "FAILED ${scenario}: ${details}"
+		diagnostics "${scenario}"
+	else
+		log "PASSED ${scenario}: ${details}"
+	fi
+}
+
+diagnostics() {
+	local scenario="$1"
+	{
+		echo "--- runner.result ---"
+		docker exec "${CONTAINER}" cat "${STAGING}/runner.result" 2>&1 || true
+		echo "--- runner.log ---"
+		docker exec "${CONTAINER}" cat "${STAGING}/runner.log" 2>&1 || true
+		echo "--- journal (upgrade units) ---"
+		docker exec "${CONTAINER}" sh -c 'journalctl --no-pager -u "metricshub-upgrade-*" 2>&1 | tail -n 80' || true
+		echo "--- service status ---"
+		docker exec "${CONTAINER}" systemctl --no-pager status "${SERVICE_UNIT:-unknown}" 2>&1 | tail -n 30 || true
+	} > "${RESULTS_DIR}/${scenario}.log" 2>&1 || true
+}
+
+cleanup() {
+	docker rm -f "${CONTAINER}" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ------------------------------------------------------------------------------------------------
+# Locate the built package
+# ------------------------------------------------------------------------------------------------
+PACKAGE_FILE=$(find packages -maxdepth 1 -type f -name "${PACKAGE_PATTERN}" | head -n 1)
+if [ -z "${PACKAGE_FILE}" ]; then
+	record "${ID_PREFIX}-setup" "failed" "package not found for pattern ${PACKAGE_PATTERN}"
+	exit 1
+fi
+PACKAGE_NAME=$(basename "${PACKAGE_FILE}")
+PACKAGE_SHA256=$(sha256sum "${PACKAGE_FILE}" | awk '{print $1}')
+log "Package under test: ${PACKAGE_NAME} (sha256 ${PACKAGE_SHA256})"
+
+# ------------------------------------------------------------------------------------------------
+# Prepare the systemd container image and, for deb, the older baseline package
+# ------------------------------------------------------------------------------------------------
+if [ "${PACKAGE_TYPE}" = "deb" ]; then
+	IMAGE="metricshub-systemd-debian:local"
+	docker build -t "${IMAGE}" - <<'DOCKERFILE'
+FROM debian:12
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends systemd systemd-sysv procps ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+CMD ["/sbin/init"]
+DOCKERFILE
+
+	# Baseline: the built package repacked as version 1.0.0 (identical payload and scriptlets)
+	log "Repacking ${PACKAGE_NAME} as baseline version 1.0.0"
+	REPACK_DIR=$(mktemp -d)
+	dpkg-deb -R "${PACKAGE_FILE}" "${REPACK_DIR}/root"
+	sed -i 's/^Version: .*/Version: 1.0.0/' "${REPACK_DIR}/root/DEBIAN/control"
+	dpkg-deb --root-owner-group -b "${REPACK_DIR}/root" "packages/baseline_1.0.0_${ARCH}.deb" > /dev/null
+	BASELINE_NAME="baseline_1.0.0_${ARCH}.deb"
+else
+	IMAGE="registry.access.redhat.com/ubi9/ubi-init"
+	BASELINE_NAME="${PACKAGE_NAME}"
+fi
+
+# ------------------------------------------------------------------------------------------------
+# Boot systemd
+# ------------------------------------------------------------------------------------------------
+log "Starting the systemd container (${IMAGE})"
+docker run -d --name "${CONTAINER}" \
+	--privileged \
+	--cgroupns=host \
+	--tmpfs /run --tmpfs /run/lock \
+	-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+	-v "${PWD}/packages:/tmp/packages:ro" \
+	-v "${PWD}/$(dirname "${RUNNER_SCRIPT}"):/tmp/runner:ro" \
+	"${IMAGE}" /sbin/init > /dev/null
+
+for _ in $(seq 1 30); do
+	STATE=$(docker exec "${CONTAINER}" systemctl is-system-running 2>/dev/null || true)
+	case "${STATE}" in
+		running|degraded) break ;;
+	esac
+	sleep 2
+done
+log "systemd state: ${STATE:-unknown}"
+
+# ------------------------------------------------------------------------------------------------
+# Install the baseline and ensure the service is active
+# ------------------------------------------------------------------------------------------------
+log "Installing the baseline package ${BASELINE_NAME}"
+if [ "${PACKAGE_TYPE}" = "deb" ]; then
+	docker exec "${CONTAINER}" sh -c "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y /tmp/packages/${BASELINE_NAME}" > /dev/null
+else
+	docker exec "${CONTAINER}" dnf install -y "/tmp/packages/${BASELINE_NAME}" > /dev/null
+fi
+
+# Discover the service unit the same way ServiceNameResolver does
+SERVICE_UNIT=$(docker exec "${CONTAINER}" sh -c 'ls /lib/systemd/system/metricshub-*-service.service /etc/systemd/system/metricshub-*-service.service 2>/dev/null | head -n 1 | xargs -r basename')
+if [ -z "${SERVICE_UNIT}" ]; then
+	record "${ID_PREFIX}-setup" "failed" "no metricshub-*-service.service unit found after baseline installation"
+	exit 1
+fi
+log "Service unit: ${SERVICE_UNIT}"
+
+docker exec "${CONTAINER}" systemctl start "${SERVICE_UNIT}" || true
+ACTIVE=""
+for _ in $(seq 1 30); do
+	if docker exec "${CONTAINER}" systemctl is-active --quiet "${SERVICE_UNIT}"; then
+		ACTIVE="yes"
+		break
+	fi
+	sleep 2
+done
+if [ -z "${ACTIVE}" ]; then
+	record "${ID_PREFIX}-setup" "failed" "the ${SERVICE_UNIT} service did not become active after the baseline installation"
+	exit 1
+fi
+
+baseline_version() {
+	if [ "${PACKAGE_TYPE}" = "deb" ]; then
+		docker exec "${CONTAINER}" dpkg-query -W -f='${Version}' metricshub
+	else
+		docker exec "${CONTAINER}" rpm -q --qf '%{VERSION}-%{RELEASE}' metricshub
+	fi
+}
+INSTALLED_BEFORE=$(baseline_version)
+log "Installed baseline version: ${INSTALLED_BEFORE}"
+
+docker exec "${CONTAINER}" mkdir -p "${STAGING}"
+
+# Launches the runner exactly as LinuxSystemdRunnerLauncher does and waits for runner.result.
+# $1 = staged package path (in container), $2 = expected sha256, $3 = mode, $4 = wait seconds
+run_runner() {
+	local staged_package="$1" sha256="$2" mode="$3" wait_seconds="$4"
+	local unit="metricshub-upgrade-ci-$(date +%s)"
+	docker exec "${CONTAINER}" sh -c "rm -f '${STAGING}/runner.result' && cp /tmp/runner/metricshub-upgrade-runner.sh '${STAGING}/metricshub-upgrade-runner.sh' && chmod 700 '${STAGING}/metricshub-upgrade-runner.sh'"
+	docker exec "${CONTAINER}" systemd-run \
+		--unit="${unit}" \
+		--collect \
+		--no-block \
+		--property=Type=oneshot \
+		--property=TimeoutStartSec=900 \
+		/bin/sh "${STAGING}/metricshub-upgrade-runner.sh" \
+		--package "${staged_package}" \
+		--sha256 "${sha256}" \
+		--type "${PACKAGE_TYPE}" \
+		--service "${SERVICE_UNIT}" \
+		--staging "${STAGING}" \
+		--mode "${mode}"
+	for _ in $(seq 1 $((wait_seconds / 2))); do
+		if docker exec "${CONTAINER}" test -f "${STAGING}/runner.result"; then
+			break
+		fi
+		sleep 2
+	done
+	docker exec "${CONTAINER}" cat "${STAGING}/runner.result" 2>/dev/null || echo "NO_RESULT"
+}
+
+# ------------------------------------------------------------------------------------------------
+# Scenario 1 - corrupted package: hash re-check fails, the installed service is untouched
+# ------------------------------------------------------------------------------------------------
+log "Scenario: corrupted package"
+docker exec "${CONTAINER}" sh -c "cp /tmp/packages/${PACKAGE_NAME} ${STAGING}/corrupted.${PACKAGE_TYPE} && dd if=/dev/zero of=${STAGING}/corrupted.${PACKAGE_TYPE} bs=1 count=64 seek=1024 conv=notrunc status=none"
+RESULT=$(run_runner "${STAGING}/corrupted.${PACKAGE_TYPE}" "${PACKAGE_SHA256}" "install" 120)
+
+SCENARIO="${ID_PREFIX}-corrupted"
+if [ "${RESULT}" != "INSTALL_FAILED exit=10 step=verify" ]; then
+	record "${SCENARIO}" "failed" "expected 'INSTALL_FAILED exit=10 step=verify', got '${RESULT}'"
+elif ! docker exec "${CONTAINER}" systemctl is-active --quiet "${SERVICE_UNIT}"; then
+	record "${SCENARIO}" "failed" "the service is no longer active after the corrupted-package attempt"
+elif [ "$(baseline_version)" != "${INSTALLED_BEFORE}" ]; then
+	record "${SCENARIO}" "failed" "the installed version changed after the corrupted-package attempt"
+else
+	record "${SCENARIO}" "passed" "runner refused the corrupted package and left the service untouched"
+fi
+
+# ------------------------------------------------------------------------------------------------
+# Scenario 2 - real installation through the runner (deb: upgrade, rpm: same-version reinstall)
+# ------------------------------------------------------------------------------------------------
+if [ "${PACKAGE_TYPE}" = "deb" ]; then
+	MODE="install"
+	SCENARIO="${ID_PREFIX}-upgrade"
+	log "Scenario: upgrade 1.0.0 -> built version"
+else
+	MODE="reinstall"
+	SCENARIO="${ID_PREFIX}-reinstall"
+	log "Scenario: same-version reinstall (hotfix path)"
+fi
+
+docker exec "${CONTAINER}" cp "/tmp/packages/${PACKAGE_NAME}" "${STAGING}/${PACKAGE_NAME}"
+RESULT=$(run_runner "${STAGING}/${PACKAGE_NAME}" "${PACKAGE_SHA256}" "${MODE}" 600)
+
+if [ "${PACKAGE_TYPE}" = "deb" ]; then
+	EXPECTED_VERSION=$(dpkg-deb -f "${PACKAGE_FILE}" Version)
+else
+	EXPECTED_VERSION=$(docker exec "${CONTAINER}" rpm -qp --qf '%{VERSION}-%{RELEASE}' "/tmp/packages/${PACKAGE_NAME}")
+fi
+INSTALLED_AFTER=$(baseline_version)
+
+MISSING_LINKS=""
+for link in config connectors extensions logs otel security; do
+	if ! docker exec "${CONTAINER}" test -L "/opt/metricshub/${link}"; then
+		MISSING_LINKS="${MISSING_LINKS} ${link}"
+	fi
+done
+
+if [ "${RESULT}" != "INSTALL_OK" ]; then
+	record "${SCENARIO}" "failed" "expected 'INSTALL_OK', got '${RESULT}'"
+elif ! docker exec "${CONTAINER}" systemctl is-active --quiet "${SERVICE_UNIT}"; then
+	record "${SCENARIO}" "failed" "the ${SERVICE_UNIT} service is not active after the installation"
+elif [ "${INSTALLED_AFTER}" != "${EXPECTED_VERSION}" ]; then
+	record "${SCENARIO}" "failed" "installed version is '${INSTALLED_AFTER}', expected '${EXPECTED_VERSION}'"
+elif [ -n "${MISSING_LINKS}" ]; then
+	record "${SCENARIO}" "failed" "missing symlinks after installation:${MISSING_LINKS}"
+else
+	record "${SCENARIO}" "passed" "runner installed ${EXPECTED_VERSION} and the service is active (was ${INSTALLED_BEFORE})"
+fi
+
+exit $((FAILURES > 0 ? 1 : 0))

--- a/.github/scripts/upgrade-test-linux.sh
+++ b/.github/scripts/upgrade-test-linux.sh
@@ -182,7 +182,10 @@ run_runner() {
 	local staged_package="$1" sha256="$2" mode="$3" wait_seconds="$4"
 	local unit="metricshub-upgrade-ci-$(date +%s)"
 	docker exec "${CONTAINER}" sh -c "rm -f '${STAGING}/runner.result' && cp /tmp/runner/metricshub-upgrade-runner.sh '${STAGING}/metricshub-upgrade-runner.sh' && chmod 700 '${STAGING}/metricshub-upgrade-runner.sh'"
+	# This function is command-substituted: its stdout must carry only the marker, so the
+	# systemd-run status text (e.g. "Running as unit: ...") is silenced and diverted to stderr
 	docker exec "${CONTAINER}" systemd-run \
+		--quiet \
 		--unit="${unit}" \
 		--collect \
 		--no-block \
@@ -194,7 +197,7 @@ run_runner() {
 		--type "${PACKAGE_TYPE}" \
 		--service "${SERVICE_UNIT}" \
 		--staging "${STAGING}" \
-		--mode "${mode}"
+		--mode "${mode}" 1>&2
 	for _ in $(seq 1 $((wait_seconds / 2))); do
 		if docker exec "${CONTAINER}" test -f "${STAGING}/runner.result"; then
 			break

--- a/.github/scripts/upgrade-test-linux.sh
+++ b/.github/scripts/upgrade-test-linux.sh
@@ -211,7 +211,9 @@ run_runner() {
 # Scenario 1 - corrupted package: hash re-check fails, the installed service is untouched
 # ------------------------------------------------------------------------------------------------
 log "Scenario: corrupted package"
-docker exec "${CONTAINER}" sh -c "cp /tmp/packages/${PACKAGE_NAME} ${STAGING}/corrupted.${PACKAGE_TYPE} && dd if=/dev/zero of=${STAGING}/corrupted.${PACKAGE_TYPE} bs=1 count=64 seek=1024 conv=notrunc status=none"
+# Corrupt by appending: package formats contain zero-padded regions, so overwriting a fixed
+# offset can be a no-op; appending always changes the hash
+docker exec "${CONTAINER}" sh -c "cp /tmp/packages/${PACKAGE_NAME} ${STAGING}/corrupted.${PACKAGE_TYPE} && printf 'CORRUPTED-BY-CI' >> ${STAGING}/corrupted.${PACKAGE_TYPE}"
 RESULT=$(run_runner "${STAGING}/corrupted.${PACKAGE_TYPE}" "${PACKAGE_SHA256}" "install" 120)
 
 SCENARIO="${ID_PREFIX}-corrupted"

--- a/.github/scripts/upgrade-test-windows.ps1
+++ b/.github/scripts/upgrade-test-windows.ps1
@@ -181,9 +181,9 @@ New-Item -ItemType Directory -Path $staging -Force | Out-Null
 Write-Host '=== Scenario: corrupted package'
 $corrupted = Join-Path $staging 'corrupted.msi'
 Copy-Item -Path $package.FullName -Destination $corrupted -Force
-$bytes = [System.IO.File]::ReadAllBytes($corrupted)
-for ($i = 1024; $i -lt 1088; $i++) { $bytes[$i] = 0 }
-[System.IO.File]::WriteAllBytes($corrupted, $bytes)
+# Corrupt by appending: the MSI compound-document format contains zero-padded regions, so
+# overwriting a fixed offset can be a no-op; appending always changes the hash
+[System.IO.File]::AppendAllText($corrupted, 'CORRUPTED-BY-CI')
 
 $result = Invoke-Runner $corrupted $packageSha256 $serviceName 'MetricsHub' 'install' 120
 $scenario = "$IdPrefix-corrupted"

--- a/.github/scripts/upgrade-test-windows.ps1
+++ b/.github/scripts/upgrade-test-windows.ps1
@@ -95,10 +95,18 @@ function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, 
 		if (Test-Path (Join-Path $staging 'runner.result')) { break }
 		Start-Sleep -Seconds 2
 	}
-	if (Test-Path (Join-Path $staging 'runner.result')) {
-		return (Get-Content (Join-Path $staging 'runner.result') -Raw).Trim()
+	if (-not (Test-Path (Join-Path $staging 'runner.result'))) {
+		return 'NO_RESULT'
 	}
-	return 'NO_RESULT'
+	# Complete-Run writes the marker before deleting the one-shot task: wait for the cleanup so
+	# consecutive scenarios never race the shared task name and the post-run /Query is reliable
+	$cleanupDeadline = (Get-Date).AddSeconds(60)
+	while ((Get-Date) -lt $cleanupDeadline) {
+		schtasks /Query /TN 'MetricsHub Upgrade' 2>&1 | Out-Null
+		if ($LASTEXITCODE -ne 0) { break }
+		Start-Sleep -Seconds 2
+	}
+	return (Get-Content (Join-Path $staging 'runner.result') -Raw).Trim()
 }
 
 # --------------------------------------------------------------------------------------------

--- a/.github/scripts/upgrade-test-windows.ps1
+++ b/.github/scripts/upgrade-test-windows.ps1
@@ -1,0 +1,201 @@
+# Drives the detached Windows upgrade runner (metricshub-upgrade-runner.ps1) end-to-end on the
+# CI host and asserts the outcome.
+#
+# Scenarios:
+#   corrupted  - a corrupted staged MSI with the pristine hash: the runner must fail with exit 10
+#                (hash re-check) and leave the installed service running
+#   reinstall  - the built MSI is force-reinstalled over itself (-Mode reinstall, the same-version
+#                hotfix path: REINSTALL=ALL REINSTALLMODE=vamus); asserts INSTALL_OK, the service
+#                Running, a single registry product and the expected DisplayVersion
+#
+# The baseline is the built MSI itself: released MSIs are not attached to GitHub releases, so a
+# version-changing upgrade cannot be sourced; the reinstall path exercises the same runner steps
+# (hash, signature, msiexec, service wait, marker).
+#
+# Usage: upgrade-test-windows.ps1 -IdPrefix windows-x64-msi -PackagePattern 'metricshub-community-*.msi'
+
+param(
+	[Parameter(Mandatory = $true)][string]$IdPrefix,
+	[Parameter(Mandatory = $true)][string]$PackagePattern
+)
+
+$ErrorActionPreference = 'Stop'
+$script:failures = 0
+New-Item -ItemType Directory -Path results -Force | Out-Null
+
+$runnerScript = 'metricshub-assets/src/main/resources/windows/upgrade-runner/metricshub-upgrade-runner.ps1'
+$staging = Join-Path $env:ProgramData 'MetricsHub\upgrade'
+
+function Write-Result([string]$scenario, [string]$status, [string]$details) {
+	[pscustomobject]@{
+		scenario = $scenario
+		os = 'Windows'
+		packageType = 'msi'
+		arch = 'x86_64'
+		status = $status
+		details = $details
+	} | ConvertTo-Json -Depth 3 | Out-File -FilePath (Join-Path 'results' "$scenario.json") -Encoding utf8
+	if ($status -ne 'passed') {
+		$script:failures++
+		Write-Host "FAILED ${scenario}: $details"
+		foreach ($diag in @('runner.result', 'runner.log', 'msiexec.log')) {
+			$path = Join-Path $staging $diag
+			if (Test-Path $path) {
+				Get-Content $path -Tail 60 | Out-File -FilePath (Join-Path 'results' "$scenario-$diag.log") -Encoding utf8
+			}
+		}
+	} else {
+		Write-Host "PASSED ${scenario}: $details"
+	}
+}
+
+function Get-MsiProperty([string]$Path, [string]$Name) {
+	$installer = New-Object -ComObject WindowsInstaller.Installer
+	$database = $installer.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $null, $installer, @($Path, 0))
+	$view = $database.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $database, @("SELECT Value FROM Property WHERE Property='$Name'"))
+	$view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null) | Out-Null
+	$record = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+	if ($record) {
+		return $record.GetType().InvokeMember('StringData', 'GetProperty', $null, $record, 1)
+	}
+	return $null
+}
+
+function Get-MetricsHubProducts {
+	@('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+	  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*') |
+		ForEach-Object { Get-ItemProperty -Path $_ -ErrorAction SilentlyContinue } |
+		Where-Object { $_.DisplayName -like 'MetricsHub*' }
+}
+
+# Runs the runner script the way the wrapper does and waits for runner.result.
+function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, [string]$subject, [string]$mode, [int]$waitSeconds) {
+	Remove-Item -Path (Join-Path $staging 'runner.result') -Force -ErrorAction SilentlyContinue
+	Copy-Item -Path $runnerScript -Destination (Join-Path $staging 'metricshub-upgrade-runner.ps1') -Force
+	& powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $staging 'metricshub-upgrade-runner.ps1') `
+		-Package $package -Sha256 $sha256 -Service $serviceName -Staging $staging `
+		-SignatureSubjectContains $subject -Mode $mode -InstallTimeoutSeconds 900 2>&1 |
+		Out-File -FilePath (Join-Path $staging 'runner-invocation.log') -Encoding utf8
+	$deadline = (Get-Date).AddSeconds($waitSeconds)
+	while ((Get-Date) -lt $deadline) {
+		if (Test-Path (Join-Path $staging 'runner.result')) { break }
+		Start-Sleep -Seconds 2
+	}
+	if (Test-Path (Join-Path $staging 'runner.result')) {
+		return (Get-Content (Join-Path $staging 'runner.result') -Raw).Trim()
+	}
+	return 'NO_RESULT'
+}
+
+# --------------------------------------------------------------------------------------------
+# Locate the built MSI
+# --------------------------------------------------------------------------------------------
+$package = Get-ChildItem -Path packages -Filter $PackagePattern -File | Select-Object -First 1
+if (-not $package) {
+	Write-Result "$IdPrefix-setup" 'failed' "package not found for pattern $PackagePattern"
+	exit 1
+}
+Write-Host "Package under test: $($package.Name)"
+
+# --------------------------------------------------------------------------------------------
+# Ensure the MSI carries a valid Authenticode signature (self-sign when the CI build is unsigned)
+# --------------------------------------------------------------------------------------------
+$signature = Get-AuthenticodeSignature -FilePath $package.FullName
+if ($signature.Status -ne 'Valid') {
+	Write-Host 'The built MSI is unsigned: signing it with a trusted self-signed CI certificate'
+	$cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject 'CN=MetricsHub CI Signing' `
+		-CertStoreLocation Cert:\LocalMachine\My
+	$cerPath = Join-Path $env:RUNNER_TEMP 'metricshub-ci.cer'
+	Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
+	Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
+	Import-Certificate -FilePath $cerPath -CertStoreLocation Cert:\LocalMachine\TrustedPublisher | Out-Null
+	$signResult = Set-AuthenticodeSignature -FilePath $package.FullName -Certificate $cert
+	if ($signResult.Status -ne 'Valid') {
+		Write-Result "$IdPrefix-setup" 'failed' "cannot produce a validly signed MSI: $($signResult.Status)"
+		exit 1
+	}
+}
+
+# The hash and version are computed on the (possibly re-signed) file the runner will verify
+$packageSha256 = (Get-FileHash -Path $package.FullName -Algorithm SHA256).Hash.ToLower()
+$expectedVersion = Get-MsiProperty $package.FullName 'ProductVersion'
+Write-Host "MSI ProductVersion: $expectedVersion, sha256: $packageSha256"
+
+# --------------------------------------------------------------------------------------------
+# Baseline: install the MSI and wait for the service
+# --------------------------------------------------------------------------------------------
+$baselineLog = Join-Path $env:RUNNER_TEMP 'baseline-install.log'
+$process = Start-Process -FilePath msiexec.exe `
+	-ArgumentList @('/i', "`"$($package.FullName)`"", '/qn', '/norestart', '/L*v', "`"$baselineLog`"") -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+	Write-Result "$IdPrefix-setup" 'failed' "baseline msi install failed with exit code $($process.ExitCode)"
+	exit 1
+}
+
+$service = Get-Service | Where-Object { $_.Name -like 'MetricsHub*' } | Select-Object -First 1
+if (-not $service) {
+	Write-Result "$IdPrefix-setup" 'failed' 'no MetricsHub service found after the baseline installation'
+	exit 1
+}
+$serviceName = $service.Name
+Write-Host "Service under test: $serviceName"
+if ($service.Status -ne 'Running') {
+	Start-Service -Name $serviceName -ErrorAction SilentlyContinue
+}
+$deadline = (Get-Date).AddSeconds(120)
+while ((Get-Date) -lt $deadline -and (Get-Service -Name $serviceName).Status -ne 'Running') {
+	Start-Sleep -Seconds 2
+}
+if ((Get-Service -Name $serviceName).Status -ne 'Running') {
+	Write-Result "$IdPrefix-setup" 'failed' "the $serviceName service did not reach Running after the baseline installation"
+	exit 1
+}
+
+New-Item -ItemType Directory -Path $staging -Force | Out-Null
+
+# --------------------------------------------------------------------------------------------
+# Scenario 1 - corrupted MSI: hash re-check fails, the installed service keeps running
+# --------------------------------------------------------------------------------------------
+Write-Host '=== Scenario: corrupted package'
+$corrupted = Join-Path $staging 'corrupted.msi'
+Copy-Item -Path $package.FullName -Destination $corrupted -Force
+$bytes = [System.IO.File]::ReadAllBytes($corrupted)
+for ($i = 1024; $i -lt 1088; $i++) { $bytes[$i] = 0 }
+[System.IO.File]::WriteAllBytes($corrupted, $bytes)
+
+$result = Invoke-Runner $corrupted $packageSha256 $serviceName 'MetricsHub' 'install' 120
+$scenario = "$IdPrefix-corrupted"
+if ($result -ne 'INSTALL_FAILED exit=10 step=verify') {
+	Write-Result $scenario 'failed' "expected 'INSTALL_FAILED exit=10 step=verify', got '$result'"
+} elseif ((Get-Service -Name $serviceName).Status -ne 'Running') {
+	Write-Result $scenario 'failed' 'the service is no longer running after the corrupted-package attempt'
+} else {
+	Write-Result $scenario 'passed' 'runner refused the corrupted package and left the service running'
+}
+
+# --------------------------------------------------------------------------------------------
+# Scenario 2 - same-version reinstall (hotfix path)
+# --------------------------------------------------------------------------------------------
+Write-Host '=== Scenario: same-version reinstall'
+$stagedMsi = Join-Path $staging $package.Name
+Copy-Item -Path $package.FullName -Destination $stagedMsi -Force
+
+$result = Invoke-Runner $stagedMsi $packageSha256 $serviceName 'MetricsHub' 'reinstall' 600
+$scenario = "$IdPrefix-reinstall"
+$products = @(Get-MetricsHubProducts)
+if ($result -ne 'INSTALL_OK') {
+	Write-Result $scenario 'failed' "expected 'INSTALL_OK', got '$result'"
+} elseif ((Get-Service -Name $serviceName).Status -ne 'Running') {
+	Write-Result $scenario 'failed' 'the service is not running after the reinstall'
+} elseif ($products.Count -ne 1) {
+	Write-Result $scenario 'failed' "expected a single registry product, found $($products.Count)"
+} elseif ($products[0].DisplayVersion -ne $expectedVersion) {
+	Write-Result $scenario 'failed' "registry DisplayVersion is '$($products[0].DisplayVersion)', expected '$expectedVersion'"
+} else {
+	Write-Result $scenario 'passed' "runner reinstalled $expectedVersion, single registry product, service running"
+}
+
+if ($script:failures -gt 0) {
+	exit 1
+}
+exit 0

--- a/.github/scripts/upgrade-test-windows.ps1
+++ b/.github/scripts/upgrade-test-windows.ps1
@@ -1,5 +1,7 @@
-# Drives the detached Windows upgrade runner (metricshub-upgrade-runner.ps1) end-to-end on the
-# CI host and asserts the outcome.
+# Drives the detached Windows upgrade runner (metricshub-upgrade-runner.ps1) end-to-end and
+# asserts the outcome. The runner is launched through the same one-shot SYSTEM scheduled task and
+# launch wrapper the agent's WindowsScheduledTaskRunnerLauncher creates, so task creation, wrapper
+# quoting, SYSTEM permissions and detachment are covered too.
 #
 # Scenarios:
 #   corrupted  - a corrupted staged MSI with the pristine hash: the runner must fail with exit 10
@@ -68,14 +70,26 @@ function Get-MetricsHubProducts {
 		Where-Object { $_.DisplayName -like 'MetricsHub*' }
 }
 
-# Runs the runner script the way the wrapper does and waits for runner.result.
+# Launches the runner exactly as WindowsScheduledTaskRunnerLauncher does: a launch wrapper in the
+# staging directory and a one-shot SYSTEM scheduled task pointing at it, so the test also covers
+# task creation, wrapper quoting, SYSTEM permissions and the runner's own task cleanup.
 function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, [string]$subject, [string]$mode, [int]$waitSeconds) {
 	Remove-Item -Path (Join-Path $staging 'runner.result') -Force -ErrorAction SilentlyContinue
-	Copy-Item -Path $runnerScript -Destination (Join-Path $staging 'metricshub-upgrade-runner.ps1') -Force
-	& powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $staging 'metricshub-upgrade-runner.ps1') `
-		-Package $package -Sha256 $sha256 -Service $serviceName -Staging $staging `
-		-SignatureSubjectContains $subject -Mode $mode -InstallTimeoutSeconds 900 2>&1 |
-		Out-File -FilePath (Join-Path $staging 'runner-invocation.log') -Encoding utf8
+	$stagedScript = Join-Path $staging 'metricshub-upgrade-runner.ps1'
+	Copy-Item -Path $runnerScript -Destination $stagedScript -Force
+
+	$powershell = 'powershell -NoProfile -ExecutionPolicy Bypass -File "' + $stagedScript + '"' +
+		' -Package "' + $package + '" -Sha256 ' + $sha256 +
+		' -Service "' + $serviceName + '" -Staging "' + $staging + '"' +
+		' -SignatureSubjectContains "' + $subject + '" -Mode ' + $mode + ' -InstallTimeoutSeconds 900'
+	$wrapper = Join-Path $staging 'metricshub-upgrade-launch.cmd'
+	Set-Content -Path $wrapper -Value ("@echo off`r`n" + $powershell + "`r`n") -Encoding Ascii -NoNewline
+
+	& schtasks /Create /TN 'MetricsHub Upgrade' /F /RU SYSTEM /RL HIGHEST /SC ONCE /ST 00:00 /TR "`"$wrapper`"" | Out-Null
+	if ($LASTEXITCODE -ne 0) { return "SCHTASKS_CREATE_FAILED exit=$LASTEXITCODE" }
+	& schtasks /Run /TN 'MetricsHub Upgrade' | Out-Null
+	if ($LASTEXITCODE -ne 0) { return "SCHTASKS_RUN_FAILED exit=$LASTEXITCODE" }
+
 	$deadline = (Get-Date).AddSeconds($waitSeconds)
 	while ((Get-Date) -lt $deadline) {
 		if (Test-Path (Join-Path $staging 'runner.result')) { break }
@@ -183,6 +197,8 @@ Copy-Item -Path $package.FullName -Destination $stagedMsi -Force
 $result = Invoke-Runner $stagedMsi $packageSha256 $serviceName 'MetricsHub' 'reinstall' 600
 $scenario = "$IdPrefix-reinstall"
 $products = @(Get-MetricsHubProducts)
+schtasks /Query /TN 'MetricsHub Upgrade' 2>&1 | Out-Null
+$taskStillPresent = ($LASTEXITCODE -eq 0)
 if ($result -ne 'INSTALL_OK') {
 	Write-Result $scenario 'failed' "expected 'INSTALL_OK', got '$result'"
 } elseif ((Get-Service -Name $serviceName).Status -ne 'Running') {
@@ -191,6 +207,8 @@ if ($result -ne 'INSTALL_OK') {
 	Write-Result $scenario 'failed' "expected a single registry product, found $($products.Count)"
 } elseif ($products[0].DisplayVersion -ne $expectedVersion) {
 	Write-Result $scenario 'failed' "registry DisplayVersion is '$($products[0].DisplayVersion)', expected '$expectedVersion'"
+} elseif ($taskStillPresent) {
+	Write-Result $scenario 'failed' 'the runner did not delete its one-shot scheduled task'
 } else {
 	Write-Result $scenario 'passed' "runner reinstalled $expectedVersion, single registry product, service running"
 }

--- a/.github/workflows/package-installation-tests.yml
+++ b/.github/workflows/package-installation-tests.yml
@@ -377,6 +377,78 @@ jobs:
         name: package-test-result-${{ matrix.id }}
         path: results/*
 
+  linux-upgrade-tests:
+    name: Linux upgrade test (${{ matrix.id }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: debian12-amd64-deb
+            osLabel: Debian 12 (systemd)
+            packageType: deb
+            packagePattern: metricshub-community_*_amd64.deb
+          - id: ubi9-amd64-rpm
+            osLabel: Red Hat UBI 9 (systemd)
+            packageType: rpm
+            packagePattern: metricshub-community-*.x86_64.rpm
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Download Linux packages
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.linuxArtifact }}
+        path: packages
+
+    - name: Run the detached upgrade runner scenarios
+      shell: bash
+      run: |
+        bash .github/scripts/upgrade-test-linux.sh \
+          '${{ matrix.id }}-upgrade-test' \
+          '${{ matrix.osLabel }}' \
+          '${{ matrix.packageType }}' \
+          '${{ matrix.packagePattern }}'
+
+    - name: Upload test result
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: package-test-result-upgrade-${{ matrix.id }}
+        path: results/*
+
+  windows-upgrade-tests:
+    name: Windows upgrade test (windows-x64-msi)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Download Windows packages
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.windowsArtifact }}
+        path: packages
+
+    - name: Run the detached upgrade runner scenarios
+      shell: pwsh
+      run: |
+        .github/scripts/upgrade-test-windows.ps1 `
+          -IdPrefix 'windows-x64-msi-upgrade-test' `
+          -PackagePattern 'metricshub-community-*.msi'
+
+    - name: Upload test result
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: package-test-result-upgrade-windows-x64-msi
+        path: results/*
+
   package-test-report:
     name: Package installation report
     runs-on: ubuntu-latest
@@ -384,6 +456,8 @@ jobs:
     needs:
     - linux-install-tests
     - windows-install-tests
+    - linux-upgrade-tests
+    - windows-upgrade-tests
 
     steps:
     - name: Download test result artifacts


### PR DESCRIPTION
Part of **EPIC: MetricsHub / OpAMP** (#1286), closes #1284. Base: `EPIC-OpAMP`. Depends on EPIC-OpAMP-04 (merged).

Adds `linux-upgrade-tests` and `windows-upgrade-tests` jobs to `package-installation-tests.yml`, driving the **real detached upgrade runners end-to-end** on the artifacts the workflow already builds:

| Scenario | Platform | What it proves |
|---|---|---|
| `debian12-amd64-deb-upgrade-test-upgrade` | Debian 12 systemd container | Version-changing upgrade: baseline 1.0.0 → built version through `systemd-run` (exact agent launch shape: `--collect --no-block --property=Type=oneshot --property=TimeoutStartSec`), `runner.result` = `INSTALL_OK`, unit active, `dpkg` version, symlinks recreated |
| `ubi9-amd64-rpm-upgrade-test-reinstall` | UBI 9 init container | Same-version hotfix path (`--mode reinstall` → `dnf reinstall`), service active, version intact |
| `windows-x64-msi-upgrade-test-reinstall` | windows-latest | `runner.ps1 -Mode reinstall` (`REINSTALL=ALL REINSTALLMODE=vamus`), Authenticode gate (MSI self-signed with a trusted CI cert when the build is unsigned), `INSTALL_OK`, service `Running`, **single registry product**, expected `DisplayVersion` |
| `*-corrupted` (all three) | — | A corrupted staged package with the pristine hash → `INSTALL_FAILED exit=10 step=verify`, installed service untouched |

**Why the baseline is derived from the built package**: GitHub releases only attach `tar.gz`/`zip` archives — no deb/rpm/msi — and the YUM repo receives no RPMs due to the known `packaging.yml` upload bug (loop iterates `maven-<ref>` instead of `packages`; tracked separately). The deb scenario therefore repacks the built package as version `1.0.0` (identical payload and scriptlets) to get a true version-changing upgrade; rpm and MSI exercise the same-version hotfix path, which drives the identical runner steps (hash → stop → install → start → marker).

Scenario results feed the existing consolidated report job. Runs with `test-main.yml` (nightly + `workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)