### PR TITLE
Issue #1302: Fix .vm draft templates failing Test/Apply and draft deletion on failed Apply

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ConfigurationFilesService.java
@@ -85,7 +85,7 @@ public class ConfigurationFilesService {
 	/**
 	 * Extension for draft configuration files.
 	 */
-	private static final String DRAFT_EXTENSION = ".draft";
+	public static final String DRAFT_EXTENSION = ".draft";
 
 	/**
 	 * Name of the backup directory for configuration files.

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/OtelConfigurationFilesService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/OtelConfigurationFilesService.java
@@ -84,7 +84,7 @@ public class OtelConfigurationFilesService {
 	/**
 	 * Extension for draft configuration files.
 	 */
-	private static final String DRAFT_EXTENSION = ".draft";
+	private static final String DRAFT_EXTENSION = ConfigurationFilesService.DRAFT_EXTENSION;
 
 	/**
 	 * Name of the backup directory for OTEL configuration files.

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
@@ -160,8 +160,10 @@ public class VelocityTemplateService {
 		}
 		String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
 		if (lowerCaseName.endsWith(ConfigurationFilesService.DRAFT_EXTENSION)) {
-			lowerCaseName =
-				lowerCaseName.substring(0, lowerCaseName.length() - ConfigurationFilesService.DRAFT_EXTENSION.length());
+			lowerCaseName = lowerCaseName.substring(
+				0,
+				lowerCaseName.length() - ConfigurationFilesService.DRAFT_EXTENSION.length()
+			);
 		}
 		final String providerLookupName = lowerCaseName;
 		return agentContext

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
@@ -40,6 +40,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class VelocityTemplateService {
 
+	/**
+	 * Extension for draft configuration files.
+	 */
+	private static final String DRAFT_EXTENSION = ".draft";
+
 	private final AgentContextHolder agentContextHolder;
 
 	/**
@@ -142,7 +147,8 @@ public class VelocityTemplateService {
 
 	/**
 	 * Finds the configuration provider extension able to handle the given template file,
-	 * based on its file extension.
+	 * based on its file extension. Draft templates (for example {@code my-config.vm.draft})
+	 * are matched against the provider of their base file.
 	 *
 	 * @param fileName the template file name (for example {@code my-config.vm})
 	 * @return the matching {@link IConfigurationProvider}
@@ -157,12 +163,16 @@ public class VelocityTemplateService {
 				"Extension manager is not available."
 			);
 		}
-		final String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
+		String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
+		if (lowerCaseName.endsWith(DRAFT_EXTENSION)) {
+			lowerCaseName = lowerCaseName.substring(0, lowerCaseName.length() - DRAFT_EXTENSION.length());
+		}
+		final String providerLookupName = lowerCaseName;
 		return agentContext
 			.getExtensionManager()
 			.getConfigurationProviderExtensions()
 			.stream()
-			.filter(provider -> provider.getFileExtensions().stream().anyMatch(lowerCaseName::endsWith))
+			.filter(provider -> provider.getFileExtensions().stream().anyMatch(providerLookupName::endsWith))
 			.findFirst()
 			.orElseThrow(() ->
 				new ConfigFilesException(

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/VelocityTemplateService.java
@@ -40,11 +40,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class VelocityTemplateService {
 
-	/**
-	 * Extension for draft configuration files.
-	 */
-	private static final String DRAFT_EXTENSION = ".draft";
-
 	private final AgentContextHolder agentContextHolder;
 
 	/**
@@ -164,8 +159,9 @@ public class VelocityTemplateService {
 			);
 		}
 		String lowerCaseName = fileName.toLowerCase(Locale.ROOT);
-		if (lowerCaseName.endsWith(DRAFT_EXTENSION)) {
-			lowerCaseName = lowerCaseName.substring(0, lowerCaseName.length() - DRAFT_EXTENSION.length());
+		if (lowerCaseName.endsWith(ConfigurationFilesService.DRAFT_EXTENSION)) {
+			lowerCaseName =
+				lowerCaseName.substring(0, lowerCaseName.length() - ConfigurationFilesService.DRAFT_EXTENSION.length());
 		}
 		final String providerLookupName = lowerCaseName;
 		return agentContext

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/VelocityTemplateServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/VelocityTemplateServiceTest.java
@@ -75,6 +75,29 @@ class VelocityTemplateServiceTest {
 	}
 
 	@Test
+	void testEvaluateDraftTemplateFromContent() throws Exception {
+		final VelocityTemplateService service = newServiceWithDir(tempConfigDir);
+		final String templateContent = "#set($name = \"world\")\nhello: $name\n";
+
+		final String result = service.evaluate("test.vm.draft", templateContent);
+
+		assertNotNull(result, "Result should not be null");
+		assertTrue(result.contains("hello: world"), "Draft template should be evaluated like its base .vm file");
+	}
+
+	@Test
+	void testEvaluateDraftTemplateOnDisk() throws Exception {
+		final VelocityTemplateService service = newServiceWithDir(tempConfigDir);
+		final String templateContent = "#set($name = \"world\")\nhello: $name\n";
+		Files.writeString(tempConfigDir.resolve("test.vm.draft"), templateContent, StandardCharsets.UTF_8);
+
+		final String result = service.evaluate("test.vm.draft", null);
+
+		assertNotNull(result, "Result should not be null");
+		assertTrue(result.contains("hello: world"), "Draft template should be evaluated like its base .vm file");
+	}
+
+	@Test
 	void testEvaluateFileNotFound() {
 		final VelocityTemplateService service = newServiceWithDir(tempConfigDir);
 

--- a/metricshub-web/react/src/components/config/editor/ConfigEditorContainer.jsx
+++ b/metricshub-web/react/src/components/config/editor/ConfigEditorContainer.jsx
@@ -148,10 +148,9 @@ function ConfigEditorContainer(props) {
 				// Navigate to normal file
 				navigate(paths.configurationFile(targetName), { replace: true });
 				// Delete the draft after navigation starts to avoid re-fetching a deleted file
-				return new Promise((resolve) => setTimeout(resolve, 50));
-			})
-			.then(() => {
-				dispatch(deleteConfig(selected));
+				return new Promise((resolve) => setTimeout(resolve, 50)).then(() =>
+					dispatch(deleteConfig(selected)),
+				);
 			})
 			.catch((e) => {
 				setDialog({ open: true, message: e?.message || "Validation failed" });

--- a/metricshub-web/react/src/components/otel/editor/OtelConfigEditorContainer.jsx
+++ b/metricshub-web/react/src/components/otel/editor/OtelConfigEditorContainer.jsx
@@ -110,10 +110,9 @@ function OtelConfigEditorContainer(props) {
 			.then((saved) => {
 				if (!saved) return null;
 				navigate(paths.configurationOtelFile(targetName), { replace: true });
-				return new Promise((resolve) => setTimeout(resolve, 50));
-			})
-			.then(() => {
-				dispatch(deleteOtelConfig(selected));
+				return new Promise((resolve) => setTimeout(resolve, 50)).then(() =>
+					dispatch(deleteOtelConfig(selected)),
+				);
 			})
 			.catch((e) => {
 				setDialog({ open: true, message: e?.message || "Validation failed" });


### PR DESCRIPTION
Fixes #1302

## Problem

Since v3.9.05, `.vm` templates converted to draft in the Web UI fail **Test** and **Apply** with:

> No configuration provider found for template 'resources.vm.draft'.

Worse, a failed **Apply** deleted the draft file from disk, losing the user's work. v3.9.04 worked correctly.

## Root cause

1. **Backend regression** (from the #1271 extension classloader isolation refactor): `VelocityTemplateService.evaluate()` used to instantiate `VelocityConfigurationLoader` directly, ignoring the file name. It now resolves the configuration provider by matching the file name ending against provider extensions. The Velocity provider registers `.vm`, so a `*.vm.draft` name never matches and every Test / validate / Apply on a draft fails.

2. **Frontend data-loss bug**: in `ConfigEditorContainer.jsx` and `OtelConfigEditorContainer.jsx`, the Apply promise chain dispatched `deleteConfig(selected)` in an unconditional final `.then()`. On validation failure the earlier steps returned `null` without breaking the chain, so the draft was deleted even though nothing was saved. Latent before 3.9.05 (also affected OTEL YAML drafts); the `.vm` regression made it systematic.

## Changes

- `VelocityTemplateService.findProviderFor()` strips the `.draft` suffix before matching provider extensions, consistent with `ConfigurationFilesService.isVmFile()`.
- Draft deletion in both editor containers now only runs after a successful save.
- Added regression tests covering `.vm.draft` evaluation from editor content and from disk.

## Testing

- `mvn test -Dtest=VelocityTemplateServiceTest`: 8/8 pass (2 new draft regression tests).
- ESLint clean on both modified JSX files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)