### PR TITLE
EPIC-OpAMP-06: Documentation and bookkeeping

### DIFF
--- a/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/linux/config/metricshub-example.yaml
@@ -28,6 +28,7 @@ otel:
 #   allowDowngrade: false
 #   # serviceName: metricshub-community-service.service # Discovered automatically; pin it if needed
 #   hostAllowlist: [ repo.metricshub.com ]
+#   # installTimeout: 30m # Deadline for the detached installation (default: 30m)
 #   # trustedCertificateFile: /opt/metricshub/security/repo-ca.pem # Trusted certificate (PEM) for the package repository
 
 # Simple resource configuration

--- a/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
+++ b/metricshub-assets/src/main/resources/windows/config/metricshub-example.yaml
@@ -28,6 +28,7 @@ otel:
 #   allowDowngrade: false
 #   # serviceName: MetricsHub Community # Discovered automatically; pin it if needed
 #   hostAllowlist: [ repo.metricshub.com ]
+#   # installTimeout: 30m # Deadline for the detached installation (default: 30m)
 #   # trustedCertificateFile: C:\ProgramData\MetricsHub\security\repo-ca.pem # Trusted certificate (PEM) for the package repository
 
 # Simple resource configuration


### PR DESCRIPTION
Part of **EPIC: MetricsHub / OpAMP** (#1286), closes #1285. Base: `EPIC-OpAMP`.

- Example configurations: final pass on the commented `opamp:`/`upgrade:` blocks (adds `installTimeout`).
- The README *Remote Management (OpAMP)* section was completed in the previous EPIC PRs and needed no further changes.
- The user documentation lands in the docs repository: MetricsHub/metricshub-doc#162 — new *Remote Management (OpAMP)* page with the `opamp:`/`upgrade:` references, instance-UID lifecycle, supported-installations matrix, security model and troubleshooting (runner exit codes, staging artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)