### PR TITLE
EPIC-OpAMP-05: Read the runner verdict from its durable log line

### DIFF
--- a/.github/scripts/upgrade-test-linux.sh
+++ b/.github/scripts/upgrade-test-linux.sh
@@ -176,13 +176,16 @@ log "Installed baseline version: ${INSTALLED_BEFORE}"
 
 docker exec "${CONTAINER}" mkdir -p "${STAGING}"
 
-# Launches the runner exactly as LinuxSystemdRunnerLauncher does and waits for runner.result.
+# Launches the runner exactly as LinuxSystemdRunnerLauncher does and waits for its verdict.
+# The verdict is read from the RESULT line of runner.log, not from the runner.result marker: the
+# marker is consumed by the running agent (startup reconciliation clears stale markers), so
+# reading the file races the agent — the log line is written in the same breath and is durable.
 # $1 = staged package path (in container), $2 = expected sha256, $3 = mode, $4 = wait seconds
 run_runner() {
 	local staged_package="$1" sha256="$2" mode="$3" wait_seconds="$4"
 	local unit="metricshub-upgrade-ci-$(date +%s)"
-	docker exec "${CONTAINER}" sh -c "rm -f '${STAGING}/runner.result' && cp /tmp/runner/metricshub-upgrade-runner.sh '${STAGING}/metricshub-upgrade-runner.sh' && chmod 700 '${STAGING}/metricshub-upgrade-runner.sh'"
-	# This function is command-substituted: its stdout must carry only the marker, so the
+	docker exec "${CONTAINER}" sh -c "rm -f '${STAGING}/runner.result' '${STAGING}/runner.log' && cp /tmp/runner/metricshub-upgrade-runner.sh '${STAGING}/metricshub-upgrade-runner.sh' && chmod 700 '${STAGING}/metricshub-upgrade-runner.sh'"
+	# This function is command-substituted: its stdout must carry only the verdict, so the
 	# systemd-run status text (e.g. "Running as unit: ...") is silenced and diverted to stderr
 	docker exec "${CONTAINER}" systemd-run \
 		--quiet \
@@ -199,13 +202,24 @@ run_runner() {
 		--staging "${STAGING}" \
 		--mode "${mode}" 1>&2
 	for _ in $(seq 1 $((wait_seconds / 2))); do
-		if docker exec "${CONTAINER}" test -f "${STAGING}/runner.result"; then
+		if docker exec "${CONTAINER}" grep -q " RESULT: " "${STAGING}/runner.log" 2>/dev/null; then
 			break
 		fi
 		sleep 2
 	done
-	docker exec "${CONTAINER}" cat "${STAGING}/runner.result" 2>/dev/null || echo "NO_RESULT"
+	docker exec "${CONTAINER}" sed -n 's/.* RESULT: \(.*\) (exit [0-9]*)$/\1/p' "${STAGING}/runner.log" 2>/dev/null |
+		tail -n 1 |
+		grep . ||
+		echo "NO_RESULT"
 }
+
+# The mode the agent itself would compute for this offer (VersionHelper.installMode): the deb
+# scenario upgrades from the older baseline, the rpm scenario re-offers the installed version
+if [ "${PACKAGE_TYPE}" = "deb" ]; then
+	MODE="install"
+else
+	MODE="reinstall"
+fi
 
 # ------------------------------------------------------------------------------------------------
 # Scenario 1 - corrupted package: hash re-check fails, the installed service is untouched
@@ -214,7 +228,7 @@ log "Scenario: corrupted package"
 # Corrupt by appending: package formats contain zero-padded regions, so overwriting a fixed
 # offset can be a no-op; appending always changes the hash
 docker exec "${CONTAINER}" sh -c "cp /tmp/packages/${PACKAGE_NAME} ${STAGING}/corrupted.${PACKAGE_TYPE} && printf 'CORRUPTED-BY-CI' >> ${STAGING}/corrupted.${PACKAGE_TYPE}"
-RESULT=$(run_runner "${STAGING}/corrupted.${PACKAGE_TYPE}" "${PACKAGE_SHA256}" "install" 120)
+RESULT=$(run_runner "${STAGING}/corrupted.${PACKAGE_TYPE}" "${PACKAGE_SHA256}" "${MODE}" 120)
 
 SCENARIO="${ID_PREFIX}-corrupted"
 if [ "${RESULT}" != "INSTALL_FAILED exit=10 step=verify" ]; then
@@ -231,11 +245,9 @@ fi
 # Scenario 2 - real installation through the runner (deb: upgrade, rpm: same-version reinstall)
 # ------------------------------------------------------------------------------------------------
 if [ "${PACKAGE_TYPE}" = "deb" ]; then
-	MODE="install"
 	SCENARIO="${ID_PREFIX}-upgrade"
 	log "Scenario: upgrade 1.0.0 -> built version"
 else
-	MODE="reinstall"
 	SCENARIO="${ID_PREFIX}-reinstall"
 	log "Scenario: same-version reinstall (hotfix path)"
 fi

--- a/.github/scripts/upgrade-test-windows.ps1
+++ b/.github/scripts/upgrade-test-windows.ps1
@@ -73,8 +73,12 @@ function Get-MetricsHubProducts {
 # Launches the runner exactly as WindowsScheduledTaskRunnerLauncher does: a launch wrapper in the
 # staging directory and a one-shot SYSTEM scheduled task pointing at it, so the test also covers
 # task creation, wrapper quoting, SYSTEM permissions and the runner's own task cleanup.
+# The verdict is read from the RESULT line of runner.log, not from the runner.result marker: the
+# marker is consumed by the running agent (startup reconciliation clears stale markers), so
+# reading the file races the agent — the log line is written in the same breath and is durable.
 function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, [string]$subject, [string]$mode, [int]$waitSeconds) {
-	Remove-Item -Path (Join-Path $staging 'runner.result') -Force -ErrorAction SilentlyContinue
+	$runnerLog = Join-Path $staging 'runner.log'
+	Remove-Item -Path (Join-Path $staging 'runner.result'), $runnerLog -Force -ErrorAction SilentlyContinue
 	$stagedScript = Join-Path $staging 'metricshub-upgrade-runner.ps1'
 	Copy-Item -Path $runnerScript -Destination $stagedScript -Force
 
@@ -92,13 +96,13 @@ function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, 
 
 	$deadline = (Get-Date).AddSeconds($waitSeconds)
 	while ((Get-Date) -lt $deadline) {
-		if (Test-Path (Join-Path $staging 'runner.result')) { break }
+		if ((Test-Path $runnerLog) -and (Select-String -Path $runnerLog -Pattern ' RESULT: ' -Quiet)) { break }
 		Start-Sleep -Seconds 2
 	}
-	if (-not (Test-Path (Join-Path $staging 'runner.result'))) {
+	if (-not ((Test-Path $runnerLog) -and (Select-String -Path $runnerLog -Pattern ' RESULT: ' -Quiet))) {
 		return 'NO_RESULT'
 	}
-	# Complete-Run writes the marker before deleting the one-shot task: wait for the cleanup so
+	# The runner logs the verdict before deleting the one-shot task: wait for the cleanup so
 	# consecutive scenarios never race the shared task name and the post-run /Query is reliable
 	$cleanupDeadline = (Get-Date).AddSeconds(60)
 	while ((Get-Date) -lt $cleanupDeadline) {
@@ -106,7 +110,11 @@ function Invoke-Runner([string]$package, [string]$sha256, [string]$serviceName, 
 		if ($LASTEXITCODE -ne 0) { break }
 		Start-Sleep -Seconds 2
 	}
-	return (Get-Content (Join-Path $staging 'runner.result') -Raw).Trim()
+	$verdict = Select-String -Path $runnerLog -Pattern ' RESULT: (.+) \(exit \d+\)$' | Select-Object -Last 1
+	if ($verdict) {
+		return $verdict.Matches[0].Groups[1].Value
+	}
+	return 'NO_RESULT'
 }
 
 # --------------------------------------------------------------------------------------------
@@ -185,7 +193,7 @@ Copy-Item -Path $package.FullName -Destination $corrupted -Force
 # overwriting a fixed offset can be a no-op; appending always changes the hash
 [System.IO.File]::AppendAllText($corrupted, 'CORRUPTED-BY-CI')
 
-$result = Invoke-Runner $corrupted $packageSha256 $serviceName 'MetricsHub' 'install' 120
+$result = Invoke-Runner $corrupted $packageSha256 $serviceName 'MetricsHub' 'reinstall' 120
 $scenario = "$IdPrefix-corrupted"
 if ($result -ne 'INSTALL_FAILED exit=10 step=verify') {
 	Write-Result $scenario 'failed' "expected 'INSTALL_FAILED exit=10 step=verify', got '$result'"


### PR DESCRIPTION
Follow-up to #1296 (merged), fixing the last flaky scenario surfaced by [test-main run 31595174040](https://github.com/MetricsHub/metricshub-community/actions/runs/31595174040).

The ubi9 corrupted scenario failed with `NO_RESULT` although `runner.log` proves the runner wrote `INSTALL_FAILED exit=10 step=verify`: the baseline agent is the EPIC build, and its startup reconciliation deliberately clears stale `runner.result` markers (no transaction on disk) — it consumed the marker before the test's poll. The same race exists after successful installations, when the freshly started upgraded agent clears the marker.

- The verdict is now read from the `RESULT:` line of `runner.log` — written by `finish()`/`Complete-Run` in the same breath as the marker, but never cleared by the agent; both files are reset before each launch.
- The corrupted scenario now drives the runner with the same mode the agent would compute for the offer (`install` for the deb upgrade, `reinstall` for the same-version rpm/MSI), so a hash-gate slip produces a realistic outcome instead of a confusing installer error.

Scoreboard of run 31595174040 before this fix: deb upgrade ✅, rpm reinstall ✅, Windows corrupted ✅, Windows reinstall (SYSTEM scheduled task, single registry product) ✅ — only ubi9-corrupted flaked on this race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)