### PR TITLE
Apply metricshub-ui.yaml last when merging configuration fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is a multi-module project:
 * **metricshub-jmx-extension**: Enables monitoring of Java applications through JMX (Java Management Extensions).
 * **metricshub-emulation-extension**: Replays recorded protocol exchanges (HTTP, SNMP, WMI, WBEM, SSH, IPMI, JDBC, JMX) from local files, enabling offline testing and development without live infrastructure.
 * **metricshub-hardware**: Hardware Energy and Sustainability module, dedicated to managing and monitoring hardware-related metrics, focusing on energy consumption and sustainability aspects.
-* **metricshub-yaml-configuration-extension**: Extension that loads configuration fragments from YAML files located in a configuration directory.
+* **metricshub-yaml-configuration-extension**: Extension that loads configuration fragments from YAML files located in a configuration directory. The UI-managed `metricshub-ui.yaml` file is handled separately: it is always merged last, after the fragments of every configuration provider, so settings configured through the web UI override every other configuration source.
 * **metricshub-programmable-configuration-extension**: Provides a programmable configuration mechanism, allowing users to define custom configurations through [Apache Velocity](https://velocity.apache.org/) scripts.
 * **metricshub-web**: Provides a user interface for interacting with MetricsHub features and functionalities.
 * **metricshub-it-common**: Contains common code and utilities used by integration tests across various modules.

--- a/UI.md
+++ b/UI.md
@@ -86,6 +86,8 @@ This is the page your example URL opens. It is a **single scrollable page** with
 | `UiConfig` | Spring MVC configuration serving the built React app (static assets + SPA fallback). |
 | `ConfigHelper` (touched) | Agent config helper; branch changes align UI-written YAML with what the agent loader accepts. |
 
+**Configuration precedence:** `metricshub-ui.yaml` is loaded through the dedicated `IConfigurationProvider.loadUiFragments` pass and merged by the agent's `ConfigurationService` **after** the regular fragments of every configuration provider (other YAML files, Velocity `.vm` templates, …). Settings written by the UI therefore always override the same settings defined in any other configuration file, regardless of file naming or provider discovery order.
+
 ### DTOs (`org.metricshub.web.dto.uiconfig`)
 
 | DTO | Purpose |

--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/ConfigurationService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/ConfigurationService.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import lombok.Builder;
 import lombok.Data;
@@ -55,10 +56,24 @@ public class ConfigurationService {
 	public JsonNode loadConfiguration(final ExtensionManager extensionManager) {
 		final JsonNode mergedConfiguration = JsonNodeFactory.instance.objectNode();
 
-		extensionManager
-			.getConfigurationProviderExtensions()
+		final var configurationProviders = extensionManager.getConfigurationProviderExtensions();
+
+		configurationProviders.forEach((IConfigurationProvider configurationProvider) -> {
+			var fragments = configurationProvider.load(configDirectory);
+			if (fragments != null) {
+				deepMergeFragments(mergedConfiguration, fragments);
+			}
+		});
+
+		// Fragments deferred by the providers (e.g. metricshub-ui.yaml) are merged once every
+		// regular fragment of every provider is in, so they always take precedence. Providers
+		// are sorted by loadLastOrder so the UI configuration also wins over any other
+		// deferred fragment.
+		configurationProviders
+			.stream()
+			.sorted(Comparator.comparingInt(IConfigurationProvider::loadLastOrder))
 			.forEach((IConfigurationProvider configurationProvider) -> {
-				var fragments = configurationProvider.load(configDirectory);
+				var fragments = configurationProvider.loadLast(configDirectory);
 				if (fragments != null) {
 					deepMergeFragments(mergedConfiguration, fragments);
 				}

--- a/metricshub-agent/src/main/java/org/metricshub/agent/service/ConfigurationService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/agent/service/ConfigurationService.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Iterator;
 import lombok.Builder;
 import lombok.Data;
@@ -65,19 +64,14 @@ public class ConfigurationService {
 			}
 		});
 
-		// Fragments deferred by the providers (e.g. metricshub-ui.yaml) are merged once every
-		// regular fragment of every provider is in, so they always take precedence. Providers
-		// are sorted by loadLastOrder so the UI configuration also wins over any other
-		// deferred fragment.
-		configurationProviders
-			.stream()
-			.sorted(Comparator.comparingInt(IConfigurationProvider::loadLastOrder))
-			.forEach((IConfigurationProvider configurationProvider) -> {
-				var fragments = configurationProvider.loadLast(configDirectory);
-				if (fragments != null) {
-					deepMergeFragments(mergedConfiguration, fragments);
-				}
-			});
+		// The UI configuration fragments (metricshub-ui.yaml) are merged once every regular
+		// fragment of every provider is in, so the UI configuration always takes precedence.
+		configurationProviders.forEach((IConfigurationProvider configurationProvider) -> {
+			var fragments = configurationProvider.loadUiFragments(configDirectory);
+			if (fragments != null) {
+				deepMergeFragments(mergedConfiguration, fragments);
+			}
+		});
 
 		return mergedConfiguration;
 	}

--- a/metricshub-agent/src/test/java/org/metricshub/agent/service/ConfigurationServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/service/ConfigurationServiceTest.java
@@ -95,8 +95,7 @@ class ConfigurationServiceTest {
 			"""
 		);
 
-		final ExtensionManager extensionManager = ExtensionManager
-			.builder()
+		final ExtensionManager extensionManager = ExtensionManager.builder()
 			.withConfigurationProviderExtensions(List.of(new YamlConfigurationProvider()))
 			.build();
 
@@ -128,8 +127,7 @@ class ConfigurationServiceTest {
 		final IConfigurationProvider leadingProvider = staticProvider("loggerLevel: debug\nleadingKey: leading");
 		final IConfigurationProvider trailingProvider = staticProvider("loggerLevel: warn\ntrailingKey: trailing");
 
-		final ExtensionManager extensionManager = ExtensionManager
-			.builder()
+		final ExtensionManager extensionManager = ExtensionManager.builder()
 			.withConfigurationProviderExtensions(List.of(leadingProvider, new YamlConfigurationProvider(), trailingProvider))
 			.build();
 
@@ -145,45 +143,18 @@ class ConfigurationServiceTest {
 	}
 
 	@Test
-	void testUiConfigurationWinsOverOtherDeferredFragments() throws IOException {
-		Files.writeString(tempDir.resolve(UI_CONFIG_FILENAME), "loggerLevel: error");
-
-		// Providers also deferring fragments, one discovered before the YAML provider and
-		// one after: the UI file must still be merged last within the loadLast pass.
-		final IConfigurationProvider leadingDeferred = deferredProvider("loggerLevel: debug\nleadingKey: leading");
-		final IConfigurationProvider trailingDeferred = deferredProvider("loggerLevel: warn\ntrailingKey: trailing");
-
-		final ExtensionManager extensionManager = ExtensionManager
-			.builder()
-			.withConfigurationProviderExtensions(
-				List.of(leadingDeferred, new YamlConfigurationProvider(), trailingDeferred)
-			)
-			.build();
-
-		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
-
-		assertEquals(
-			"error",
-			config.get("loggerLevel").asText(),
-			"metricshub-ui.yaml must win even over other deferred fragments"
-		);
-		assertEquals("leading", config.get("leadingKey").asText(), "Leading deferred fragment must be merged");
-		assertEquals("trailing", config.get("trailingKey").asText(), "Trailing deferred fragment must be merged");
-	}
-
-	@Test
-	void testLoadLastInvokedAfterAllRegularLoads() {
+	void testUiFragmentsMergedAfterAllRegularLoads() {
 		final IConfigurationProvider firstProvider = mock(IConfigurationProvider.class);
 		final IConfigurationProvider secondProvider = mock(IConfigurationProvider.class);
 
 		when(firstProvider.load(tempDir)).thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "one")));
 		when(secondProvider.load(tempDir)).thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "two")));
-		when(firstProvider.loadLast(tempDir))
-			.thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "last")));
-		when(secondProvider.loadLast(tempDir)).thenReturn(List.of());
+		when(firstProvider.loadUiFragments(tempDir)).thenReturn(
+			List.of(JsonNodeFactory.instance.objectNode().put("key", "ui"))
+		);
+		when(secondProvider.loadUiFragments(tempDir)).thenReturn(List.of());
 
-		final ExtensionManager extensionManager = ExtensionManager
-			.builder()
+		final ExtensionManager extensionManager = ExtensionManager.builder()
 			.withConfigurationProviderExtensions(List.of(firstProvider, secondProvider))
 			.build();
 
@@ -192,20 +163,19 @@ class ConfigurationServiceTest {
 		final InOrder order = inOrder(firstProvider, secondProvider);
 		order.verify(firstProvider).load(tempDir);
 		order.verify(secondProvider).load(tempDir);
-		order.verify(firstProvider).loadLast(tempDir);
-		order.verify(secondProvider).loadLast(tempDir);
+		order.verify(firstProvider).loadUiFragments(tempDir);
+		order.verify(secondProvider).loadUiFragments(tempDir);
 
-		assertEquals("last", config.get("key").asText(), "Deferred fragments must be merged after regular fragments");
+		assertEquals("ui", config.get("key").asText(), "UI fragments must be merged after regular fragments");
 	}
 
 	@Test
 	void testLoadConfigurationToleratesNullFragments() {
 		final IConfigurationProvider nullProvider = mock(IConfigurationProvider.class);
 		when(nullProvider.load(tempDir)).thenReturn(null);
-		when(nullProvider.loadLast(tempDir)).thenReturn(null);
+		when(nullProvider.loadUiFragments(tempDir)).thenReturn(null);
 
-		final ExtensionManager extensionManager = ExtensionManager
-			.builder()
+		final ExtensionManager extensionManager = ExtensionManager.builder()
 			.withConfigurationProviderExtensions(List.of(nullProvider))
 			.build();
 
@@ -225,32 +195,6 @@ class ConfigurationServiceTest {
 		return new IConfigurationProvider() {
 			@Override
 			public Collection<JsonNode> load(final Path path) {
-				return List.of(parseYaml(yaml));
-			}
-
-			@Override
-			public Set<String> getFileExtensions() {
-				return Set.of();
-			}
-		};
-	}
-
-	/**
-	 * Creates a provider returning the given YAML content as its single deferred fragment,
-	 * with the default {@code loadLastOrder}.
-	 *
-	 * @param yaml the YAML content of the fragment
-	 * @return a stub {@link IConfigurationProvider}
-	 */
-	private static IConfigurationProvider deferredProvider(final String yaml) {
-		return new IConfigurationProvider() {
-			@Override
-			public Collection<JsonNode> load(final Path path) {
-				return List.of();
-			}
-
-			@Override
-			public Collection<JsonNode> loadLast(final Path path) {
 				return List.of(parseYaml(yaml));
 			}
 

--- a/metricshub-agent/src/test/java/org/metricshub/agent/service/ConfigurationServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/agent/service/ConfigurationServiceTest.java
@@ -1,0 +1,277 @@
+package org.metricshub.agent.service;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.configuration.YamlConfigurationProvider;
+import org.metricshub.engine.common.helpers.JsonHelper;
+import org.metricshub.engine.extension.ExtensionManager;
+import org.metricshub.engine.extension.IConfigurationProvider;
+import org.mockito.InOrder;
+
+class ConfigurationServiceTest {
+
+	private static final String UI_CONFIG_FILENAME = "metricshub-ui.yaml";
+
+	@TempDir
+	Path tempDir;
+
+	/**
+	 * Builds a {@link ConfigurationService} targeting the test's temporary directory.
+	 *
+	 * @return a new {@link ConfigurationService}
+	 */
+	private ConfigurationService newConfigurationService() {
+		return ConfigurationService.builder().withConfigDirectory(tempDir).build();
+	}
+
+	@Test
+	void testUiConfigurationOverridesEveryOtherYamlFile() throws IOException {
+		Files.writeString(
+			tempDir.resolve("metricshub.yaml"),
+			"""
+			loggerLevel: debug
+			resources:
+			  server-1:
+			    attributes:
+			      host.name: server-1
+			      host.type: linux
+			"""
+		);
+		// Sorts after metricshub-ui.yaml in a directory listing: without the deferred pass it
+		// would be merged after the UI file and would win.
+		Files.writeString(
+			tempDir.resolve("zzz-extra.yaml"),
+			"""
+			loggerLevel: info
+			extraKey: fromZzz
+			"""
+		);
+		Files.writeString(
+			tempDir.resolve(UI_CONFIG_FILENAME),
+			"""
+			loggerLevel: error
+			resources:
+			  server-1:
+			    attributes:
+			      host.type: windows
+			  ui-host:
+			    attributes:
+			      host.name: ui-host
+			"""
+		);
+
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withConfigurationProviderExtensions(List.of(new YamlConfigurationProvider()))
+			.build();
+
+		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
+
+		assertEquals("error", config.get("loggerLevel").asText(), "metricshub-ui.yaml must win over every YAML file");
+		assertEquals("fromZzz", config.get("extraKey").asText(), "Non-conflicting keys must be preserved");
+
+		final JsonNode server1Attributes = config.get("resources").get("server-1").get("attributes");
+		assertEquals(
+			"windows",
+			server1Attributes.get("host.type").asText(),
+			"metricshub-ui.yaml must override nested resource attributes"
+		);
+		assertEquals(
+			"server-1",
+			server1Attributes.get("host.name").asText(),
+			"Attributes not redefined by metricshub-ui.yaml must be preserved"
+		);
+		assertTrue(config.get("resources").has("ui-host"), "Resources added by metricshub-ui.yaml must be present");
+	}
+
+	@Test
+	void testUiConfigurationAppliedAfterAllProviders() throws IOException {
+		Files.writeString(tempDir.resolve(UI_CONFIG_FILENAME), "loggerLevel: error");
+
+		// Regular fragments overriding the same key, one provider discovered before the YAML
+		// provider and one after: the UI file must win over both.
+		final IConfigurationProvider leadingProvider = staticProvider("loggerLevel: debug\nleadingKey: leading");
+		final IConfigurationProvider trailingProvider = staticProvider("loggerLevel: warn\ntrailingKey: trailing");
+
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withConfigurationProviderExtensions(List.of(leadingProvider, new YamlConfigurationProvider(), trailingProvider))
+			.build();
+
+		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
+
+		assertEquals(
+			"error",
+			config.get("loggerLevel").asText(),
+			"metricshub-ui.yaml must be applied after the regular fragments of all providers"
+		);
+		assertEquals("leading", config.get("leadingKey").asText(), "Leading provider fragment must be merged");
+		assertEquals("trailing", config.get("trailingKey").asText(), "Trailing provider fragment must be merged");
+	}
+
+	@Test
+	void testUiConfigurationWinsOverOtherDeferredFragments() throws IOException {
+		Files.writeString(tempDir.resolve(UI_CONFIG_FILENAME), "loggerLevel: error");
+
+		// Providers also deferring fragments, one discovered before the YAML provider and
+		// one after: the UI file must still be merged last within the loadLast pass.
+		final IConfigurationProvider leadingDeferred = deferredProvider("loggerLevel: debug\nleadingKey: leading");
+		final IConfigurationProvider trailingDeferred = deferredProvider("loggerLevel: warn\ntrailingKey: trailing");
+
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withConfigurationProviderExtensions(
+				List.of(leadingDeferred, new YamlConfigurationProvider(), trailingDeferred)
+			)
+			.build();
+
+		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
+
+		assertEquals(
+			"error",
+			config.get("loggerLevel").asText(),
+			"metricshub-ui.yaml must win even over other deferred fragments"
+		);
+		assertEquals("leading", config.get("leadingKey").asText(), "Leading deferred fragment must be merged");
+		assertEquals("trailing", config.get("trailingKey").asText(), "Trailing deferred fragment must be merged");
+	}
+
+	@Test
+	void testLoadLastInvokedAfterAllRegularLoads() {
+		final IConfigurationProvider firstProvider = mock(IConfigurationProvider.class);
+		final IConfigurationProvider secondProvider = mock(IConfigurationProvider.class);
+
+		when(firstProvider.load(tempDir)).thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "one")));
+		when(secondProvider.load(tempDir)).thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "two")));
+		when(firstProvider.loadLast(tempDir))
+			.thenReturn(List.of(JsonNodeFactory.instance.objectNode().put("key", "last")));
+		when(secondProvider.loadLast(tempDir)).thenReturn(List.of());
+
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withConfigurationProviderExtensions(List.of(firstProvider, secondProvider))
+			.build();
+
+		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
+
+		final InOrder order = inOrder(firstProvider, secondProvider);
+		order.verify(firstProvider).load(tempDir);
+		order.verify(secondProvider).load(tempDir);
+		order.verify(firstProvider).loadLast(tempDir);
+		order.verify(secondProvider).loadLast(tempDir);
+
+		assertEquals("last", config.get("key").asText(), "Deferred fragments must be merged after regular fragments");
+	}
+
+	@Test
+	void testLoadConfigurationToleratesNullFragments() {
+		final IConfigurationProvider nullProvider = mock(IConfigurationProvider.class);
+		when(nullProvider.load(tempDir)).thenReturn(null);
+		when(nullProvider.loadLast(tempDir)).thenReturn(null);
+
+		final ExtensionManager extensionManager = ExtensionManager
+			.builder()
+			.withConfigurationProviderExtensions(List.of(nullProvider))
+			.build();
+
+		final JsonNode config = newConfigurationService().loadConfiguration(extensionManager);
+
+		assertTrue(config.isObject(), "Configuration must still be an object when providers return null");
+		assertTrue(config.isEmpty(), "Configuration must be empty when providers return null");
+	}
+
+	/**
+	 * Creates a provider returning the given YAML content as its single regular fragment.
+	 *
+	 * @param yaml the YAML content of the fragment
+	 * @return a stub {@link IConfigurationProvider}
+	 */
+	private static IConfigurationProvider staticProvider(final String yaml) {
+		return new IConfigurationProvider() {
+			@Override
+			public Collection<JsonNode> load(final Path path) {
+				return List.of(parseYaml(yaml));
+			}
+
+			@Override
+			public Set<String> getFileExtensions() {
+				return Set.of();
+			}
+		};
+	}
+
+	/**
+	 * Creates a provider returning the given YAML content as its single deferred fragment,
+	 * with the default {@code loadLastOrder}.
+	 *
+	 * @param yaml the YAML content of the fragment
+	 * @return a stub {@link IConfigurationProvider}
+	 */
+	private static IConfigurationProvider deferredProvider(final String yaml) {
+		return new IConfigurationProvider() {
+			@Override
+			public Collection<JsonNode> load(final Path path) {
+				return List.of();
+			}
+
+			@Override
+			public Collection<JsonNode> loadLast(final Path path) {
+				return List.of(parseYaml(yaml));
+			}
+
+			@Override
+			public Set<String> getFileExtensions() {
+				return Set.of();
+			}
+		};
+	}
+
+	/**
+	 * Parses the given YAML content into a {@link JsonNode}.
+	 *
+	 * @param yaml the YAML content
+	 * @return the parsed node
+	 */
+	private static JsonNode parseYaml(final String yaml) {
+		try {
+			return JsonHelper.buildYamlMapper().readTree(yaml);
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/metricshub-engine/src/main/java/org/metricshub/engine/extension/IConfigurationProvider.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/extension/IConfigurationProvider.java
@@ -41,33 +41,19 @@ public interface IConfigurationProvider {
 	Collection<JsonNode> load(Path path);
 
 	/**
-	 * Load configuration fragments that must be applied last, after the regular
-	 * fragments of <b>all</b> providers have been merged.
+	 * Load the fragments of the UI managed configuration file ({@code metricshub-ui.yaml}).
 	 * <p>
-	 * This lets a provider defer specific fragments (for example, the UI managed
-	 * {@code metricshub-ui.yaml} file) so they always take precedence over any other
-	 * configuration source, regardless of provider discovery order or file listing order.
-	 * Providers with no such fragments return an empty collection.
+	 * These fragments are merged after the regular {@link #load(Path)} fragments of
+	 * <b>all</b> providers, so the UI configuration always takes precedence over any
+	 * other configuration source, regardless of provider discovery order or file
+	 * listing order. Providers that do not manage the UI configuration return an
+	 * empty collection.
 	 *
 	 * @param path The path to the configuration directory.
-	 * @return A collection of {@link JsonNode} representing the configuration fragments to merge last.
+	 * @return A collection of {@link JsonNode} representing the UI configuration fragments.
 	 */
-	default Collection<JsonNode> loadLast(Path path) {
+	default Collection<JsonNode> loadUiFragments(Path path) {
 		return Collections.emptyList();
-	}
-
-	/**
-	 * Order of this provider within the {@link #loadLast(Path)} merge pass.
-	 * <p>
-	 * When several providers return deferred fragments, they are merged in ascending
-	 * order: fragments from providers with a greater order are merged later and thus
-	 * take precedence. The provider managing the UI configuration file returns
-	 * {@link Integer#MAX_VALUE} so it is always merged last.
-	 *
-	 * @return The merge order of this provider's deferred fragments. Defaults to {@code 0}.
-	 */
-	default int loadLastOrder() {
-		return 0;
 	}
 
 	/**

--- a/metricshub-engine/src/main/java/org/metricshub/engine/extension/IConfigurationProvider.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/extension/IConfigurationProvider.java
@@ -24,6 +24,7 @@ package org.metricshub.engine.extension;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,6 +39,36 @@ public interface IConfigurationProvider {
 	 * @return A collection of {@link JsonNode} representing the configuration fragments.
 	 */
 	Collection<JsonNode> load(Path path);
+
+	/**
+	 * Load configuration fragments that must be applied last, after the regular
+	 * fragments of <b>all</b> providers have been merged.
+	 * <p>
+	 * This lets a provider defer specific fragments (for example, the UI managed
+	 * {@code metricshub-ui.yaml} file) so they always take precedence over any other
+	 * configuration source, regardless of provider discovery order or file listing order.
+	 * Providers with no such fragments return an empty collection.
+	 *
+	 * @param path The path to the configuration directory.
+	 * @return A collection of {@link JsonNode} representing the configuration fragments to merge last.
+	 */
+	default Collection<JsonNode> loadLast(Path path) {
+		return Collections.emptyList();
+	}
+
+	/**
+	 * Order of this provider within the {@link #loadLast(Path)} merge pass.
+	 * <p>
+	 * When several providers return deferred fragments, they are merged in ascending
+	 * order: fragments from providers with a greater order are merged later and thus
+	 * take precedence. The provider managing the UI configuration file returns
+	 * {@link Integer#MAX_VALUE} so it is always merged last.
+	 *
+	 * @return The merge order of this provider's deferred fragments. Defaults to {@code 0}.
+	 */
+	default int loadLastOrder() {
+		return 0;
+	}
 
 	/**
 	 * Get the set of the file extensions that this configuration provider can handle.

--- a/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
+++ b/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
@@ -48,8 +48,8 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 
 	/**
 	 * Name of the UI managed configuration file. It is excluded from the regular
-	 * {@link #load(Path)} pass and only returned by {@link #loadLast(Path)} so it is
-	 * always merged after every other configuration fragment.
+	 * {@link #load(Path)} pass and only returned by {@link #loadUiFragments(Path)} so it
+	 * is always merged after every other configuration fragment.
 	 */
 	static final String UI_CONFIGURATION_FILENAME = "metricshub-ui.yaml";
 
@@ -82,7 +82,7 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 	}
 
 	@Override
-	public Collection<JsonNode> loadLast(final Path configDirectory) {
+	public Collection<JsonNode> loadUiFragments(final Path configDirectory) {
 		final List<JsonNode> configurations = new ArrayList<>();
 
 		try (Stream<Path> stream = Files.list(configDirectory)) {
@@ -101,13 +101,6 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 		}
 
 		return configurations;
-	}
-
-	@Override
-	public int loadLastOrder() {
-		// This provider defers the UI configuration file, which must win over any other
-		// deferred fragment: merge it after every other provider's loadLast pass.
-		return Integer.MAX_VALUE;
 	}
 
 	/**

--- a/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
+++ b/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
@@ -105,12 +105,17 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 
 	/**
 	 * Checks whether the given path is the UI managed configuration file.
+	 * <p>
+	 * The match is exact (case-sensitive): the UI always writes the canonical
+	 * {@value #UI_CONFIGURATION_FILENAME} name. On case-sensitive filesystems an
+	 * alternate-case variant is a different, hand-made file: it is deliberately treated
+	 * as a regular fragment, so the canonical UI file is always merged after it.
 	 *
 	 * @param path The path to check.
-	 * @return {@code true} if the file name matches {@value #UI_CONFIGURATION_FILENAME} (case-insensitive).
+	 * @return {@code true} if the file name is exactly {@value #UI_CONFIGURATION_FILENAME}.
 	 */
 	private static boolean isUiConfigurationFile(final Path path) {
-		return UI_CONFIGURATION_FILENAME.equalsIgnoreCase(path.getFileName().toString());
+		return UI_CONFIGURATION_FILENAME.equals(path.getFileName().toString());
 	}
 
 	/**

--- a/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
+++ b/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
@@ -106,16 +106,24 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 	/**
 	 * Checks whether the given path is the UI managed configuration file.
 	 * <p>
-	 * The match is exact (case-sensitive): the UI always writes the canonical
-	 * {@value #UI_CONFIGURATION_FILENAME} name. On case-sensitive filesystems an
-	 * alternate-case variant is a different, hand-made file: it is deliberately treated
-	 * as a regular fragment, so the canonical UI file is always merged after it.
+	 * The comparison relies on filesystem identity ({@link Files#isSameFile}) against the
+	 * canonical {@value #UI_CONFIGURATION_FILENAME} sibling, mirroring how the UI resolves
+	 * the file it reads and writes. On case-insensitive filesystems (e.g. Windows) an
+	 * alternate-case variant is the UI file itself and is deferred accordingly, while on
+	 * case-sensitive filesystems it is a distinct, hand-made file treated as a regular
+	 * fragment and therefore merged before the UI configuration.
 	 *
-	 * @param path The path to check.
-	 * @return {@code true} if the file name is exactly {@value #UI_CONFIGURATION_FILENAME}.
+	 * @param path The path to check (an existing file).
+	 * @return {@code true} if the path designates the UI managed configuration file.
 	 */
-	private static boolean isUiConfigurationFile(final Path path) {
-		return UI_CONFIGURATION_FILENAME.equals(path.getFileName().toString());
+	static boolean isUiConfigurationFile(final Path path) {
+		final Path uiConfigurationFile = path.resolveSibling(UI_CONFIGURATION_FILENAME);
+		try {
+			return Files.exists(uiConfigurationFile) && Files.isSameFile(path, uiConfigurationFile);
+		} catch (IOException e) {
+			log.debug("Cannot compare '{}' with the UI configuration file '{}'. Exception:", path, uiConfigurationFile, e);
+			return false;
+		}
 	}
 
 	/**

--- a/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
+++ b/metricshub-yaml-configuration-extension/src/main/java/org/metricshub/configuration/YamlConfigurationProvider.java
@@ -46,6 +46,13 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 
 	private static final ObjectMapper YAML_MAPPER = JsonHelper.buildYamlMapper();
 
+	/**
+	 * Name of the UI managed configuration file. It is excluded from the regular
+	 * {@link #load(Path)} pass and only returned by {@link #loadLast(Path)} so it is
+	 * always merged after every other configuration fragment.
+	 */
+	static final String UI_CONFIGURATION_FILENAME = "metricshub-ui.yaml";
+
 	@Override
 	public Collection<JsonNode> load(final Path configDirectory) {
 		final List<JsonNode> configurations = new ArrayList<>();
@@ -57,6 +64,7 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 					String fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
 					return getFileExtensions().stream().anyMatch(fileName::endsWith);
 				})
+				.filter((Path path) -> !isUiConfigurationFile(path))
 				.forEach((Path path) ->
 					readFragment(path).ifPresent((JsonNode jsonNode) -> {
 						configurations.add(jsonNode);
@@ -71,6 +79,45 @@ public class YamlConfigurationProvider implements IConfigurationProvider {
 		final int size = configurations.size();
 		log.info("Loaded {} YAML configuration fragment{} from '{}'.", size, size > 1 ? "s" : "", configDirectory);
 		return configurations;
+	}
+
+	@Override
+	public Collection<JsonNode> loadLast(final Path configDirectory) {
+		final List<JsonNode> configurations = new ArrayList<>();
+
+		try (Stream<Path> stream = Files.list(configDirectory)) {
+			stream
+				.filter((Path path) -> !Files.isDirectory(path))
+				.filter(YamlConfigurationProvider::isUiConfigurationFile)
+				.forEach((Path path) ->
+					readFragment(path).ifPresent((JsonNode jsonNode) -> {
+						configurations.add(jsonNode);
+						log.debug("Successfully loaded UI YAML configuration fragment: '{}'", path);
+					})
+				);
+		} catch (IOException e) {
+			log.error("Failed to list configuration directory: '{}'. Error: {}", configDirectory, e.getMessage());
+			log.debug("Failed to list configuration directory: '{}'. Exception:", configDirectory, e);
+		}
+
+		return configurations;
+	}
+
+	@Override
+	public int loadLastOrder() {
+		// This provider defers the UI configuration file, which must win over any other
+		// deferred fragment: merge it after every other provider's loadLast pass.
+		return Integer.MAX_VALUE;
+	}
+
+	/**
+	 * Checks whether the given path is the UI managed configuration file.
+	 *
+	 * @param path The path to check.
+	 * @return {@code true} if the file name matches {@value #UI_CONFIGURATION_FILENAME} (case-insensitive).
+	 */
+	private static boolean isUiConfigurationFile(final Path path) {
+		return UI_CONFIGURATION_FILENAME.equalsIgnoreCase(path.getFileName().toString());
 	}
 
 	/**

--- a/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
+++ b/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
@@ -85,6 +85,63 @@ class YamlConfigurationProviderTest {
 	}
 
 	@Test
+	void testLoadExcludesUiConfigurationFile(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("config1.yaml"), "key1: value1");
+		Files.writeString(tempDir.resolve(YamlConfigurationProvider.UI_CONFIGURATION_FILENAME), "key1: uiValue");
+
+		final Collection<JsonNode> configurations = provider.load(tempDir);
+
+		assertEquals(1, configurations.size(), "load() should skip the UI configuration file");
+		assertEquals(
+			"value1",
+			getJsonNodeAsText(configurations.iterator().next(), "key1"),
+			"Only config1.yaml should be loaded by load()"
+		);
+	}
+
+	@Test
+	void testLoadLastReturnsOnlyUiConfigurationFile(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("config1.yaml"), "key1: value1");
+		Files.writeString(tempDir.resolve(YamlConfigurationProvider.UI_CONFIGURATION_FILENAME), "key1: uiValue");
+
+		// Create an empty directory to make sure directories are skipped
+		Files.createDirectories(tempDir.resolve("additional-dir"));
+
+		final Collection<JsonNode> configurations = provider.loadLast(tempDir);
+
+		assertEquals(1, configurations.size(), "loadLast() should return only the UI configuration file");
+		assertEquals(
+			"uiValue",
+			getJsonNodeAsText(configurations.iterator().next(), "key1"),
+			"loadLast() should load the UI configuration fragment"
+		);
+	}
+
+	@Test
+	void testLoadLastWithoutUiConfigurationFile(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve("config1.yaml"), "key1: value1");
+
+		final Collection<JsonNode> configurations = provider.loadLast(tempDir);
+
+		assertTrue(configurations.isEmpty(), "loadLast() should be empty when the UI configuration file is absent");
+	}
+
+	@Test
+	void testLoadLastWithInvalidDirectory(@TempDir Path tempDir) {
+		final Collection<JsonNode> configurations = provider.loadLast(tempDir.resolve("invalid-dir"));
+		assertTrue(configurations.isEmpty(), "Invalid directory should yield no configurations");
+	}
+
+	@Test
+	void testLoadLastOrderIsMaximum() {
+		assertEquals(
+			Integer.MAX_VALUE,
+			provider.loadLastOrder(),
+			"The UI configuration fragment must be merged after every other deferred fragment"
+		);
+	}
+
+	@Test
 	void testLoadWithInvalidYaml(@TempDir Path tempDir) throws IOException {
 		final Path invalidYaml = tempDir.resolve("invalid.yaml");
 		Files.writeString(invalidYaml, "key: : : value");

--- a/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
+++ b/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
@@ -133,6 +133,24 @@ class YamlConfigurationProviderTest {
 	}
 
 	@Test
+	void testAlternateCaseUiFileIsARegularFragment(@TempDir Path tempDir) throws IOException {
+		// Only the canonical name written by the UI is a UI fragment: an alternate-case
+		// variant is a regular fragment, merged before the canonical file.
+		Files.writeString(tempDir.resolve("METRICSHUB-UI.YAML"), "key1: alternateCase");
+
+		final Collection<JsonNode> uiFragments = provider.loadUiFragments(tempDir);
+		assertTrue(uiFragments.isEmpty(), "An alternate-case variant must not be returned by loadUiFragments()");
+
+		final Collection<JsonNode> configurations = provider.load(tempDir);
+		assertEquals(1, configurations.size(), "An alternate-case variant must be loaded as a regular fragment");
+		assertEquals(
+			"alternateCase",
+			getJsonNodeAsText(configurations.iterator().next(), "key1"),
+			"The alternate-case variant content must be loaded by load()"
+		);
+	}
+
+	@Test
 	void testLoadWithInvalidYaml(@TempDir Path tempDir) throws IOException {
 		final Path invalidYaml = tempDir.resolve("invalid.yaml");
 		Files.writeString(invalidYaml, "key: : : value");

--- a/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
+++ b/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
@@ -1,6 +1,7 @@
 package org.metricshub.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -133,20 +134,44 @@ class YamlConfigurationProviderTest {
 	}
 
 	@Test
-	void testAlternateCaseUiFileIsARegularFragment(@TempDir Path tempDir) throws IOException {
-		// Only the canonical name written by the UI is a UI fragment: an alternate-case
-		// variant is a regular fragment, merged before the canonical file.
+	void testAlternateCaseUiFileFollowsFilesystemSemantics(@TempDir Path tempDir) throws IOException {
+		// The UI file is identified by filesystem identity, mirroring how the UI resolves
+		// the file it reads and writes.
 		Files.writeString(tempDir.resolve("METRICSHUB-UI.YAML"), "key1: alternateCase");
 
 		final Collection<JsonNode> uiFragments = provider.loadUiFragments(tempDir);
-		assertTrue(uiFragments.isEmpty(), "An alternate-case variant must not be returned by loadUiFragments()");
-
 		final Collection<JsonNode> configurations = provider.load(tempDir);
-		assertEquals(1, configurations.size(), "An alternate-case variant must be loaded as a regular fragment");
-		assertEquals(
-			"alternateCase",
-			getJsonNodeAsText(configurations.iterator().next(), "key1"),
-			"The alternate-case variant content must be loaded by load()"
+
+		if (Files.exists(tempDir.resolve(YamlConfigurationProvider.UI_CONFIGURATION_FILENAME))) {
+			// Case-insensitive filesystem (e.g. Windows): the variant IS the UI file
+			assertEquals(1, uiFragments.size(), "On a case-insensitive filesystem the variant is the UI file");
+			assertTrue(configurations.isEmpty(), "The UI file must not be loaded as a regular fragment");
+			assertEquals(
+				"alternateCase",
+				getJsonNodeAsText(uiFragments.iterator().next(), "key1"),
+				"The UI file content must be loaded by loadUiFragments()"
+			);
+		} else {
+			// Case-sensitive filesystem: the variant is a distinct, hand-made regular fragment
+			assertTrue(uiFragments.isEmpty(), "A distinct alternate-case file must not be a UI fragment");
+			assertEquals(1, configurations.size(), "A distinct alternate-case file is a regular fragment");
+			assertEquals(
+				"alternateCase",
+				getJsonNodeAsText(configurations.iterator().next(), "key1"),
+				"The alternate-case variant content must be loaded by load()"
+			);
+		}
+	}
+
+	@Test
+	void testIsUiConfigurationFileWhenComparisonFails(@TempDir Path tempDir) throws IOException {
+		Files.writeString(tempDir.resolve(YamlConfigurationProvider.UI_CONFIGURATION_FILENAME), "key1: uiValue");
+
+		// The given path does not exist: Files.isSameFile fails and the file is
+		// conservatively treated as a regular fragment.
+		assertFalse(
+			YamlConfigurationProvider.isUiConfigurationFile(tempDir.resolve("missing.yaml")),
+			"A path that cannot be compared must not be classified as the UI configuration file"
 		);
 	}
 

--- a/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
+++ b/metricshub-yaml-configuration-extension/src/test/java/org/metricshub/configuration/YamlConfigurationProviderTest.java
@@ -100,45 +100,36 @@ class YamlConfigurationProviderTest {
 	}
 
 	@Test
-	void testLoadLastReturnsOnlyUiConfigurationFile(@TempDir Path tempDir) throws IOException {
+	void testLoadUiFragmentsReturnsOnlyUiConfigurationFile(@TempDir Path tempDir) throws IOException {
 		Files.writeString(tempDir.resolve("config1.yaml"), "key1: value1");
 		Files.writeString(tempDir.resolve(YamlConfigurationProvider.UI_CONFIGURATION_FILENAME), "key1: uiValue");
 
 		// Create an empty directory to make sure directories are skipped
 		Files.createDirectories(tempDir.resolve("additional-dir"));
 
-		final Collection<JsonNode> configurations = provider.loadLast(tempDir);
+		final Collection<JsonNode> configurations = provider.loadUiFragments(tempDir);
 
-		assertEquals(1, configurations.size(), "loadLast() should return only the UI configuration file");
+		assertEquals(1, configurations.size(), "loadUiFragments() should return only the UI configuration file");
 		assertEquals(
 			"uiValue",
 			getJsonNodeAsText(configurations.iterator().next(), "key1"),
-			"loadLast() should load the UI configuration fragment"
+			"loadUiFragments() should load the UI configuration fragment"
 		);
 	}
 
 	@Test
-	void testLoadLastWithoutUiConfigurationFile(@TempDir Path tempDir) throws IOException {
+	void testLoadUiFragmentsWithoutUiConfigurationFile(@TempDir Path tempDir) throws IOException {
 		Files.writeString(tempDir.resolve("config1.yaml"), "key1: value1");
 
-		final Collection<JsonNode> configurations = provider.loadLast(tempDir);
+		final Collection<JsonNode> configurations = provider.loadUiFragments(tempDir);
 
-		assertTrue(configurations.isEmpty(), "loadLast() should be empty when the UI configuration file is absent");
+		assertTrue(configurations.isEmpty(), "loadUiFragments() should be empty when the UI configuration file is absent");
 	}
 
 	@Test
-	void testLoadLastWithInvalidDirectory(@TempDir Path tempDir) {
-		final Collection<JsonNode> configurations = provider.loadLast(tempDir.resolve("invalid-dir"));
+	void testLoadUiFragmentsWithInvalidDirectory(@TempDir Path tempDir) {
+		final Collection<JsonNode> configurations = provider.loadUiFragments(tempDir.resolve("invalid-dir"));
 		assertTrue(configurations.isEmpty(), "Invalid directory should yield no configurations");
-	}
-
-	@Test
-	void testLoadLastOrderIsMaximum() {
-		assertEquals(
-			Integer.MAX_VALUE,
-			provider.loadLastOrder(),
-			"The UI configuration fragment must be merged after every other deferred fragment"
-		);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #1299

**Problem**

`ConfigurationService.loadConfiguration()` merges fragments in provider discovery order, and `YamlConfigurationProvider` returns YAML files in directory-listing order. The UI-managed `metricshub-ui.yaml` could therefore be overridden by YAML files sorting after it (e.g. `zzz.yaml`) or by fragments from providers discovered later (e.g. `.vm` Velocity templates).

**Changes**

- **`IConfigurationProvider`** (engine): new default `loadUiFragments(Path)` method returning the fragments of the UI-managed configuration file (empty for providers that do not manage it).
- **`YamlConfigurationProvider`**: excludes `metricshub-ui.yaml` from the regular `load()` pass and returns it from `loadUiFragments()`.
- **`ConfigurationService`**: merges all providers'' regular fragments first, then merges the UI fragments at the end, so the UI configuration always takes precedence. This covers agent startup, reload, and the UI''s `loadMergedConfiguration()` path.
- **Docs**: the precedence rule is documented in `README.md` and `UI.md`.

**Tests**

- `YamlConfigurationProviderTest`: `load()` exclusion, `loadUiFragments()` behavior (present/absent/invalid directory).
- New `ConfigurationServiceTest`: UI file wins over files sorting after it and over providers discovered before/after the YAML provider, `load()` of all providers invoked before any `loadUiFragments()`, null-fragment tolerance.

**Checks**

`mvn prettier:write`, `mvn license:check-file-header`, and `mvn checkstyle:check` pass on the three modified modules; module test suites pass (yaml extension 9/9 with the 100% JaCoCo gate, agent 66/66 across the configuration-related test classes, engine extension tests 36/36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)