### PR TITLE
Web UI: list the Other host type last in the Host Type select

### DIFF
--- a/metricshub-web/react/src/components/hosts/connector-utils.test.js
+++ b/metricshub-web/react/src/components/hosts/connector-utils.test.js
@@ -94,6 +94,13 @@ describe("other host.type", () => {
 		expect(HOST_TYPES).toContain("other");
 	});
 
+	it("offers Other last, after the concrete host types sorted A–Z", () => {
+		expect(HOST_TYPES[HOST_TYPES.length - 1]).toBe("other");
+		const concrete = HOST_TYPES.slice(0, -1);
+		expect(concrete).not.toContain("other");
+		expect(concrete).toEqual([...concrete].sort((a, b) => a.localeCompare(b)));
+	});
+
 	it("labels the other key instead of falling back to the raw value", () => {
 		expect(formatHostTypeLabel("other")).toBe("Other");
 	});

--- a/metricshub-web/react/src/components/hosts/protocol-definitions.js
+++ b/metricshub-web/react/src/components/hosts/protocol-definitions.js
@@ -95,7 +95,18 @@ export const HOST_TYPE_LABELS = {
 	windows: "Windows",
 };
 
-export const HOST_TYPES = Object.keys(HOST_TYPE_LABELS).sort(compareLocale);
+/** Catch-all host.type key, always offered last in the form select. */
+export const HOST_TYPE_OTHER = "other";
+
+/**
+ * Selectable host.type keys: concrete platforms A–Z, then the "other" catch-all.
+ */
+export const HOST_TYPES = [
+	...Object.keys(HOST_TYPE_LABELS)
+		.filter((hostType) => hostType !== HOST_TYPE_OTHER)
+		.sort(compareLocale),
+	HOST_TYPE_OTHER,
+];
 
 /**
  * @param {string} [hostType]


### PR DESCRIPTION
Closes #1319

## Problem

In the guided configuration form (create/edit resource), the **Host Type** select sorted every `host.type` key alphabetically, so **Other** landed in the middle of the list — between OOB and Solaris.

## Change

`HOST_TYPES` is now built as *concrete platforms sorted A–Z*, followed by the `other` catch-all:

`Aix, HP-UX, IBM i, Linux, Network, OOB, Solaris, Storage, Windows, Other`

A `HOST_TYPE_OTHER` constant keeps the catch-all key out of the ordering logic as a bare string literal.

`HOST_TYPES` is consumed only by the Host Type select in `HostConfigBasicsSection.jsx` (plus tests), so no other list ordering changes.

## Tests

Added a case in `connector-utils.test.js` asserting `other` is last and the remaining keys stay alphabetical. `connector-utils.test.js` + `HostTypeIcon.test.jsx`: 54 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2544" height="1273" alt="image" src="https://github.com/user-attachments/assets/61798c44-cd30-4b52-b1c3-9a14cc592d4d" />

