### PR TITLE
Web UI: keep the typed text in a protocol hostname override cell

### DIFF
--- a/metricshub-web/react/src/components/hosts/ProtocolHostnameOverridesTable.jsx
+++ b/metricshub-web/react/src/components/hosts/ProtocolHostnameOverridesTable.jsx
@@ -155,6 +155,20 @@ const ProtocolHostnameOverridesTable = ({
 	const slots = React.useMemo(() => deriveOverrideSlots(value, hostNames), [value, hostNames]);
 	const configuredCount = slots.filter(Boolean).length;
 
+	// Latest slots in a ref so the per-row change handler stays referentially
+	// stable and memoized rows only re-render when their own cell changes.
+	const slotsRef = React.useRef(slots);
+	slotsRef.current = slots;
+
+	// The row being edited stays mounted even when its override stops matching
+	// the search (typing a replacement must not unmount the focused input), and
+	// it renders the raw typed text instead of the derived slot: deriveOverrideSlots
+	// collapses a slot equal to its own host.name entry back to blank, which would
+	// wipe the cell the moment the typed value passes through the host entry
+	// itself — making a longer name ("host12" over "host1") impossible to type.
+	const [editingIndex, setEditingIndex] = React.useState(/** @type {number | null} */ (null));
+	const [editingValue, setEditingValue] = React.useState("");
+
 	// Hosts sharing one effective collection hostname get a per-row warning and
 	// a clickable count chip that filters the table down to just those rows.
 	const duplicateGroups = React.useMemo(
@@ -190,18 +204,23 @@ const ProtocolHostnameOverridesTable = ({
 	const hostNamesKey = hostNames.join(" ");
 	React.useEffect(() => {
 		setDuplicateSnapshot(null);
+		// The in-progress raw text is bound to a row index too: drop it as well
+		// rather than let it bleed onto whatever host now sits at that index.
+		setEditingIndex(null);
 	}, [hostNamesKey]);
 
-	// Latest slots in a ref so the per-row change handler stays referentially
-	// stable and memoized rows only re-render when their own cell changes.
-	const slotsRef = React.useRef(slots);
-	slotsRef.current = slots;
+	const handleSlotFocus = React.useCallback((index) => {
+		setEditingIndex(index);
+		setEditingValue(slotsRef.current[index] || "");
+	}, []);
+	const handleSlotBlur = React.useCallback(() => setEditingIndex(null), []);
 
 	const handleSlotChange = React.useCallback(
 		(index, raw) => {
 			// Hostnames never contain whitespace, and `,`/`;` are the multi-value
 			// separators of the stored configuration: block all three at input.
 			const sanitized = raw.replace(/[;,\s]/g, "");
+			setEditingValue(sanitized);
 			const next = [...slotsRef.current];
 			next[index] = sanitized;
 			onChange(next);
@@ -211,12 +230,6 @@ const ProtocolHostnameOverridesTable = ({
 
 	const needle = query.trim().toLowerCase();
 	const filteredView = Boolean(needle) || showDuplicatesOnly;
-
-	// The row being edited stays mounted even when its override stops matching
-	// the search (typing a replacement must not unmount the focused input).
-	const [editingIndex, setEditingIndex] = React.useState(/** @type {number | null} */ (null));
-	const handleSlotFocus = React.useCallback((index) => setEditingIndex(index), []);
-	const handleSlotBlur = React.useCallback(() => setEditingIndex(null), []);
 
 	const handleSlotPaste = React.useCallback(
 		(index, event) => {
@@ -241,6 +254,8 @@ const ProtocolHostnameOverridesTable = ({
 					next[index + offset] = token;
 				});
 			}
+			// The pasted-into row holds the focus, so its raw text drives the cell.
+			setEditingValue(next[index] || "");
 			onChange(next);
 		},
 		[filteredView, onChange],
@@ -368,7 +383,7 @@ const ProtocolHostnameOverridesTable = ({
 									key={index}
 									index={index}
 									hostEntry={hostEntry}
-									slotValue={slots[index] || ""}
+									slotValue={index === editingIndex ? editingValue : slots[index] || ""}
 									duplicateTitle={duplicateTitles.get(index) || ""}
 									onSlotChange={handleSlotChange}
 									onSlotPaste={handleSlotPaste}

--- a/metricshub-web/react/src/components/hosts/ProtocolHostnameOverridesTable.test.jsx
+++ b/metricshub-web/react/src/components/hosts/ProtocolHostnameOverridesTable.test.jsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ProtocolHostnameOverridesTable from "./ProtocolHostnameOverridesTable";
+
+/** Controlled wrapper mirroring how ProtocolConfigForm drives the table. */
+const Harness = ({ hostNames, initialValue = [] }) => {
+	const [value, setValue] = React.useState(initialValue);
+	return (
+		<ProtocolHostnameOverridesTable
+			hostNames={hostNames}
+			value={value}
+			onChange={setValue}
+			label="Hostname"
+		/>
+	);
+};
+
+describe("ProtocolHostnameOverridesTable", () => {
+	it("keeps the typed text when it passes through the row's own host.name entry", () => {
+		render(<Harness hostNames={["host1", "host2"]} />);
+		const input = screen.getByLabelText("Hostname override for host1");
+
+		// Typing "host1" makes the override equal to the host entry: the derived
+		// slot collapses to blank, but the focused cell must keep the raw text so
+		// the next keystroke can extend it to "host12".
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: "host1" } });
+		expect(input).toHaveValue("host1");
+
+		fireEvent.change(input, { target: { value: "host12" } });
+		expect(input).toHaveValue("host12");
+	});
+
+	it("shows the host.name entry as a blank cell once the row loses focus", () => {
+		render(<Harness hostNames={["host1", "host2"]} />);
+		const input = screen.getByLabelText("Hostname override for host1");
+
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: "host1" } });
+		fireEvent.blur(input);
+
+		expect(input).toHaveValue("");
+		expect(input).toHaveAttribute("placeholder", "host1");
+	});
+
+	it("renders a saved override and lets it be edited from its stored value", () => {
+		render(<Harness hostNames={["host1", "host2"]} initialValue={["proxy1", "host2"]} />);
+		const input = screen.getByLabelText("Hostname override for host1");
+		expect(input).toHaveValue("proxy1");
+
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: "proxy12" } });
+		expect(input).toHaveValue("proxy12");
+	});
+});


### PR DESCRIPTION
## Problem

In the multi-host **protocol hostname** mapping table, typing an override into a row cleared the cell as soon as the text matched that row's own `host.name` entry. On the `host1` row, typing `host1` emptied the field — so `host12` could never be typed, because there was nothing left to append to.

## Cause

Each cell rendered straight from `deriveOverrideSlots(value, hostNames)`, which deliberately collapses a slot equal to its own `host.name` entry back to blank. That is the "blank = use the `host.name` entry" contract that keeps a saved partial mapping rendering identically after a reload — but applied mid-keystroke it wipes the input the moment the typed value passes through the host entry.

## Fix

The focused row now renders the raw typed text instead of the derived slot:

- `editingValue` is added alongside the existing `editingIndex`; focus seeds it from the current slot, each keystroke updates it, and a multi-value paste into the focused row syncs it too.
- The cell value is `index === editingIndex ? editingValue : slots[index] || ""`, so unfocused rows keep the canonical derived rendering — a value equal to the host entry still collapses to the grey placeholder on blur, matching what a reload shows.
- The in-progress text is dropped when the `host.name` list changes, so stale raw text cannot bleed onto whatever host lands at that index.

## Tests

New `ProtocolHostnameOverridesTable.test.jsx` with three cases; the first (typing `host1` then `host12` on the `host1` row) fails on the old code and is the regression guard.

## Validation

Web-only change — no Java sources touched.

- `npm run format` — clean
- `npm run lint` — clean
- `npm test` — 39 files / 321 tests passing
- `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
