### PR TITLE
Issue #1321: File source: support wildcards in directory segments of paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ This is a multi-module project:
 > [!TIP]
 > Looking for connectors? Check the [MetricsHub Community Connectors](https://github.com/metricshub/community-connectors) repository.
 
+## File log capture
+
+When a file source uses wildcards or multiple paths, LOG mode includes an empty
+`<<<LOG:file="...">>>` / `<<<END_LOG>>>` block for each accessible file on its first
+poll and on subsequent polls with no new content. The first poll initializes the
+cursor without reading existing content. A single literal path retains its
+content-only output format.
+
 ## How to build the Project
 
 ### Requirements

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -582,16 +582,30 @@ public class FileHelper {
 	}
 
 	/**
-	 * Escapes {@code [} and {@code ]}, which PowerShell wildcards treat as character classes, so that they match
-	 * literally in a {@code Get-Item -Path} pattern and only {@code *} and {@code ?} act as wildcards.
-	 * The backtick is doubled because the pattern is embedded in a double-quoted PowerShell string, where a single
-	 * backtick would be consumed as the string escape character before reaching the wildcard engine.
+	 * Escapes a path pattern embedded in a double-quoted PowerShell string and passed to {@code Get-Item -Path}, so
+	 * that only {@code *} and {@code ?} act as wildcards and nothing is expanded or executed:
+	 * <ul>
+	 * <li>{@code $} is escaped for the string ({@code `$}), otherwise PowerShell expands variables and {@code $()}
+	 * subexpressions;</li>
+	 * <li>{@code [} and {@code ]} are wildcard character classes: they need a backtick for the wildcard engine, doubled
+	 * so that the string parsing does not consume it ({@code ``[});</li>
+	 * <li>a literal backtick is the escape character of both layers, so it is written four times.</li>
+	 * </ul>
 	 *
 	 * @param pattern the PowerShell path pattern
-	 * @return the pattern with literal brackets
+	 * @return the escaped pattern
 	 */
-	public static String escapePowerShellBrackets(final String pattern) {
-		return pattern.replace("[", "``[").replace("]", "``]");
+	public static String escapePowerShellPattern(final String pattern) {
+		final StringBuilder escaped = new StringBuilder(pattern.length());
+		for (final char c : pattern.toCharArray()) {
+			switch (c) {
+				case '`' -> escaped.append("````");
+				case '$' -> escaped.append("`$");
+				case '[', ']' -> escaped.append("``").append(c);
+				default -> escaped.append(c);
+			}
+		}
+		return escaped.toString();
 	}
 
 	/**

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -317,7 +317,8 @@ public class FileHelper {
 		}
 
 		final String delimiter = DeviceKind.WINDOWS.equals(hostType) ? BACKSLASH : SLASH;
-		String normalized = path.trim();
+		// Not trimmed: leading and trailing spaces are significant in file names
+		String normalized = path;
 
 		// A trailing delimiter designates a directory: match all its files
 		if (normalized.endsWith(delimiter)) {

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -263,13 +263,6 @@ public class FileHelper {
 		}
 
 		/**
-		 * @return the number of segments after the root
-		 */
-		public int depth() {
-			return segments.size();
-		}
-
-		/**
 		 * @return the last segment, i.e. the filename pattern
 		 */
 		public String filename() {
@@ -281,6 +274,16 @@ public class FileHelper {
 		 */
 		public String fullPattern() {
 			return joinPath(root, String.join(delimiter, segments), delimiter);
+		}
+
+		/**
+		 * @return the directory pattern: the root followed by every segment but the last, or the root alone when the
+		 * pattern has a single segment
+		 */
+		public String directoryPattern() {
+			return segments.size() == 1
+				? root
+				: joinPath(root, String.join(delimiter, segments.subList(0, segments.size() - 1)), delimiter);
 		}
 	}
 

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -380,7 +380,8 @@ public class FileHelper {
 
 	/**
 	 * Parses remote command output into a set of validated absolute file paths.
-	 * Splits on {@code \n} or {@code \r\n}, trims and skips empty lines, and keeps only lines
+	 * Splits on {@code \n} or {@code \r\n}, skips blank lines, keeps each path verbatim (spaces are significant in
+	 * file names), and keeps only lines
 	 * matching the expected format for the given device kind. Non-matching lines are logged and skipped.
 	 *
 	 * @param result      raw command output
@@ -403,9 +404,8 @@ public class FileHelper {
 			? ABSOLUTE_WINDOWS_PATH
 			: ABSOLUTE_LINUX_PATH;
 
-		for (final String raw : result.split(LINE_SPLIT_REGEX, -1)) {
-			final String line = raw.trim();
-			if (line.isEmpty()) {
+		for (final String line : result.split(LINE_SPLIT_REGEX, -1)) {
+			if (line.isBlank()) {
 				continue;
 			}
 			if (pathPatternMatcher.matcher(line).matches()) {

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,14 +59,26 @@ import org.metricshub.engine.connector.model.common.DeviceKind;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FileHelper {
 
-	// Empty string constant used for default return values.
-	public static final String EMPTY = "";
-
 	// Path delimiter used in Linux/Unix file systems.
 	public static final String SLASH = "/";
 
 	// Path delimiter used in Windows file systems.
 	public static final String BACKSLASH = "\\";
+
+	/**
+	 * Prefix of UNC paths ({@code \\server\share\...}).
+	 */
+	private static final String UNC_PREFIX = "\\\\";
+
+	/**
+	 * Windows drive designator ({@code C:}) as the first segment of an absolute path.
+	 */
+	private static final Pattern WINDOWS_DRIVE = Pattern.compile("^[A-Za-z]:$");
+
+	/**
+	 * Glob characters, other than the supported {@code *} and {@code ?} wildcards, that must be escaped to match literally.
+	 */
+	private static final String GLOB_SPECIALS = "[]{}\\";
 
 	/**
 	 * Regex to split command output by line; accepts both {@code \n} and {@code \r\n}.
@@ -230,49 +243,135 @@ public class FileHelper {
 	}
 
 	/**
-	 * Extracts the base directory path from an absolute file path.
-	 * Removes the filename portion, leaving only the directory path.
+	 * A file path pattern split into a literal root directory and the remaining path segments.
+	 * <p>
+	 * The root never contains a wildcard and never ends with the delimiter, except for bare roots
+	 * ({@code /}, {@code D:\}, {@code \\server\share}). The segments hold everything after the root; any
+	 * segment, directory or filename, may contain the {@code *} and {@code ?} wildcards.
+	 * </p>
 	 *
-	 * @param absolutePath The absolute file path
-	 * @param hostType The device kind to determine the path delimiter
-	 * @return The base directory path, or empty string if path is invalid
+	 * @param root      literal root directory
+	 * @param segments  path segments after the root (at least one)
+	 * @param delimiter path delimiter of the target host
 	 */
-	public static String extractBasePath(final String absolutePath, final DeviceKind hostType) {
-		if (absolutePath == null || absolutePath.isBlank()) {
-			return EMPTY;
+	public record PathPattern(String root, List<String> segments, String delimiter) {
+		/**
+		 * @return true when a directory segment (any segment but the last) contains a wildcard
+		 */
+		public boolean hasDirectoryWildcard() {
+			return segments.subList(0, segments.size() - 1).stream().anyMatch(FileHelper::containsWildcard);
 		}
 
-		// Set the path delimiter depending on the host type
-		final String pathDelimiter = hostType.equals(DeviceKind.WINDOWS) ? BACKSLASH : SLASH;
-
-		// If path doesn't contain the delimiter, it's not a valid absolute path
-		if (!absolutePath.contains(pathDelimiter)) {
-			return EMPTY;
+		/**
+		 * @return the number of segments after the root
+		 */
+		public int depth() {
+			return segments.size();
 		}
 
-		return absolutePath.substring(0, absolutePath.lastIndexOf(pathDelimiter));
+		/**
+		 * @return the last segment, i.e. the filename pattern
+		 */
+		public String filename() {
+			return segments.get(segments.size() - 1);
+		}
+
+		/**
+		 * @return the full pattern: the root followed by every segment, joined with the delimiter
+		 */
+		public String fullPattern() {
+			return joinPath(root, String.join(delimiter, segments), delimiter);
+		}
 	}
 
 	/**
-	 * Extracts the filename from an absolute file path.
-	 * Returns the last component of the path after the path delimiter.
+	 * Checks whether a path segment contains a wildcard ({@code *} or {@code ?}).
 	 *
-	 * @param absolutePath The absolute file path
-	 * @param hostType The device kind to determine the path delimiter
-	 * @return The filename, or empty string if path is invalid
+	 * @param segment the path segment to check
+	 * @return true when the segment contains at least one wildcard
 	 */
-	public static String extractFilename(final String absolutePath, final DeviceKind hostType) {
-		if (absolutePath == null || absolutePath.isBlank()) {
-			return EMPTY;
+	public static boolean containsWildcard(final String segment) {
+		return segment != null && (segment.indexOf('*') >= 0 || segment.indexOf('?') >= 0);
+	}
+
+	/**
+	 * Parses an absolute file path pattern into a literal root and path segments.
+	 * <ul>
+	 * <li>A trailing delimiter designates a directory and is normalized to {@code *} (all files of the directory).</li>
+	 * <li>Windows paths must start with a drive ({@code C:\}) or a UNC prefix ({@code \\server\share}); the server
+	 * and share names are always literal.</li>
+	 * <li>Other paths must start with {@code /}.</li>
+	 * <li>The root is extended with every leading literal directory segment, but never with the last segment.</li>
+	 * </ul>
+	 *
+	 * @param path     the path pattern, possibly containing {@code *} and {@code ?} in any segment
+	 * @param hostType the device kind, which determines the path delimiter
+	 * @return the parsed pattern, or null when the path is blank, relative or has a wildcard in a UNC server or share
+	 */
+	public static PathPattern parsePathPattern(final String path, final DeviceKind hostType) {
+		if (path == null || path.isBlank()) {
+			return null;
 		}
 
-		final String pathDelimiter = hostType.equals(DeviceKind.WINDOWS) ? BACKSLASH : SLASH;
+		final String delimiter = DeviceKind.WINDOWS.equals(hostType) ? BACKSLASH : SLASH;
+		String normalized = path.trim();
 
-		if (!absolutePath.contains(pathDelimiter)) {
-			return EMPTY;
+		// A trailing delimiter designates a directory: match all its files
+		if (normalized.endsWith(delimiter)) {
+			normalized += "*";
 		}
 
-		return absolutePath.substring(absolutePath.lastIndexOf(pathDelimiter) + 1, absolutePath.length());
+		final List<String> parts = Arrays.stream(normalized.split(Pattern.quote(delimiter)))
+			.filter(part -> !part.isEmpty())
+			.toList();
+
+		// Determine the fixed root, which can never hold a wildcard
+		final String fixedRoot;
+		final int fixedCount;
+		if (DeviceKind.WINDOWS.equals(hostType)) {
+			if (normalized.startsWith(UNC_PREFIX)) {
+				if (parts.size() < 2 || containsWildcard(parts.get(0)) || containsWildcard(parts.get(1))) {
+					return null;
+				}
+				fixedRoot = UNC_PREFIX + parts.get(0) + BACKSLASH + parts.get(1);
+				fixedCount = 2;
+			} else if (!parts.isEmpty() && WINDOWS_DRIVE.matcher(parts.get(0)).matches()) {
+				fixedRoot = parts.get(0) + BACKSLASH;
+				fixedCount = 1;
+			} else {
+				return null;
+			}
+		} else if (normalized.startsWith(SLASH)) {
+			fixedRoot = SLASH;
+			fixedCount = 0;
+		} else {
+			return null;
+		}
+
+		final List<String> remaining = parts.subList(fixedCount, parts.size());
+		if (remaining.isEmpty()) {
+			return null;
+		}
+
+		// Extend the root with the leading literal directory segments, never consuming the last segment
+		int literalCount = 0;
+		while (literalCount < remaining.size() - 1 && !containsWildcard(remaining.get(literalCount))) {
+			literalCount++;
+		}
+
+		final String root =
+			literalCount == 0
+				? fixedRoot
+				: joinPath(fixedRoot, String.join(delimiter, remaining.subList(0, literalCount)), delimiter);
+
+		return new PathPattern(root, List.copyOf(remaining.subList(literalCount, remaining.size())), delimiter);
+	}
+
+	/**
+	 * Appends a relative path to a root, inserting the delimiter unless the root already ends with it.
+	 */
+	private static String joinPath(final String root, final String relative, final String delimiter) {
+		return root.endsWith(delimiter) ? root + relative : root + delimiter + relative;
 	}
 
 	/**
@@ -368,8 +467,10 @@ public class FileHelper {
 	}
 
 	/**
-	 * Resolves file paths locally by matching filename patterns in the specified directories.
-	 * Uses native Java file system APIs to find matching files.
+	 * Resolves file path patterns locally using the native Java file system APIs.
+	 * Each pattern is walked segment by segment from its literal root, so {@code *} and {@code ?} are honored in
+	 * directory segments as well as in the filename. Only regular files are returned. A pattern that cannot be
+	 * parsed or resolved is logged and skipped without affecting the other patterns.
 	 *
 	 * @param hostname   The hostname for logging purposes
 	 * @param paths      The set containing path patterns to resolve
@@ -388,21 +489,92 @@ public class FileHelper {
 		}
 
 		for (final String stringPath : paths) {
-			// Extract the base directory path from the pattern
-			final String basePath = FileHelper.extractBasePath(stringPath, deviceKind);
-			// Extract the filename pattern (may contain wildcards)
-			final String filename = FileHelper.extractFilename(stringPath, deviceKind);
+			final PathPattern pattern = parsePathPattern(stringPath, deviceKind);
+			if (pattern == null) {
+				log.info("Hostname {} - Skipping invalid file path pattern: {}", hostname, stringPath);
+				continue;
+			}
 
-			// Use directory stream to find all files matching the filename pattern
-			try (DirectoryStream<Path> stream = Files.newDirectoryStream(Path.of(basePath), filename)) {
-				stream.forEach(resolvedPath -> resolvedPaths.add(resolvedPath.toString()));
-			} catch (IOException e) {
+			try {
+				collectMatchingFiles(Path.of(pattern.root()), pattern.segments(), 0, resolvedPaths, hostname);
+			} catch (IOException | RuntimeException e) {
+				// I/O failure or invalid path (e.g. InvalidPathException): log and continue with the other patterns
 				log.info("Hostname {} - Unable to resolve path: {}. Message: {}", hostname, stringPath, e.getMessage());
 				log.debug("Hostname {} - Exception occurred when resolving path {}: {}", hostname, stringPath, e);
 			}
 		}
 
 		return resolvedPaths;
+	}
+
+	/**
+	 * Walks one segment of a path pattern under {@code directory}, recursing into matching directories and
+	 * collecting matching regular files on the last segment.
+	 *
+	 * @param directory     the directory to scan
+	 * @param segments      all pattern segments
+	 * @param index         index of the segment to match in {@code directory}
+	 * @param resolvedPaths accumulator of resolved absolute file paths
+	 * @param hostname      the hostname for logging purposes
+	 * @throws IOException if {@code directory} cannot be listed
+	 */
+	private static void collectMatchingFiles(
+		final Path directory,
+		final List<String> segments,
+		final int index,
+		final Set<String> resolvedPaths,
+		final String hostname
+	) throws IOException {
+		final String segment = segments.get(index);
+		final boolean isLast = index == segments.size() - 1;
+
+		// Literal segment: resolve it directly, no directory listing needed
+		if (!containsWildcard(segment)) {
+			final Path candidate = directory.resolve(segment);
+			if (isLast) {
+				if (Files.isRegularFile(candidate)) {
+					resolvedPaths.add(candidate.toString());
+				}
+			} else if (Files.isDirectory(candidate)) {
+				collectMatchingFiles(candidate, segments, index + 1, resolvedPaths, hostname);
+			}
+			return;
+		}
+
+		// Wildcard segment: list the directory with a glob restricted to '*' and '?'
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, escapeGlobSpecials(segment))) {
+			for (final Path match : stream) {
+				if (isLast) {
+					if (Files.isRegularFile(match)) {
+						resolvedPaths.add(match.toString());
+					}
+				} else if (Files.isDirectory(match)) {
+					try {
+						collectMatchingFiles(match, segments, index + 1, resolvedPaths, hostname);
+					} catch (IOException e) {
+						// One matched directory cannot be listed: skip it and keep scanning its siblings
+						log.debug("Hostname {} - Unable to scan directory {}: {}", hostname, match, e.getMessage());
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Escapes the glob characters other than {@code *} and {@code ?} so that they match literally.
+	 *
+	 * @param segment the path segment to escape
+	 * @return a glob expression where only {@code *} and {@code ?} act as wildcards
+	 */
+	static String escapeGlobSpecials(final String segment) {
+		final StringBuilder escaped = new StringBuilder(segment.length());
+		for (final char c : segment.toCharArray()) {
+			if (GLOB_SPECIALS.indexOf(c) >= 0) {
+				escaped.append('\\');
+			}
+			escaped.append(c);
+		}
+		return escaped.toString();
 	}
 
 	/**

--- a/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/common/helpers/FileHelper.java
@@ -578,6 +578,19 @@ public class FileHelper {
 	}
 
 	/**
+	 * Escapes {@code [} and {@code ]}, which PowerShell wildcards treat as character classes, so that they match
+	 * literally in a {@code Get-Item -Path} pattern and only {@code *} and {@code ?} act as wildcards.
+	 * The backtick is doubled because the pattern is embedded in a double-quoted PowerShell string, where a single
+	 * backtick would be consumed as the string escape character before reaching the wildcard engine.
+	 *
+	 * @param pattern the PowerShell path pattern
+	 * @return the pattern with literal brackets
+	 */
+	public static String escapePowerShellBrackets(final String pattern) {
+		return pattern.replace("[", "``[").replace("]", "``]");
+	}
+
+	/**
 	 * Escapes newline characters in a string by replacing them with a placeholder.
 	 * Handles Windows line endings (\r\n) and Unix line endings (\n).
 	 *

--- a/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/monitor/task/source/FileSource.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/monitor/task/source/FileSource.java
@@ -77,6 +77,8 @@ public class FileSource extends Source {
 
 	/**
 	 * File path patterns to read (e.g. {@code C:\logs\*.log}, {@code /var/log/app/*.log}).
+	 * The {@code *} and {@code ?} wildcards are accepted in any path segment, directory or filename
+	 * (e.g. {@code D:\apps\node*\out\event_*.log}); each wildcard matches within a single segment.
 	 * Supports comma-separated strings or YAML arrays.
 	 */
 	@JsonSetter(nulls = SKIP)

--- a/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/monitor/task/source/FileSource.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/connector/model/monitor/task/source/FileSource.java
@@ -78,7 +78,8 @@ public class FileSource extends Source {
 	/**
 	 * File path patterns to read (e.g. {@code C:\logs\*.log}, {@code /var/log/app/*.log}).
 	 * The {@code *} and {@code ?} wildcards are accepted in any path segment, directory or filename
-	 * (e.g. {@code D:\apps\node*\out\event_*.log}); each wildcard matches within a single segment.
+	 * (e.g. {@code D:\apps\node*\out\event_*.log}); each wildcard matches within a single segment. On remote Linux
+	 * hosts, a wildcard in a directory segment does not match hidden (dot-prefixed) directories.
 	 * Supports comma-separated strings or YAML arrays.
 	 */
 	@JsonSetter(nulls = SKIP)

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -442,6 +442,13 @@ class FileHelperTest {
 	}
 
 	@Test
+	void parseResolvedPathsFromCommandResult_keepsSignificantSpaces() {
+		final String input = "/tmp/node1/report \r\n/tmp/node2/ report\n   \n";
+		final var result = parseResolvedPathsFromCommandResult(input, DeviceKind.LINUX, HOSTNAME, "/tmp/node*/*report*");
+		assertEquals(Set.of("/tmp/node1/report ", "/tmp/node2/ report"), result);
+	}
+
+	@Test
 	void parseResolvedPathsFromCommandResult_linuxAbsolutePath_returnsPath() {
 		final String path = "/opt/metricshub/logs/test.log";
 		final var result = parseResolvedPathsFromCommandResult(

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -185,6 +185,13 @@ class FileHelperTest {
 		assertEquals("plain", FileHelper.escapeGlobSpecials("plain"));
 	}
 
+	@Test
+	void escapePowerShellBrackets_doublesBacktickForDoubleQuotedString() {
+		assertEquals("C:\\logs\\app``[1``].log", FileHelper.escapePowerShellBrackets("C:\\logs\\app[1].log"));
+		assertEquals("D:\\``[prod``]\\node*\\app?.log", FileHelper.escapePowerShellBrackets("D:\\[prod]\\node*\\app?.log"));
+		assertEquals("C:\\logs\\*.log", FileHelper.escapePowerShellBrackets("C:\\logs\\*.log"));
+	}
+
 	private DeviceKind localDeviceKind() {
 		return LocalOsHandler.isWindows() ? DeviceKind.WINDOWS : DeviceKind.LINUX;
 	}

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -211,10 +211,16 @@ class FileHelperTest {
 	}
 
 	@Test
-	void escapePowerShellBrackets_doublesBacktickForDoubleQuotedString() {
-		assertEquals("C:\\logs\\app``[1``].log", FileHelper.escapePowerShellBrackets("C:\\logs\\app[1].log"));
-		assertEquals("D:\\``[prod``]\\node*\\app?.log", FileHelper.escapePowerShellBrackets("D:\\[prod]\\node*\\app?.log"));
-		assertEquals("C:\\logs\\*.log", FileHelper.escapePowerShellBrackets("C:\\logs\\*.log"));
+	void escapePowerShellPattern_keepsOnlyStarAndQuestionMarkAsWildcards() {
+		assertEquals("C:\\logs\\app``[1``].log", FileHelper.escapePowerShellPattern("C:\\logs\\app[1].log"));
+		assertEquals("D:\\``[prod``]\\node*\\app?.log", FileHelper.escapePowerShellPattern("D:\\[prod]\\node*\\app?.log"));
+		assertEquals("C:\\logs\\*.log", FileHelper.escapePowerShellPattern("C:\\logs\\*.log"));
+		// $ and $() are never expanded, a literal backtick survives both the string and the wildcard layers
+		assertEquals(
+			"C:\\data\\`$logs\\node*\\`$(id).log",
+			FileHelper.escapePowerShellPattern("C:\\data\\$logs\\node*\\$(id).log")
+		);
+		assertEquals("C:\\a````b\\*.log", FileHelper.escapePowerShellPattern("C:\\a`b\\*.log"));
 	}
 
 	private DeviceKind localDeviceKind() {

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -5,14 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.metricshub.engine.common.helpers.FileHelper.extractBasePath;
-import static org.metricshub.engine.common.helpers.FileHelper.extractFilename;
+import static org.metricshub.engine.common.helpers.FileHelper.findFilesByPattern;
+import static org.metricshub.engine.common.helpers.FileHelper.parsePathPattern;
 import static org.metricshub.engine.common.helpers.FileHelper.parseResolvedPathsFromCommandResult;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.metricshub.engine.common.helpers.FileHelper.PathPattern;
 import org.metricshub.engine.connector.model.common.DeviceKind;
 
 class FileHelperTest {
@@ -22,6 +30,9 @@ class FileHelperTest {
 	private final String LINUX_ABSOLUTE_PATH = "/opt/metricshub/logs/*.log";
 
 	private final String WINDOWS_ABSOLUTE_PATH = "C:\\Program Files\\MetricsHub\\logs\\*.log";
+
+	@TempDir
+	Path tempDir;
 
 	@Test
 	void testGetExtension() {
@@ -42,29 +53,289 @@ class FileHelperTest {
 	}
 
 	@Test
-	void testExtractBasePath() {
-		// Null and empty path
-		assertEquals("", extractBasePath(null, DeviceKind.AIX));
-		assertEquals("", extractBasePath("", DeviceKind.AIX));
-
-		// Linux Paths
-		assertEquals("/opt/metricshub/logs", extractBasePath(LINUX_ABSOLUTE_PATH, DeviceKind.AIX));
-
-		// Windows Paths
-		assertEquals("C:\\Program Files\\MetricsHub\\logs", extractBasePath(WINDOWS_ABSOLUTE_PATH, DeviceKind.WINDOWS));
+	void parsePathPattern_linuxFilenameWildcard() {
+		final PathPattern pattern = parsePathPattern(LINUX_ABSOLUTE_PATH, DeviceKind.AIX);
+		assertNotNull(pattern);
+		assertEquals("/opt/metricshub/logs", pattern.root());
+		assertEquals(List.of("*.log"), pattern.segments());
+		assertEquals("*.log", pattern.filename());
+		assertEquals(1, pattern.depth());
+		assertFalse(pattern.hasDirectoryWildcard());
+		assertEquals(LINUX_ABSOLUTE_PATH, pattern.fullPattern());
 	}
 
 	@Test
-	void testExtractFilename() {
-		// Null and empty path
-		assertEquals("", extractFilename(null, DeviceKind.AIX));
-		assertEquals("", extractFilename("", DeviceKind.AIX));
+	void parsePathPattern_linuxDirectoryWildcard() {
+		final PathPattern pattern = parsePathPattern("/opt/autosys/autouser*/out/event_demon*PE2", DeviceKind.LINUX);
+		assertNotNull(pattern);
+		assertEquals("/opt/autosys", pattern.root());
+		assertEquals(List.of("autouser*", "out", "event_demon*PE2"), pattern.segments());
+		assertEquals(3, pattern.depth());
+		assertTrue(pattern.hasDirectoryWildcard());
+		assertEquals("/opt/autosys/autouser*/out/event_demon*PE2", pattern.fullPattern());
+	}
 
-		// Linux paths
-		assertEquals("*.log", extractFilename(LINUX_ABSOLUTE_PATH, DeviceKind.AIX));
+	@Test
+	void parsePathPattern_linuxFirstSegmentWildcard_rootIsSlash() {
+		final PathPattern pattern = parsePathPattern("/opt*/x.log", DeviceKind.LINUX);
+		assertNotNull(pattern);
+		assertEquals("/", pattern.root());
+		assertEquals(List.of("opt*", "x.log"), pattern.segments());
+		assertEquals("/opt*/x.log", pattern.fullPattern());
+	}
 
-		// Windows paths
-		assertEquals("*.log", extractFilename(WINDOWS_ABSOLUTE_PATH, DeviceKind.WINDOWS));
+	@Test
+	void parsePathPattern_trailingDelimiter_matchesAllFiles() {
+		final PathPattern linux = parsePathPattern("/var/log/", DeviceKind.LINUX);
+		assertNotNull(linux);
+		assertEquals("/var/log", linux.root());
+		assertEquals(List.of("*"), linux.segments());
+		assertEquals("/var/log/*", linux.fullPattern());
+
+		final PathPattern windows = parsePathPattern("C:\\logs\\", DeviceKind.WINDOWS);
+		assertNotNull(windows);
+		assertEquals("C:\\logs", windows.root());
+		assertEquals(List.of("*"), windows.segments());
+		assertEquals("C:\\logs\\*", windows.fullPattern());
+	}
+
+	@Test
+	void parsePathPattern_windowsFilenameWildcard() {
+		final PathPattern pattern = parsePathPattern(WINDOWS_ABSOLUTE_PATH, DeviceKind.WINDOWS);
+		assertNotNull(pattern);
+		assertEquals("C:\\Program Files\\MetricsHub\\logs", pattern.root());
+		assertEquals(List.of("*.log"), pattern.segments());
+		assertFalse(pattern.hasDirectoryWildcard());
+		assertEquals(WINDOWS_ABSOLUTE_PATH, pattern.fullPattern());
+	}
+
+	@Test
+	void parsePathPattern_windowsDirectoryWildcard() {
+		final PathPattern pattern = parsePathPattern(
+			"D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2",
+			DeviceKind.WINDOWS
+		);
+		assertNotNull(pattern);
+		assertEquals("D:\\Autosys_waae", pattern.root());
+		assertEquals(List.of("autouser*", "out", "event_demon*PE2"), pattern.segments());
+		assertTrue(pattern.hasDirectoryWildcard());
+		assertEquals("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2", pattern.fullPattern());
+	}
+
+	@Test
+	void parsePathPattern_windowsDriveRoot() {
+		final PathPattern pattern = parsePathPattern("D:\\auto*\\x.log", DeviceKind.WINDOWS);
+		assertNotNull(pattern);
+		assertEquals("D:\\", pattern.root());
+		assertEquals(List.of("auto*", "x.log"), pattern.segments());
+		assertEquals("D:\\auto*\\x.log", pattern.fullPattern());
+
+		final PathPattern drive = parsePathPattern("D:\\", DeviceKind.WINDOWS);
+		assertNotNull(drive);
+		assertEquals("D:\\", drive.root());
+		assertEquals(List.of("*"), drive.segments());
+		assertEquals("D:\\*", drive.fullPattern());
+	}
+
+	@Test
+	void parsePathPattern_windowsUnc() {
+		final PathPattern pattern = parsePathPattern("\\\\server\\share\\a*\\b.log", DeviceKind.WINDOWS);
+		assertNotNull(pattern);
+		assertEquals("\\\\server\\share", pattern.root());
+		assertEquals(List.of("a*", "b.log"), pattern.segments());
+		assertEquals("\\\\server\\share\\a*\\b.log", pattern.fullPattern());
+
+		final PathPattern literalDirectories = parsePathPattern("\\\\server\\share\\logs\\*.log", DeviceKind.WINDOWS);
+		assertNotNull(literalDirectories);
+		assertEquals("\\\\server\\share\\logs", literalDirectories.root());
+		assertEquals(List.of("*.log"), literalDirectories.segments());
+
+		// Server and share names are always literal
+		assertNull(parsePathPattern("\\\\server\\sha*\\b.log", DeviceKind.WINDOWS));
+		assertNull(parsePathPattern("\\\\server", DeviceKind.WINDOWS));
+	}
+
+	@Test
+	void parsePathPattern_invalid_returnsNull() {
+		assertNull(parsePathPattern(null, DeviceKind.LINUX));
+		assertNull(parsePathPattern("  ", DeviceKind.LINUX));
+		assertNull(parsePathPattern("relative/path.log", DeviceKind.LINUX));
+		assertNull(parsePathPattern("file.log", DeviceKind.LINUX));
+		assertNull(parsePathPattern("logs\\file.log", DeviceKind.WINDOWS));
+		assertNull(parsePathPattern("/opt/x.log", DeviceKind.WINDOWS));
+	}
+
+	@Test
+	void parsePathPattern_questionMarkIsWildcard() {
+		final PathPattern pattern = parsePathPattern("/opt/node?/app.log", DeviceKind.LINUX);
+		assertNotNull(pattern);
+		assertEquals("/opt", pattern.root());
+		assertEquals(List.of("node?", "app.log"), pattern.segments());
+		assertTrue(pattern.hasDirectoryWildcard());
+		assertTrue(FileHelper.containsWildcard("node?"));
+		assertTrue(FileHelper.containsWildcard("*"));
+		assertFalse(FileHelper.containsWildcard("node"));
+		assertFalse(FileHelper.containsWildcard(null));
+	}
+
+	@Test
+	void escapeGlobSpecials_keepsOnlyStarAndQuestionMarkAsWildcards() {
+		assertEquals("app\\[1\\]*.log?", FileHelper.escapeGlobSpecials("app[1]*.log?"));
+		assertEquals("a\\{b\\}", FileHelper.escapeGlobSpecials("a{b}"));
+		assertEquals("plain", FileHelper.escapeGlobSpecials("plain"));
+	}
+
+	private DeviceKind localDeviceKind() {
+		return LocalOsHandler.isWindows() ? DeviceKind.WINDOWS : DeviceKind.LINUX;
+	}
+
+	private String localPattern(final String... segments) {
+		return tempDir.toString() + File.separator + String.join(File.separator, segments);
+	}
+
+	private String createTreeFile(final String... segments) throws IOException {
+		Path file = tempDir;
+		for (final String segment : segments) {
+			file = file.resolve(segment);
+		}
+		Files.createDirectories(file.getParent());
+		Files.createFile(file);
+		return file.toString();
+	}
+
+	/**
+	 * Builds the following tree under {@link #tempDir} and returns the two files matching a pattern with a
+	 * wildcard in both the first directory segment and the filename (autouser prefix, out, event_demon prefix, PE2 suffix):
+	 * <pre>
+	 * autouser01/out/event_demon.PE2
+	 * autouser02/out/event_demon_XPE2
+	 * autouser02/out/event_demonPE2.log
+	 * autouser02/out/event_demon_DIRPE2/   (directory)
+	 * other/out/event_demon.PE2
+	 * </pre>
+	 */
+	private Set<String> createTree() throws IOException {
+		final String first = createTreeFile("autouser01", "out", "event_demon.PE2");
+		final String second = createTreeFile("autouser02", "out", "event_demon_XPE2");
+		createTreeFile("autouser02", "out", "event_demonPE2.log");
+		Files.createDirectories(tempDir.resolve("autouser02").resolve("out").resolve("event_demon_DIRPE2"));
+		createTreeFile("other", "out", "event_demon.PE2");
+		return Set.of(first, second);
+	}
+
+	@Test
+	void findFilesByPattern_directoryWildcard() throws IOException {
+		final Set<String> expected = createTree();
+
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser*", "out", "event_demon*PE2")),
+			localDeviceKind()
+		);
+
+		assertEquals(expected, resolved);
+	}
+
+	@Test
+	void findFilesByPattern_filenameWildcardOnly() throws IOException {
+		createTree();
+
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser02", "out", "event_demon*")),
+			localDeviceKind()
+		);
+
+		// The matching directory event_demon_DIRPE2 is excluded
+		assertEquals(
+			Set.of(
+				tempDir.resolve("autouser02").resolve("out").resolve("event_demon_XPE2").toString(),
+				tempDir.resolve("autouser02").resolve("out").resolve("event_demonPE2.log").toString()
+			),
+			resolved
+		);
+	}
+
+	@Test
+	void findFilesByPattern_questionMarkWildcard() throws IOException {
+		createTree();
+
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser0?", "out", "event_demon.PE2")),
+			localDeviceKind()
+		);
+
+		assertEquals(Set.of(tempDir.resolve("autouser01").resolve("out").resolve("event_demon.PE2").toString()), resolved);
+	}
+
+	@Test
+	void findFilesByPattern_literalFileAndLiteralDirectory() throws IOException {
+		createTree();
+
+		final String literalFile = localPattern("autouser01", "out", "event_demon.PE2");
+		assertEquals(Set.of(literalFile), findFilesByPattern(HOSTNAME, Set.of(literalFile), localDeviceKind()));
+
+		// A literal directory without a trailing delimiter is not a regular file
+		assertTrue(findFilesByPattern(HOSTNAME, Set.of(localPattern("autouser01", "out")), localDeviceKind()).isEmpty());
+	}
+
+	@Test
+	void findFilesByPattern_trailingDelimiterListsAllFiles() throws IOException {
+		createTree();
+
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser02", "out") + File.separator),
+			localDeviceKind()
+		);
+
+		assertEquals(
+			Set.of(
+				tempDir.resolve("autouser02").resolve("out").resolve("event_demon_XPE2").toString(),
+				tempDir.resolve("autouser02").resolve("out").resolve("event_demonPE2.log").toString()
+			),
+			resolved
+		);
+	}
+
+	@Test
+	void findFilesByPattern_nonExistingRootAndNullPaths() throws IOException {
+		createTree();
+
+		assertTrue(findFilesByPattern(HOSTNAME, Set.of(localPattern("nope", "*.log")), localDeviceKind()).isEmpty());
+		assertTrue(
+			findFilesByPattern(HOSTNAME, Set.of(localPattern("nope*", "out", "*.log")), localDeviceKind()).isEmpty()
+		);
+		assertTrue(findFilesByPattern(HOSTNAME, null, localDeviceKind()).isEmpty());
+	}
+
+	@Test
+	void findFilesByPattern_invalidPatternDoesNotHideValidOnes() throws IOException {
+		final Set<String> expected = createTree();
+
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser*", "out", "event_demon*PE2"), "relative/path.log"),
+			localDeviceKind()
+		);
+
+		assertEquals(expected, resolved);
+	}
+
+	@Test
+	@EnabledOnOs(OS.WINDOWS)
+	void findFilesByPattern_illegalCharacterDoesNotHideValidOnes() throws IOException {
+		final Set<String> expected = createTree();
+
+		// ':' is illegal in a Windows path segment and makes Path.of throw InvalidPathException
+		final Set<String> resolved = findFilesByPattern(
+			HOSTNAME,
+			Set.of(localPattern("autouser*", "out", "event_demon*PE2"), localPattern("bad:name", "*.log")),
+			DeviceKind.WINDOWS
+		);
+
+		assertEquals(expected, resolved);
 	}
 
 	@Test

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -168,6 +168,19 @@ class FileHelperTest {
 	}
 
 	@Test
+	void parsePathPattern_keepsSignificantSpaces() {
+		final PathPattern pattern = parsePathPattern("/var/log/report ", DeviceKind.LINUX);
+		assertNotNull(pattern);
+		assertEquals("/var/log", pattern.root());
+		assertEquals(List.of("report "), pattern.segments());
+
+		final PathPattern windows = parsePathPattern("C:\\my logs\\ app*.log", DeviceKind.WINDOWS);
+		assertNotNull(windows);
+		assertEquals("C:\\my logs", windows.root());
+		assertEquals(List.of(" app*.log"), windows.segments());
+	}
+
+	@Test
 	void parsePathPattern_invalid_returnsNull() {
 		assertNull(parsePathPattern(null, DeviceKind.LINUX));
 		assertNull(parsePathPattern("  ", DeviceKind.LINUX));

--- a/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/common/helpers/FileHelperTest.java
@@ -59,7 +59,6 @@ class FileHelperTest {
 		assertEquals("/opt/metricshub/logs", pattern.root());
 		assertEquals(List.of("*.log"), pattern.segments());
 		assertEquals("*.log", pattern.filename());
-		assertEquals(1, pattern.depth());
 		assertFalse(pattern.hasDirectoryWildcard());
 		assertEquals(LINUX_ABSOLUTE_PATH, pattern.fullPattern());
 	}
@@ -70,9 +69,22 @@ class FileHelperTest {
 		assertNotNull(pattern);
 		assertEquals("/opt/autosys", pattern.root());
 		assertEquals(List.of("autouser*", "out", "event_demon*PE2"), pattern.segments());
-		assertEquals(3, pattern.depth());
 		assertTrue(pattern.hasDirectoryWildcard());
 		assertEquals("/opt/autosys/autouser*/out/event_demon*PE2", pattern.fullPattern());
+		assertEquals("/opt/autosys/autouser*/out", pattern.directoryPattern());
+	}
+
+	@Test
+	void parsePathPattern_directoryPattern() {
+		assertEquals("/opt/metricshub/logs", parsePathPattern(LINUX_ABSOLUTE_PATH, DeviceKind.LINUX).directoryPattern());
+		assertEquals("/opt*", parsePathPattern("/opt*/x.log", DeviceKind.LINUX).directoryPattern());
+		assertEquals("/", parsePathPattern("/*.log", DeviceKind.LINUX).directoryPattern());
+		assertEquals(
+			"D:\\Autosys_waae\\autouser*\\out",
+			parsePathPattern("D:\\Autosys_waae\\autouser*\\out\\e*", DeviceKind.WINDOWS).directoryPattern()
+		);
+		assertEquals("D:\\auto*", parsePathPattern("D:\\auto*\\x.log", DeviceKind.WINDOWS).directoryPattern());
+		assertEquals("D:\\", parsePathPattern("D:\\", DeviceKind.WINDOWS).directoryPattern());
 	}
 
 	@Test

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -77,6 +77,10 @@ public class FileSourceProcessor {
 	public static final String RESOLVE_LINUX_FILES_BY_PATH_COMMAND =
 		"find -L \"%s\" -maxdepth %d -type f -path \"%s\" -print";
 
+	// Escaped form of a literal backslash in a find pattern embedded in a double-quoted shell argument: the shell turns
+	// the four backslashes into two, which find then reads as one escaped backslash.
+	private static final String FIND_ESCAPED_BACKSLASH = "\\\\\\\\";
+
 	// Line break sequence used in Windows (CRLF).
 	public static final String WINDOWS_LINE_BREAK_SEQUENCE = "\r\n";
 
@@ -486,6 +490,7 @@ public class FileSourceProcessor {
 	 * <li>Linux otherwise: the existing {@code find -name} command (or the directory listing when the filename is
 	 * {@code *}), so that existing configurations produce unchanged commands.</li>
 	 * </ul>
+	 * In both find patterns, glob metacharacters other than {@code *} and {@code ?} are escaped to match literally.
 	 *
 	 * @param pattern    the parsed path pattern
 	 * @param deviceKind the device kind of the remote host
@@ -497,7 +502,11 @@ public class FileSourceProcessor {
 		}
 
 		if (pattern.hasDirectoryWildcard()) {
-			return RESOLVE_LINUX_FILES_BY_PATH_COMMAND.formatted(pattern.root(), pattern.depth(), pattern.fullPattern());
+			return RESOLVE_LINUX_FILES_BY_PATH_COMMAND.formatted(
+				pattern.root(),
+				pattern.depth(),
+				escapeFindPattern(pattern.fullPattern())
+			);
 		}
 
 		final String filename = pattern.filename();
@@ -505,7 +514,29 @@ public class FileSourceProcessor {
 			return RESOLVE_LINUX_DIRECTORIES_COMMAND.formatted(pattern.root());
 		}
 
-		return RESOLVE_LINUX_FILES_COMMAND.formatted(pattern.root(), filename);
+		return RESOLVE_LINUX_FILES_COMMAND.formatted(pattern.root(), escapeFindPattern(filename));
+	}
+
+	/**
+	 * Escapes the glob metacharacters other than {@code *} and {@code ?} in a {@code find -name}/{@code -path} pattern
+	 * so that they match literally, consistently with the local resolver. The pattern is embedded in a double-quoted
+	 * shell argument, where {@code \[} reaches find unchanged while a literal backslash needs two escaping levels.
+	 *
+	 * @param pattern the find pattern
+	 * @return the pattern where only {@code *} and {@code ?} act as wildcards
+	 */
+	static String escapeFindPattern(final String pattern) {
+		final StringBuilder escaped = new StringBuilder(pattern.length());
+		for (final char c : pattern.toCharArray()) {
+			if (c == '\\') {
+				escaped.append(FIND_ESCAPED_BACKSLASH);
+			} else if (c == '[' || c == ']') {
+				escaped.append('\\').append(c);
+			} else {
+				escaped.append(c);
+			}
+		}
+		return escaped.toString();
 	}
 
 	/**

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -490,7 +490,7 @@ public class FileSourceProcessor {
 	 * <li>Linux otherwise: the existing {@code find -name} command (or the directory listing when the filename is
 	 * {@code *}), so that existing configurations produce unchanged commands.</li>
 	 * </ul>
-	 * In both find patterns, glob metacharacters other than {@code *} and {@code ?} are escaped to match literally.
+	 * In every pattern, glob metacharacters other than {@code *} and {@code ?} are escaped to match literally.
 	 *
 	 * @param pattern    the parsed path pattern
 	 * @param deviceKind the device kind of the remote host
@@ -498,7 +498,7 @@ public class FileSourceProcessor {
 	 */
 	static String buildResolveCommand(final PathPattern pattern, final DeviceKind deviceKind) {
 		if (DeviceKind.WINDOWS.equals(deviceKind)) {
-			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(pattern.fullPattern());
+			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellBrackets(pattern.fullPattern()));
 		}
 
 		if (pattern.hasDirectoryWildcard()) {

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -72,10 +72,12 @@ public class FileSourceProcessor {
 	// Linux find command template for resolving directory paths.
 	public static final String RESOLVE_LINUX_DIRECTORIES_COMMAND = "find -L \"%s\" -maxdepth 1 -type f -print";
 
-	// Linux find command template for resolving file paths when a directory segment holds a wildcard:
-	// arguments are the literal root, the number of segments below it and the full pattern.
-	public static final String RESOLVE_LINUX_FILES_BY_PATH_COMMAND =
-		"find -L \"%s\" -maxdepth %d -type f -path \"%s\" -print";
+	// Linux command template for resolving file paths when a directory segment holds a wildcard. The shell expands the
+	// directory glob, so only matching directories are visited (no traversal of unrelated or unreadable subtrees) and
+	// a wildcard never crosses a separator; the filename is then resolved in each matched directory with find, exactly
+	// as in RESOLVE_LINUX_FILES_COMMAND. Arguments are the shell-quoted directory glob and the filename pattern.
+	public static final String RESOLVE_LINUX_FILES_IN_MATCHING_DIRECTORIES_COMMAND =
+		"sh -c 'for d in %s; do [ -d \"$d\" ] && find -L \"$d\" -maxdepth 1 -type f -name \"%s\" -print; done'";
 
 	// Escaped form of a literal backslash in a find pattern embedded in a double-quoted shell argument: the shell turns
 	// the four backslashes into two, which find then reads as one escaped backslash.
@@ -485,8 +487,8 @@ public class FileSourceProcessor {
 	 * Builds the OS-specific command that lists the files matching a path pattern on the remote host.
 	 * <ul>
 	 * <li>Windows: the full pattern is passed to {@code Get-Item}, which expands wildcards in every segment.</li>
-	 * <li>Linux with a wildcard in a directory segment: {@code find -path} from the literal root, bounded to the
-	 * pattern depth.</li>
+	 * <li>Linux with a wildcard in a directory segment: the shell expands the directory glob and {@code find -name}
+	 * resolves the filename in each matched directory.</li>
 	 * <li>Linux otherwise: the existing {@code find -name} command (or the directory listing when the filename is
 	 * {@code *}), so that existing configurations produce unchanged commands.</li>
 	 * </ul>
@@ -502,10 +504,9 @@ public class FileSourceProcessor {
 		}
 
 		if (pattern.hasDirectoryWildcard()) {
-			return RESOLVE_LINUX_FILES_BY_PATH_COMMAND.formatted(
-				pattern.root(),
-				pattern.depth(),
-				escapeFindPattern(pattern.fullPattern())
+			return RESOLVE_LINUX_FILES_IN_MATCHING_DIRECTORIES_COMMAND.formatted(
+				quoteShellGlob(pattern.directoryPattern()),
+				escapeFindPattern(pattern.filename())
 			);
 		}
 
@@ -518,9 +519,49 @@ public class FileSourceProcessor {
 	}
 
 	/**
-	 * Escapes the glob metacharacters other than {@code *} and {@code ?} in a {@code find -name}/{@code -path} pattern
-	 * so that they match literally, consistently with the local resolver. The pattern is embedded in a double-quoted
-	 * shell argument, where {@code \[} reaches find unchanged while a literal backslash needs two escaping levels.
+	 * Quotes a directory pattern as a shell glob: literal runs are enclosed in double quotes (with {@code \}, {@code "},
+	 * {@code $} and {@code `} escaped) so that spaces, brackets and other special characters are taken literally, while
+	 * {@code *} and {@code ?} are left unquoted so that the shell expands them. A single quote is written as
+	 * {@code '\''} because the glob is embedded in the single-quoted {@code sh -c} script.
+	 *
+	 * @param pattern the directory pattern
+	 * @return the shell glob expression
+	 */
+	static String quoteShellGlob(final String pattern) {
+		final StringBuilder glob = new StringBuilder(pattern.length() + 2);
+		boolean inLiteral = false;
+		for (final char c : pattern.toCharArray()) {
+			if (c == '*' || c == '?') {
+				if (inLiteral) {
+					glob.append('"');
+					inLiteral = false;
+				}
+				glob.append(c);
+				continue;
+			}
+			if (!inLiteral) {
+				glob.append('"');
+				inLiteral = true;
+			}
+			if (c == '\'') {
+				glob.append("'\\''");
+			} else {
+				if (c == '\\' || c == '"' || c == '$' || c == '`') {
+					glob.append('\\');
+				}
+				glob.append(c);
+			}
+		}
+		if (inLiteral) {
+			glob.append('"');
+		}
+		return glob.toString();
+	}
+
+	/**
+	 * Escapes the glob metacharacters other than {@code *} and {@code ?} in a {@code find -name} pattern so that they
+	 * match literally, consistently with the local resolver. The pattern is embedded in a double-quoted shell argument,
+	 * where {@code \[} reaches find unchanged while a literal backslash needs two escaping levels.
 	 *
 	 * @param pattern the find pattern
 	 * @return the pattern where only {@code *} and {@code ?} act as wildcards

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -501,7 +501,7 @@ public class FileSourceProcessor {
 	 */
 	static String buildResolveCommand(final PathPattern pattern, final DeviceKind deviceKind) {
 		if (DeviceKind.WINDOWS.equals(deviceKind)) {
-			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellBrackets(pattern.fullPattern()));
+			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellPattern(pattern.fullPattern()));
 		}
 
 		// Both values end up inside double quotes of the remote shell; the filename is additionally a find pattern

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -74,14 +74,14 @@ public class FileSourceProcessor {
 
 	// Linux command template for resolving file paths when a directory segment holds a wildcard. The shell expands the
 	// directory glob, so only matching directories are visited (no traversal of unrelated or unreadable subtrees) and
-	// a wildcard never crosses a separator; the filename is then resolved in each matched directory with find, exactly
-	// as in RESOLVE_LINUX_FILES_COMMAND. Arguments are the shell-quoted directory glob and the filename pattern.
+	// a wildcard never crosses a separator; as with any shell glob, a wildcard does not match dot-prefixed names. The
+	// filename is then resolved in each matched directory with find, exactly as in RESOLVE_LINUX_FILES_COMMAND.
+	// Arguments are the shell-quoted directory glob and the escaped filename pattern.
 	public static final String RESOLVE_LINUX_FILES_IN_MATCHING_DIRECTORIES_COMMAND =
 		"sh -c 'for d in %s; do [ -d \"$d\" ] && find -L \"$d\" -maxdepth 1 -type f -name \"%s\" -print; done'";
 
-	// Escaped form of a literal backslash in a find pattern embedded in a double-quoted shell argument: the shell turns
-	// the four backslashes into two, which find then reads as one escaped backslash.
-	private static final String FIND_ESCAPED_BACKSLASH = "\\\\\\\\";
+	// A single quote inside the single-quoted `sh -c` script: closes the quote, adds an escaped quote, reopens it.
+	private static final String SINGLE_QUOTE_IN_SCRIPT = "'\\''";
 
 	// Line break sequence used in Windows (CRLF).
 	public static final String WINDOWS_LINE_BREAK_SEQUENCE = "\r\n";
@@ -492,7 +492,8 @@ public class FileSourceProcessor {
 	 * <li>Linux otherwise: the existing {@code find -name} command (or the directory listing when the filename is
 	 * {@code *}), so that existing configurations produce unchanged commands.</li>
 	 * </ul>
-	 * In every pattern, glob metacharacters other than {@code *} and {@code ?} are escaped to match literally.
+	 * In every pattern, glob metacharacters other than {@code *} and {@code ?} are escaped to match literally, and
+	 * shell metacharacters are escaped so that a path is never interpreted by the remote shell.
 	 *
 	 * @param pattern    the parsed path pattern
 	 * @param deviceKind the device kind of the remote host
@@ -503,26 +504,29 @@ public class FileSourceProcessor {
 			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellBrackets(pattern.fullPattern()));
 		}
 
+		// Both values end up inside double quotes of the remote shell; the filename is additionally a find pattern
+		final String root = escapeDoubleQuotedShell(pattern.root());
+		final String filename = escapeDoubleQuotedShell(escapeFindMetacharacters(pattern.filename()));
+
 		if (pattern.hasDirectoryWildcard()) {
 			return RESOLVE_LINUX_FILES_IN_MATCHING_DIRECTORIES_COMMAND.formatted(
 				quoteShellGlob(pattern.directoryPattern()),
-				escapeFindPattern(pattern.filename())
+				filename.replace("'", SINGLE_QUOTE_IN_SCRIPT)
 			);
 		}
 
-		final String filename = pattern.filename();
-		if ("*".equals(filename)) {
-			return RESOLVE_LINUX_DIRECTORIES_COMMAND.formatted(pattern.root());
+		if ("*".equals(pattern.filename())) {
+			return RESOLVE_LINUX_DIRECTORIES_COMMAND.formatted(root);
 		}
 
-		return RESOLVE_LINUX_FILES_COMMAND.formatted(pattern.root(), escapeFindPattern(filename));
+		return RESOLVE_LINUX_FILES_COMMAND.formatted(root, filename);
 	}
 
 	/**
-	 * Quotes a directory pattern as a shell glob: literal runs are enclosed in double quotes (with {@code \}, {@code "},
-	 * {@code $} and {@code `} escaped) so that spaces, brackets and other special characters are taken literally, while
-	 * {@code *} and {@code ?} are left unquoted so that the shell expands them. A single quote is written as
-	 * {@code '\''} because the glob is embedded in the single-quoted {@code sh -c} script.
+	 * Quotes a directory pattern as a shell glob: literal runs are enclosed in double quotes (with shell metacharacters
+	 * escaped, see {@link #escapeDoubleQuotedShell(String)}) so that spaces, brackets and other special characters are
+	 * taken literally, while {@code *} and {@code ?} are left unquoted so that the shell expands them. A single quote is
+	 * written as {@code '\''} because the glob is embedded in the single-quoted {@code sh -c} script.
 	 *
 	 * @param pattern the directory pattern
 	 * @return the shell glob expression
@@ -544,12 +548,9 @@ public class FileSourceProcessor {
 				inLiteral = true;
 			}
 			if (c == '\'') {
-				glob.append("'\\''");
+				glob.append(SINGLE_QUOTE_IN_SCRIPT);
 			} else {
-				if (c == '\\' || c == '"' || c == '$' || c == '`') {
-					glob.append('\\');
-				}
-				glob.append(c);
+				glob.append(escapeDoubleQuotedShell(String.valueOf(c)));
 			}
 		}
 		if (inLiteral) {
@@ -559,23 +560,39 @@ public class FileSourceProcessor {
 	}
 
 	/**
-	 * Escapes the glob metacharacters other than {@code *} and {@code ?} in a {@code find -name} pattern so that they
-	 * match literally, consistently with the local resolver. The pattern is embedded in a double-quoted shell argument,
-	 * where {@code \[} reaches find unchanged while a literal backslash needs two escaping levels.
+	 * Escapes the characters that the shell still interprets inside double quotes ({@code \}, {@code "}, {@code $} and
+	 * {@code `}), so that a value embedded in a double-quoted argument reaches the command verbatim and can never be
+	 * expanded or executed by the shell.
+	 *
+	 * @param value the value to embed in a double-quoted shell argument
+	 * @return the escaped value
+	 */
+	static String escapeDoubleQuotedShell(final String value) {
+		final StringBuilder escaped = new StringBuilder(value.length());
+		for (final char c : value.toCharArray()) {
+			if (c == '\\' || c == '"' || c == '$' || c == '`') {
+				escaped.append('\\');
+			}
+			escaped.append(c);
+		}
+		return escaped.toString();
+	}
+
+	/**
+	 * Escapes the glob metacharacters other than {@code *} and {@code ?} ({@code [}, {@code ]} and {@code \}) in a
+	 * {@code find -name} pattern so that they match literally, consistently with the local resolver. The result still
+	 * has to go through {@link #escapeDoubleQuotedShell(String)} before being embedded in the command.
 	 *
 	 * @param pattern the find pattern
 	 * @return the pattern where only {@code *} and {@code ?} act as wildcards
 	 */
-	static String escapeFindPattern(final String pattern) {
+	static String escapeFindMetacharacters(final String pattern) {
 		final StringBuilder escaped = new StringBuilder(pattern.length());
 		for (final char c : pattern.toCharArray()) {
-			if (c == '\\') {
-				escaped.append(FIND_ESCAPED_BACKSLASH);
-			} else if (c == '[' || c == ']') {
-				escaped.append('\\').append(c);
-			} else {
-				escaped.append(c);
+			if (c == '[' || c == ']' || c == '\\') {
+				escaped.append('\\');
 			}
+			escaped.append(c);
 		}
 		return escaped.toString();
 	}

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -37,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.metricshub.engine.common.exception.ClientException;
 import org.metricshub.engine.common.exception.ControlledSshException;
 import org.metricshub.engine.common.helpers.FileHelper;
+import org.metricshub.engine.common.helpers.FileHelper.PathPattern;
 import org.metricshub.engine.common.helpers.TextTableHelper;
 import org.metricshub.engine.connector.model.common.DeviceKind;
 import org.metricshub.engine.connector.model.common.FileOperations;
@@ -60,15 +61,21 @@ public class FileSourceProcessor {
 	@NonNull
 	private OsCommandService osCommandService;
 
-	// PowerShell command template for resolving file paths on Windows.
+	// PowerShell command template for resolving file paths on Windows. The full pattern is passed to Get-Item, which
+	// expands wildcards in every segment and, unlike Get-ChildItem, never enumerates the children of a literal directory.
 	public static final String RESOLVE_WINDOWS_FILES_COMMAND =
-		"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-ChildItem -Path \\\"%s\\\" -File -Filter \\\"%s\\\" | ForEach-Object { $_.FullName }\"";
+		"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-Item -Path \\\"%s\\\" -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | ForEach-Object { $_.FullName }\"";
 
-	// Linux find command template for resolving file paths.
+	// Linux find command template for resolving file paths when no directory segment holds a wildcard.
 	public static final String RESOLVE_LINUX_FILES_COMMAND = "find -L \"%s\" -maxdepth 1 -type f -name \"%s\" -print";
 
 	// Linux find command template for resolving directory paths.
 	public static final String RESOLVE_LINUX_DIRECTORIES_COMMAND = "find -L \"%s\" -maxdepth 1 -type f -print";
+
+	// Linux find command template for resolving file paths when a directory segment holds a wildcard:
+	// arguments are the literal root, the number of segments below it and the full pattern.
+	public static final String RESOLVE_LINUX_FILES_BY_PATH_COMMAND =
+		"find -L \"%s\" -maxdepth %d -type f -path \"%s\" -print";
 
 	// Line break sequence used in Windows (CRLF).
 	public static final String WINDOWS_LINE_BREAK_SEQUENCE = "\r\n";
@@ -420,7 +427,7 @@ public class FileSourceProcessor {
 		final TelemetryManager telemetryManager,
 		final DeviceKind deviceKind
 	) {
-		final Set<String> resolvedFiles = new HashSet<>();
+		final Set<String> absolutePaths = new HashSet<>();
 
 		final SshConfiguration sshConfiguration = (SshConfiguration) telemetryManager
 			.getHostConfiguration()
@@ -429,32 +436,24 @@ public class FileSourceProcessor {
 
 		if (sshConfiguration == null) {
 			log.info("Hostname {} - No SSH configuration found. Cannot resolve remote file paths.", hostname);
-			return resolvedFiles;
+			return absolutePaths;
 		}
 
 		final Set<String> rawPaths = fileSource.getPaths();
 
 		if (rawPaths == null || rawPaths.isEmpty()) {
-			return new HashSet<>();
+			return absolutePaths;
 		}
 
-		final Set<String> absolutePaths = new HashSet<>();
-
 		for (final String path : rawPaths) {
-			// Extract filename pattern and base path from the path pattern
-			String filename = FileHelper.extractFilename(path, deviceKind);
-			final String basePath = FileHelper.extractBasePath(path, deviceKind);
+			final PathPattern pattern = FileHelper.parsePathPattern(path, deviceKind);
+			if (pattern == null) {
+				log.info("Hostname {} - Skipping invalid file path pattern: {}", hostname, path);
+				continue;
+			}
 
 			// Build OS-specific command to find matching files
-			String command;
-
-			if (deviceKind.equals(DeviceKind.WINDOWS)) {
-				command = RESOLVE_WINDOWS_FILES_COMMAND.formatted(basePath, filename);
-			} else if (filename.equals("*") || filename.isBlank()) {
-				command = RESOLVE_LINUX_DIRECTORIES_COMMAND.formatted(basePath);
-			} else {
-				command = RESOLVE_LINUX_FILES_COMMAND.formatted(basePath, filename);
-			}
+			final String command = buildResolveCommand(pattern, deviceKind);
 
 			try {
 				// Execute SSH command to find matching files on remote host
@@ -476,6 +475,37 @@ public class FileSourceProcessor {
 			}
 		}
 		return absolutePaths;
+	}
+
+	/**
+	 * Builds the OS-specific command that lists the files matching a path pattern on the remote host.
+	 * <ul>
+	 * <li>Windows: the full pattern is passed to {@code Get-Item}, which expands wildcards in every segment.</li>
+	 * <li>Linux with a wildcard in a directory segment: {@code find -path} from the literal root, bounded to the
+	 * pattern depth.</li>
+	 * <li>Linux otherwise: the existing {@code find -name} command (or the directory listing when the filename is
+	 * {@code *}), so that existing configurations produce unchanged commands.</li>
+	 * </ul>
+	 *
+	 * @param pattern    the parsed path pattern
+	 * @param deviceKind the device kind of the remote host
+	 * @return the command to execute
+	 */
+	static String buildResolveCommand(final PathPattern pattern, final DeviceKind deviceKind) {
+		if (DeviceKind.WINDOWS.equals(deviceKind)) {
+			return RESOLVE_WINDOWS_FILES_COMMAND.formatted(pattern.fullPattern());
+		}
+
+		if (pattern.hasDirectoryWildcard()) {
+			return RESOLVE_LINUX_FILES_BY_PATH_COMMAND.formatted(pattern.root(), pattern.depth(), pattern.fullPattern());
+		}
+
+		final String filename = pattern.filename();
+		if ("*".equals(filename)) {
+			return RESOLVE_LINUX_DIRECTORIES_COMMAND.formatted(pattern.root());
+		}
+
+		return RESOLVE_LINUX_FILES_COMMAND.formatted(pattern.root(), filename);
 	}
 
 	/**

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/file/FileSourceProcessor.java
@@ -629,12 +629,12 @@ public class FileSourceProcessor {
 
 			// First read: cursor is null, initialize cursor to current file size without reading content
 			if (cursor == null) {
-				return FileSourceProcessingResult.builder().cursor(fileSize).remainingSize(remainingSize).build();
+				return FileSourceProcessingResult.builder().content("").cursor(fileSize).remainingSize(remainingSize).build();
 			}
 
 			// File has not grown since the last read, no new content to read
 			if (fileSize.equals(cursor)) {
-				return FileSourceProcessingResult.builder().cursor(cursor).remainingSize(remainingSize).build();
+				return FileSourceProcessingResult.builder().content("").cursor(cursor).remainingSize(remainingSize).build();
 			}
 
 			// Due to log rotation, the file keeps the same name, but its content is transfered and archived elsewhere

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -123,6 +123,28 @@ class FileSourceProcessorTest {
 	}
 
 	@Test
+	void buildResolveCommand_linuxEscapesGlobMetacharactersOtherThanWildcards() {
+		// Brackets are literal in a literal segment, in the root and in the filename; only '*' and '?' are wildcards
+		assertEquals(
+			"find -L \"/apps\" -maxdepth 3 -type f -path \"/apps/node*/\\[prod\\]/app.log\" -print",
+			buildResolveCommand("/apps/node*/[prod]/app.log", DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/apps/[prod]\" -maxdepth 2 -type f -path \"/apps/\\[prod\\]/node*/app?.log\" -print",
+			buildResolveCommand("/apps/[prod]/node*/app?.log", DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"app\\[1\\].log\" -print",
+			buildResolveCommand("/opt/logs/app[1].log", DeviceKind.LINUX)
+		);
+		// A literal backslash needs two escaping levels: shell double quotes, then find
+		assertEquals(
+			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"a\\\\\\\\b*.log\" -print",
+			buildResolveCommand("/opt/logs/a\\b*.log", DeviceKind.LINUX)
+		);
+	}
+
+	@Test
 	void resolveRemoteFiles_runsBuiltCommandAndSkipsInvalidPatterns() throws Exception {
 		final OsCommandService osCommandService = mock(OsCommandService.class);
 		final SshConfiguration sshConfiguration = SshConfiguration.sshConfigurationBuilder()

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -88,6 +88,11 @@ class FileSourceProcessorTest {
 			template.formatted("C:\\logs\\app``[1``].log"),
 			buildResolveCommand("C:\\logs\\app[1].log", DeviceKind.WINDOWS)
 		);
+		// $ is never expanded by the double-quoted PowerShell string
+		assertEquals(
+			template.formatted("C:\\data\\`$logs\\node*\\`$(id).log"),
+			buildResolveCommand("C:\\data\\$logs\\node*\\$(id).log", DeviceKind.WINDOWS)
+		);
 	}
 
 	@Test

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -112,32 +112,30 @@ class FileSourceProcessorTest {
 	}
 
 	@Test
-	void buildResolveCommand_linuxUsesPathCommandWithDirectoryWildcard() {
+	void buildResolveCommand_linuxExpandsDirectoryGlobWithDirectoryWildcard() {
+		final String template =
+			"sh -c 'for d in %s; do [ -d \"$d\" ] && find -L \"$d\" -maxdepth 1 -type f -name \"%s\" -print; done'";
+
 		assertEquals(
-			"find -L \"/opt/autosys\" -maxdepth 3 -type f -path \"/opt/autosys/autouser*/out/event_demon*PE2\" -print",
+			template.formatted("\"/opt/autosys/autouser\"*\"/out\"", "event_demon*PE2"),
 			buildResolveCommand("/opt/autosys/autouser*/out/event_demon*PE2", DeviceKind.LINUX)
 		);
+		assertEquals(template.formatted("\"/opt\"*", "x.log"), buildResolveCommand("/opt*/x.log", DeviceKind.LINUX));
+		assertEquals(template.formatted("\"/opt/node\"?", "*"), buildResolveCommand("/opt/node?/", DeviceKind.LINUX));
+		// Brackets, spaces, quotes and shell-special characters in literal runs are quoted or escaped
 		assertEquals(
-			"find -L \"/\" -maxdepth 2 -type f -path \"/opt*/x.log\" -print",
-			buildResolveCommand("/opt*/x.log", DeviceKind.LINUX)
+			template.formatted("\"/apps/node\"*\"/[prod]\"", "app.log"),
+			buildResolveCommand("/apps/node*/[prod]/app.log", DeviceKind.LINUX)
 		);
 		assertEquals(
-			"find -L \"/opt\" -maxdepth 2 -type f -path \"/opt/node?/*\" -print",
-			buildResolveCommand("/opt/node?/", DeviceKind.LINUX)
+			template.formatted("\"/opt/my app/it'\\''s/\\$x/\\\"q\\\"/node\"*", "app?.log"),
+			buildResolveCommand("/opt/my app/it's/$x/\"q\"/node*/app?.log", DeviceKind.LINUX)
 		);
 	}
 
 	@Test
 	void buildResolveCommand_linuxEscapesGlobMetacharactersOtherThanWildcards() {
-		// Brackets are literal in a literal segment, in the root and in the filename; only '*' and '?' are wildcards
-		assertEquals(
-			"find -L \"/apps\" -maxdepth 3 -type f -path \"/apps/node*/\\[prod\\]/app.log\" -print",
-			buildResolveCommand("/apps/node*/[prod]/app.log", DeviceKind.LINUX)
-		);
-		assertEquals(
-			"find -L \"/apps/[prod]\" -maxdepth 2 -type f -path \"/apps/\\[prod\\]/node*/app?.log\" -print",
-			buildResolveCommand("/apps/[prod]/node*/app?.log", DeviceKind.LINUX)
-		);
+		// Brackets are literal in the filename; only '*' and '?' are wildcards
 		assertEquals(
 			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"app\\[1\\].log\" -print",
 			buildResolveCommand("/opt/logs/app[1].log", DeviceKind.LINUX)
@@ -172,7 +170,7 @@ class FileSourceProcessorTest {
 			.build();
 
 		final String expectedCommand =
-			"find -L \"/opt/autosys\" -maxdepth 3 -type f -path \"/opt/autosys/autouser*/out/event_demon*PE2\" -print";
+			"sh -c 'for d in \"/opt/autosys/autouser\"*\"/out\"; do [ -d \"$d\" ] && find -L \"$d\" -maxdepth 1 -type f -name \"event_demon*PE2\" -print; done'";
 		doReturn("/opt/autosys/autouser01/out/event_demon.PE2\n/opt/autosys/autouser02/out/event_demon_XPE2\n")
 			.when(osCommandService)
 			.runSshCommand(

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -13,6 +13,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -61,6 +63,118 @@ class FileSourceProcessorTest {
 		final StringBuilder logBlock = new StringBuilder();
 		FileHelper.appendLogBlock(logBlock, path, FileHelper.escapeSemiColon(rawContent));
 		return logBlock.toString();
+	}
+
+	private static String buildResolveCommand(final String path, final DeviceKind deviceKind) {
+		return FileSourceProcessor.buildResolveCommand(FileHelper.parsePathPattern(path, deviceKind), deviceKind);
+	}
+
+	@Test
+	void buildResolveCommand_windowsPassesFullPatternToGetItem() {
+		final String template =
+			"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-Item -Path \\\"%s\\\" -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | ForEach-Object { $_.FullName }\"";
+
+		assertEquals(
+			template.formatted(WINDOWS_ABSOLUTE_PATH),
+			buildResolveCommand(WINDOWS_ABSOLUTE_PATH, DeviceKind.WINDOWS)
+		);
+		assertEquals(
+			template.formatted("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2"),
+			buildResolveCommand("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2", DeviceKind.WINDOWS)
+		);
+		assertEquals(template.formatted("C:\\logs\\*"), buildResolveCommand("C:\\logs\\", DeviceKind.WINDOWS));
+	}
+
+	@Test
+	void buildResolveCommand_linuxKeepsNameCommandWithoutDirectoryWildcard() {
+		assertEquals(
+			"find -L \"/opt/metricshub/logs\" -maxdepth 1 -type f -name \"*.log\" -print",
+			buildResolveCommand(LINUX_ABSOLUTE_PATH, DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/opt/metricshub/logs\" -maxdepth 1 -type f -name \"*.log\" -print",
+			buildResolveCommand(LINUX_ABSOLUTE_PATH, DeviceKind.AIX)
+		);
+		assertEquals(
+			"find -L \"/opt/metricshub/logs\" -maxdepth 1 -type f -name \"app.log\" -print",
+			buildResolveCommand("/opt/metricshub/logs/app.log", DeviceKind.LINUX)
+		);
+		assertEquals("find -L \"/var/log\" -maxdepth 1 -type f -print", buildResolveCommand("/var/log/", DeviceKind.LINUX));
+		assertEquals(
+			"find -L \"/var/log\" -maxdepth 1 -type f -print",
+			buildResolveCommand("/var/log/*", DeviceKind.LINUX)
+		);
+	}
+
+	@Test
+	void buildResolveCommand_linuxUsesPathCommandWithDirectoryWildcard() {
+		assertEquals(
+			"find -L \"/opt/autosys\" -maxdepth 3 -type f -path \"/opt/autosys/autouser*/out/event_demon*PE2\" -print",
+			buildResolveCommand("/opt/autosys/autouser*/out/event_demon*PE2", DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/\" -maxdepth 2 -type f -path \"/opt*/x.log\" -print",
+			buildResolveCommand("/opt*/x.log", DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/opt\" -maxdepth 2 -type f -path \"/opt/node?/*\" -print",
+			buildResolveCommand("/opt/node?/", DeviceKind.LINUX)
+		);
+	}
+
+	@Test
+	void resolveRemoteFiles_runsBuiltCommandAndSkipsInvalidPatterns() throws Exception {
+		final OsCommandService osCommandService = mock(OsCommandService.class);
+		final SshConfiguration sshConfiguration = SshConfiguration.sshConfigurationBuilder()
+			.hostname(HOSTNAME)
+			.username(USERNAME)
+			.password(PASSWORD.toCharArray())
+			.build();
+		final HostConfiguration hostConfiguration = HostConfiguration.builder()
+			.hostname(HOSTNAME)
+			.configurations(Map.of(SshConfiguration.class, sshConfiguration))
+			.hostType(DeviceKind.LINUX)
+			.build();
+		final TelemetryManager telemetryManager = TelemetryManager.builder()
+			.hostProperties(HostProperties.builder().isLocalhost(false).build())
+			.hostConfiguration(hostConfiguration)
+			.build();
+		final FileSource fileSource = FileSource.builder()
+			.key(SOURCE_KEY)
+			.paths(Set.of("/opt/autosys/autouser*/out/event_demon*PE2", "relative/path.log"))
+			.build();
+
+		final String expectedCommand =
+			"find -L \"/opt/autosys\" -maxdepth 3 -type f -path \"/opt/autosys/autouser*/out/event_demon*PE2\" -print";
+		doReturn("/opt/autosys/autouser01/out/event_demon.PE2\n/opt/autosys/autouser02/out/event_demon_XPE2\n")
+			.when(osCommandService)
+			.runSshCommand(
+				eq(expectedCommand),
+				eq(HOSTNAME),
+				eq(sshConfiguration),
+				anyLong(),
+				any(),
+				eq(expectedCommand),
+				eq(DeviceKind.LINUX)
+			);
+
+		final FileSourceProcessor processor = new FileSourceProcessor(osCommandService);
+		final Set<String> resolved = processor.resolveRemoteFiles(HOSTNAME, fileSource, telemetryManager, DeviceKind.LINUX);
+
+		assertEquals(
+			Set.of("/opt/autosys/autouser01/out/event_demon.PE2", "/opt/autosys/autouser02/out/event_demon_XPE2"),
+			resolved
+		);
+		// The relative path is skipped before any command is run
+		verify(osCommandService, times(1)).runSshCommand(
+			anyString(),
+			anyString(),
+			any(),
+			anyLong(),
+			any(),
+			anyString(),
+			any()
+		);
 	}
 
 	/**

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -135,15 +135,34 @@ class FileSourceProcessorTest {
 
 	@Test
 	void buildResolveCommand_linuxEscapesGlobMetacharactersOtherThanWildcards() {
-		// Brackets are literal in the filename; only '*' and '?' are wildcards
+		// Brackets are literal in the filename; only '*' and '?' are wildcards. The find escape (\[) is itself escaped
+		// for the shell double quotes (\\[), which hands \[ to find.
 		assertEquals(
-			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"app\\[1\\].log\" -print",
+			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"app\\\\[1\\\\].log\" -print",
 			buildResolveCommand("/opt/logs/app[1].log", DeviceKind.LINUX)
 		);
-		// A literal backslash needs two escaping levels: shell double quotes, then find
+		// A literal backslash needs two escaping levels: find (\\), then shell double quotes (\\\\)
 		assertEquals(
 			"find -L \"/opt/logs\" -maxdepth 1 -type f -name \"a\\\\\\\\b*.log\" -print",
 			buildResolveCommand("/opt/logs/a\\b*.log", DeviceKind.LINUX)
+		);
+	}
+
+	@Test
+	void buildResolveCommand_linuxNeverLetsTheShellInterpretPaths() {
+		// $, backtick and double quote are escaped in the root and in the filename: no expansion, no command substitution
+		assertEquals(
+			"find -L \"/opt/\\$x/\\`q\\`\" -maxdepth 1 -type f -name \"\\$(touch pwned)*.log\" -print",
+			buildResolveCommand("/opt/$x/`q`/$(touch pwned)*.log", DeviceKind.LINUX)
+		);
+		assertEquals(
+			"find -L \"/opt/\\\"q\\\"\" -maxdepth 1 -type f -print",
+			buildResolveCommand("/opt/\"q\"/", DeviceKind.LINUX)
+		);
+		// Same inside the single-quoted sh -c script, where a single quote in the filename is also handled
+		assertEquals(
+			"sh -c 'for d in \"/opt/node\"*; do [ -d \"$d\" ] && find -L \"$d\" -maxdepth 1 -type f -name \"it'\\''s\\$(id)*.log\" -print; done'",
+			buildResolveCommand("/opt/node*/it's$(id)*.log", DeviceKind.LINUX)
 		);
 	}
 

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -83,6 +83,11 @@ class FileSourceProcessorTest {
 			buildResolveCommand("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2", DeviceKind.WINDOWS)
 		);
 		assertEquals(template.formatted("C:\\logs\\*"), buildResolveCommand("C:\\logs\\", DeviceKind.WINDOWS));
+		// Brackets are PowerShell wildcard characters: escaped so that only '*' and '?' are wildcards
+		assertEquals(
+			template.formatted("C:\\logs\\app``[1``].log"),
+			buildResolveCommand("C:\\logs\\app[1].log", DeviceKind.WINDOWS)
+		);
 	}
 
 	@Test

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/file/FileSourceProcessorTest.java
@@ -388,14 +388,14 @@ class FileSourceProcessorTest {
 		// Create testable processor with injected mock
 		final FileSourceProcessor processor = new TestableFileSourceProcessor(mockRequestExecutor, osCommandService);
 
-		// Iteration 1: First read - should set cursor but return empty table
+		// Iteration 1: First read - should set cursor and return an empty log block
 		when(mockRequestExecutor.getRemoteFileSize(anyString())).thenReturn(initialFileSize);
 
 		SourceTable result1 = processor.process(fileSource, CONNECTOR_ID, telemetryManager);
 
 		// Assertions for iteration 1
 		assertNotNull(result1);
-		assertTrue(result1.isEmpty());
+		assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 		// Verify cursor was set correctly
 		Map<String, Long> cursors = telemetryManager
@@ -544,14 +544,14 @@ class FileSourceProcessorTest {
 		// Create testable processor with injected mock
 		final FileSourceProcessor processor = new TestableFileSourceProcessor(mockRequestExecutor, osCommandService);
 
-		// Iteration 1: First read - should set cursor but return empty table
+		// Iteration 1: First read - should set cursor and return an empty log block
 		when(mockRequestExecutor.getRemoteFileSize(anyString())).thenReturn(initialFileSize);
 
 		SourceTable result1 = processor.process(fileSource, CONNECTOR_ID, telemetryManager);
 
 		// Assertions for iteration 1
 		assertNotNull(result1);
-		assertTrue(result1.isEmpty());
+		assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 		// Verify cursor was set correctly
 		Map<String, Long> cursors = telemetryManager
@@ -666,7 +666,7 @@ class FileSourceProcessorTest {
 
 			SourceTable result1 = processor.process(fileSource, CONNECTOR_ID, telemetryManager);
 			assertNotNull(result1);
-			assertTrue(result1.isEmpty());
+			assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 			Map<String, Long> cursors = telemetryManager
 				.getHostProperties()
@@ -725,7 +725,7 @@ class FileSourceProcessorTest {
 
 			SourceTable result1 = processor.process(fileSource, CONNECTOR_ID, telemetryManager);
 			assertNotNull(result1);
-			assertTrue(result1.isEmpty());
+			assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 			Map<String, Long> cursors = telemetryManager
 				.getHostProperties()
@@ -782,5 +782,35 @@ class FileSourceProcessorTest {
 			assertNotNull(result);
 			assertEquals(expectedMarkedLogCell(path1, content1), result.getRawData());
 		}
+	}
+
+	@Test
+	void testLogModeEmitsEmptyBlocksForInitialAndUnchangedFiles() throws Exception {
+		final FileOperations fileOps = mock(FileOperations.class);
+		final String path1 = "/logs/a.log";
+		final String path2 = "/logs/b.log";
+		final Set<String> paths = new java.util.LinkedHashSet<>(java.util.List.of(path1, path2));
+		final Map<String, Long> cursors = new HashMap<>();
+		final FileSource source = FileSource.builder().maxSizePerPoll(100L).build();
+		final FileSourceProcessor processor = new FileSourceProcessor(mock(OsCommandService.class));
+		when(fileOps.getFileSize(path1)).thenReturn(10L, 10L, 14L);
+		when(fileOps.getFileSize(path2)).thenReturn(10L);
+		when(fileOps.readFromOffset(path1, 10L, 4)).thenReturn("line");
+		final String emptyBlocks =
+			"<<<LOG:file=\"/logs/a.log\">>>\n<<<END_LOG>>>\n\n" + "<<<LOG:file=\"/logs/b.log\">>>\n<<<END_LOG>>>\n\n";
+
+		for (int poll = 0; poll < 2; poll++) {
+			final var rows = processor.processFilesInLogMode(fileOps, paths, cursors, source, HOSTNAME);
+			assertEquals(emptyBlocks, FileHelper.buildLogBlock(rows, paths, paths));
+			assertEquals(Map.of(path1, 10L, path2, 10L), cursors);
+		}
+
+		final var rows = processor.processFilesInLogMode(fileOps, paths, cursors, source, HOSTNAME);
+		assertEquals(
+			"<<<LOG:file=\"/logs/a.log\">>>\nline\n<<<END_LOG>>>\n\n" + "<<<LOG:file=\"/logs/b.log\">>>\n<<<END_LOG>>>\n\n",
+			FileHelper.buildLogBlock(rows, paths, paths)
+		);
+		assertEquals(Map.of(path1, 14L, path2, 10L), cursors);
+		verify(fileOps, times(1)).readFromOffset(path1, 10L, 4);
 	}
 }

--- a/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
@@ -41,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.metricshub.engine.common.exception.ClientException;
 import org.metricshub.engine.common.helpers.FileHelper;
+import org.metricshub.engine.common.helpers.FileHelper.PathPattern;
 import org.metricshub.engine.common.helpers.ResourceHelper;
 import org.metricshub.engine.common.helpers.TextTableHelper;
 import org.metricshub.engine.connector.model.common.DeviceKind;
@@ -62,7 +63,7 @@ public class FileSourceProcessor {
 	 * PowerShell command template for resolving file paths on Windows.
 	 */
 	public static final String RESOLVE_WINDOWS_FILES_COMMAND =
-		"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-ChildItem -Path \\\"%s\\\" -File -Filter \\\"%s\\\" | ForEach-Object FullName\"";
+		"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-Item -Path \\\"%s\\\" -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | ForEach-Object FullName\"";
 
 	/**
 	 *
@@ -503,12 +504,14 @@ public class FileSourceProcessor {
 		}
 
 		for (final String path : rawPaths) {
-			// Extract filename pattern and base path from the path pattern
-			final String filename = FileHelper.extractFilename(path, DeviceKind.WINDOWS);
-			final String basePath = FileHelper.extractBasePath(path, DeviceKind.WINDOWS);
+			final PathPattern pattern = FileHelper.parsePathPattern(path, DeviceKind.WINDOWS);
+			if (pattern == null) {
+				log.info("Hostname {} - Skipping invalid file path pattern: {}", hostname, path);
+				continue;
+			}
 
-			// Build OS-specific command to find matching files
-			final String command = RESOLVE_WINDOWS_FILES_COMMAND.formatted(basePath, filename);
+			// Build the PowerShell command to find matching files
+			final String command = buildResolveCommand(pattern);
 
 			try {
 				// Execute SSH command to find matching files on remote host
@@ -529,6 +532,18 @@ public class FileSourceProcessor {
 			}
 		}
 		return absolutePaths;
+	}
+
+	/**
+	 * Builds the PowerShell command that lists the files matching a path pattern on the remote Windows host.
+	 * The full pattern is passed to {@code Get-Item}, which expands wildcards in every segment and, unlike
+	 * {@code Get-ChildItem}, never enumerates the children of a literal directory.
+	 *
+	 * @param pattern the parsed path pattern
+	 * @return the command to execute
+	 */
+	static String buildResolveCommand(final PathPattern pattern) {
+		return RESOLVE_WINDOWS_FILES_COMMAND.formatted(pattern.fullPattern());
 	}
 
 	/**

--- a/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
@@ -537,14 +537,14 @@ public class FileSourceProcessor {
 	/**
 	 * Builds the PowerShell command that lists the files matching a path pattern on the remote Windows host.
 	 * The full pattern is passed to {@code Get-Item}, which expands wildcards in every segment and, unlike
-	 * {@code Get-ChildItem}, never enumerates the children of a literal directory. Brackets are escaped so that only
-	 * {@code *} and {@code ?} act as wildcards.
+	 * {@code Get-ChildItem}, never enumerates the children of a literal directory. Brackets, {@code $} and backticks
+	 * are escaped so that only {@code *} and {@code ?} act as wildcards and nothing is expanded.
 	 *
 	 * @param pattern the parsed path pattern
 	 * @return the command to execute
 	 */
 	static String buildResolveCommand(final PathPattern pattern) {
-		return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellBrackets(pattern.fullPattern()));
+		return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellPattern(pattern.fullPattern()));
 	}
 
 	/**

--- a/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
@@ -537,13 +537,14 @@ public class FileSourceProcessor {
 	/**
 	 * Builds the PowerShell command that lists the files matching a path pattern on the remote Windows host.
 	 * The full pattern is passed to {@code Get-Item}, which expands wildcards in every segment and, unlike
-	 * {@code Get-ChildItem}, never enumerates the children of a literal directory.
+	 * {@code Get-ChildItem}, never enumerates the children of a literal directory. Brackets are escaped so that only
+	 * {@code *} and {@code ?} act as wildcards.
 	 *
 	 * @param pattern the parsed path pattern
 	 * @return the command to execute
 	 */
 	static String buildResolveCommand(final PathPattern pattern) {
-		return RESOLVE_WINDOWS_FILES_COMMAND.formatted(pattern.fullPattern());
+		return RESOLVE_WINDOWS_FILES_COMMAND.formatted(FileHelper.escapePowerShellBrackets(pattern.fullPattern()));
 	}
 
 	/**

--- a/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
+++ b/metricshub-win-extension-common/src/main/java/org/metricshub/extension/win/source/FileSourceProcessor.java
@@ -579,12 +579,12 @@ public class FileSourceProcessor {
 
 			// First read: cursor is null, initialize cursor to current file size without reading content
 			if (cursor == null) {
-				return FileSourceProcessingResult.builder().cursor(fileSize).remainingSize(remainingSize).build();
+				return FileSourceProcessingResult.builder().content("").cursor(fileSize).remainingSize(remainingSize).build();
 			}
 
 			// File has not grown since the last read, no new content to read
 			if (fileSize.equals(cursor)) {
-				return FileSourceProcessingResult.builder().cursor(cursor).remainingSize(remainingSize).build();
+				return FileSourceProcessingResult.builder().content("").cursor(cursor).remainingSize(remainingSize).build();
 			}
 
 			// Due to log rotation, the file keeps the same name, but its content is transfered and archived elsewhere

--- a/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
@@ -11,6 +11,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -54,6 +56,67 @@ class FileSourceProcessorTest {
 		final StringBuilder logBlock = new StringBuilder();
 		FileHelper.appendLogBlock(logBlock, path, FileHelper.escapeSemiColon(rawContent));
 		return logBlock.toString();
+	}
+
+	private static String buildResolveCommand(final String path) {
+		return FileSourceProcessor.buildResolveCommand(FileHelper.parsePathPattern(path, DeviceKind.WINDOWS));
+	}
+
+	@Test
+	void buildResolveCommand_passesFullPatternToGetItem() {
+		final String template =
+			"PowerShell.exe -ExecutionPolicy Bypass -Command \"Get-Item -Path \\\"%s\\\" -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | ForEach-Object FullName\"";
+
+		assertEquals(template.formatted(WINDOWS_ABSOLUTE_PATH), buildResolveCommand(WINDOWS_ABSOLUTE_PATH));
+		assertEquals(
+			template.formatted("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2"),
+			buildResolveCommand("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2")
+		);
+		assertEquals(template.formatted("C:\\logs\\*"), buildResolveCommand("C:\\logs\\"));
+	}
+
+	@Test
+	void resolveRemoteFiles_runsBuiltCommandAndSkipsInvalidPatterns() throws Exception {
+		final IWinConfiguration wmiConfiguration = WmiTestConfiguration.builder().hostname(HOSTNAME).build();
+		final HostConfiguration hostConfiguration = HostConfiguration.builder()
+			.hostname(HOSTNAME)
+			.configurations(Map.of(IWinConfiguration.class, wmiConfiguration))
+			.hostType(DeviceKind.WINDOWS)
+			.build();
+		final TelemetryManager telemetryManager = TelemetryManager.builder()
+			.hostProperties(HostProperties.builder().isLocalhost(false).build())
+			.hostConfiguration(hostConfiguration)
+			.build();
+		final String pattern = "D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2";
+		final FileSource fileSource = FileSource.builder()
+			.key("sourceKey")
+			.paths(Set.of(pattern, "logs\\relative.log"))
+			.build();
+
+		when(mockConfigurationRetriever.apply(any(TelemetryManager.class))).thenReturn(wmiConfiguration);
+		final String expectedCommand = buildResolveCommand(pattern);
+		when(
+			mockWinRequestExecutor.executeWinRemoteCommand(eq(HOSTNAME), eq(wmiConfiguration), eq(expectedCommand), anyList())
+		).thenReturn(
+			"D:\\Autosys_waae\\autouser01\\out\\event_demon.PE2\r\nD:\\Autosys_waae\\autouser02\\out\\event_demon_XPE2\r\n"
+		);
+
+		final FileSourceProcessor processor = new FileSourceProcessor(
+			mockWinRequestExecutor,
+			mockConfigurationRetriever,
+			CONNECTOR_ID
+		);
+		final Set<String> resolved = processor.resolveRemoteFiles(HOSTNAME, fileSource, telemetryManager);
+
+		assertEquals(
+			Set.of(
+				"D:\\Autosys_waae\\autouser01\\out\\event_demon.PE2",
+				"D:\\Autosys_waae\\autouser02\\out\\event_demon_XPE2"
+			),
+			resolved
+		);
+		// The relative path is skipped before any command is run
+		verify(mockWinRequestExecutor, times(1)).executeWinRemoteCommand(anyString(), any(), anyString(), anyList());
 	}
 
 	private final String WINDOWS_ABSOLUTE_PATH = "C:\\Program Files\\MetricsHub\\logs\\*.log";

--- a/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
@@ -73,6 +73,8 @@ class FileSourceProcessorTest {
 			buildResolveCommand("D:\\Autosys_waae\\autouser*\\out\\event_demon*PE2")
 		);
 		assertEquals(template.formatted("C:\\logs\\*"), buildResolveCommand("C:\\logs\\"));
+		// Brackets are PowerShell wildcard characters: escaped so that only '*' and '?' are wildcards
+		assertEquals(template.formatted("C:\\logs\\app``[1``].log"), buildResolveCommand("C:\\logs\\app[1].log"));
 	}
 
 	@Test

--- a/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
@@ -75,6 +75,11 @@ class FileSourceProcessorTest {
 		assertEquals(template.formatted("C:\\logs\\*"), buildResolveCommand("C:\\logs\\"));
 		// Brackets are PowerShell wildcard characters: escaped so that only '*' and '?' are wildcards
 		assertEquals(template.formatted("C:\\logs\\app``[1``].log"), buildResolveCommand("C:\\logs\\app[1].log"));
+		// $ is never expanded by the double-quoted PowerShell string
+		assertEquals(
+			template.formatted("C:\\data\\`$logs\\node*\\`$(id).log"),
+			buildResolveCommand("C:\\data\\$logs\\node*\\$(id).log")
+		);
 	}
 
 	@Test

--- a/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
+++ b/metricshub-win-extension-common/src/test/java/org/metricshub/extension/win/source/FileSourceProcessorTest.java
@@ -269,11 +269,11 @@ class FileSourceProcessorTest {
 			CONNECTOR_ID
 		);
 
-		// Iteration 1: First read - should set cursor but return empty table
+		// Iteration 1: First read - should set cursor and return an empty log block
 		SourceTable result1 = processor.process(fileSource, telemetryManager);
 
 		assertNotNull(result1);
-		assertTrue(result1.isEmpty());
+		assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 		Map<String, Long> cursors = telemetryManager
 			.getHostProperties()
@@ -394,7 +394,7 @@ class FileSourceProcessorTest {
 			// First Iteration, empty results are returned.
 			SourceTable result1 = processor.process(fileSource, telemetryManager);
 			assertNotNull(result1);
-			assertTrue(result1.isEmpty());
+			assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 			Map<String, Long> cursors = telemetryManager
 				.getHostProperties()
@@ -458,7 +458,7 @@ class FileSourceProcessorTest {
 
 			SourceTable result1 = processor.process(fileSource, telemetryManager);
 			assertNotNull(result1);
-			assertTrue(result1.isEmpty());
+			assertEquals(expectedMarkedLogCell(resolvedPath, ""), result1.getRawData());
 
 			Map<String, Long> cursors = telemetryManager
 				.getHostProperties()
@@ -676,5 +676,39 @@ class FileSourceProcessorTest {
 			assertNotNull(result);
 			assertEquals(expectedMarkedLogCell(path1, content1), result.getRawData());
 		}
+	}
+
+	@Test
+	void testLogModeEmitsEmptyBlocksForInitialAndUnchangedFiles() throws Exception {
+		final FileOperations fileOps = mock(FileOperations.class);
+		final String path1 = "/logs/a.log";
+		final String path2 = "/logs/b.log";
+		final Set<String> paths = new java.util.LinkedHashSet<>(java.util.List.of(path1, path2));
+		final Map<String, Long> cursors = new HashMap<>();
+		final FileSource source = FileSource.builder().maxSizePerPoll(100L).build();
+		final FileSourceProcessor processor = new FileSourceProcessor(
+			mockWinRequestExecutor,
+			mockConfigurationRetriever,
+			CONNECTOR_ID
+		);
+		when(fileOps.getFileSize(path1)).thenReturn(10L, 10L, 14L);
+		when(fileOps.getFileSize(path2)).thenReturn(10L);
+		when(fileOps.readFromOffset(path1, 10L, 4)).thenReturn("line");
+		final String emptyBlocks =
+			"<<<LOG:file=\"/logs/a.log\">>>\n<<<END_LOG>>>\n\n" + "<<<LOG:file=\"/logs/b.log\">>>\n<<<END_LOG>>>\n\n";
+
+		for (int poll = 0; poll < 2; poll++) {
+			final var rows = processor.processFilesInLogMode(fileOps, paths, cursors, source, HOSTNAME);
+			assertEquals(emptyBlocks, FileHelper.buildLogBlock(rows, paths, paths));
+			assertEquals(Map.of(path1, 10L, path2, 10L), cursors);
+		}
+
+		final var rows = processor.processFilesInLogMode(fileOps, paths, cursors, source, HOSTNAME);
+		assertEquals(
+			"<<<LOG:file=\"/logs/a.log\">>>\nline\n<<<END_LOG>>>\n\n" + "<<<LOG:file=\"/logs/b.log\">>>\n<<<END_LOG>>>\n\n",
+			FileHelper.buildLogBlock(rows, paths, paths)
+		);
+		assertEquals(Map.of(path1, 14L, path2, 10L), cursors);
+		verify(fileOps, times(1)).readFromOffset(path1, 10L, 4);
 	}
 }


### PR DESCRIPTION
Closes #1321

## Summary

`paths` of the `file` source only honored wildcards in the last segment. A pattern such as `D:\Autosys_waae\autouser*\out\event_demon*PE2` returned nothing on every execution path, and on a local Windows host the `InvalidPathException` even emptied the whole source, losing the other valid paths.

This PR resolves `*` and `?` in any segment, directory or filename, consistently on the five execution paths:

| Execution path | Change |
|---|---|
| Local (Windows, Linux) | `FileHelper.parsePathPattern` splits the pattern into a literal root and segments; `findFilesByPattern` walks segment by segment with `Files.newDirectoryStream`, returns regular files only, and catches per path so one bad path no longer hides the others |
| SSH Windows | `Get-Item -Path "<full pattern>" -ErrorAction SilentlyContinue \| Where-Object { -not $_.PSIsContainer }`: expands wildcards in every segment and never enumerates the children of a literal directory |
| SSH Linux | when a directory segment holds a wildcard, `sh -c 'for d in <directory glob>; do [ -d "$d" ] && find -L "$d" -maxdepth 1 -type f -name "<filename>" -print; done'`: the shell expands the directory glob, so only matching directories are visited (no traversal of unrelated or unreadable subtrees) and a wildcard never crosses a separator; the existing `find -name` command is kept otherwise, so existing configurations produce byte-identical commands |
| WinRM/WMI Windows | same `Get-Item` template in `metricshub-win-extension-common` |

A trailing delimiter (`/var/log/`, `C:\logs\`) now lists all files of the directory on every path (previously local matched nothing while remote Linux listed everything).

## Behaviour notes

- Windows remote resolution no longer uses `-Filter`, whose 8.3 short-name matching let `*.log` match `x.log1`. `Get-Item` wildcards are stricter and aligned with local and Linux behaviour.
- Relative paths are now skipped with an info log instead of being resolved against the agent working directory locally (remote resolution already discarded relative results).
- `[`, `]` (and the backslash on Linux) are escaped in the generated `find` and `Get-Item` patterns, and literal directory runs are shell-quoted, so only `*` and `?` act as wildcards on every execution path, consistently with the local resolver.
- Shell metacharacters (`$`, backtick, `"`, `\`) in the root and filename are escaped in the generated Linux commands, and `$` and backticks are escaped in the double-quoted PowerShell pattern, so a configured path can never be expanded or executed on the monitored host (this also hardens the pre-existing `find -name` and `Get-Item` commands).
- On remote Linux hosts, a wildcard in a directory segment does not match dot-prefixed (hidden) directories, as with any shell glob. A literal dot-prefixed segment still works.
- Leading and trailing spaces in a path are preserved, as they are significant in file names.

## Verification

- Full unit test suites of `metricshub-engine`, `metricshub-oscommand-extension` and `metricshub-win-extension-common` pass. New tests cover pattern parsing, local resolution with a real directory tree (`@TempDir`), the generated commands (including brackets, spaces, quotes, shell metacharacters and a command-substitution attempt), and the "one invalid path does not hide valid ones" case.
- The generated PowerShell command was executed through `cmd.exe` on PowerShell 5.1 and the generated `sh -c` commands in a real `sh`, both against real trees: directory wildcard, trailing delimiter, literal directory, literal file, missing path, bracketed names, directories containing spaces, apostrophes or `$`, and a `$(touch ...)` injection attempt (no file created) all behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Testing
```bash
[2026-09-07T20:39:15,994][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Resolved paths:
+-------------------------------------------+
| Path                                      |
+-------------------------------------------+
| C:\work\users\nassim\event_demon_test.PE2 |
| C:\work\users\elyes\event_demon_test.PE2  |
+-------------------------------------------+
[2026-09-07T20:39:15,996][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Path [C:\work\users\nassim\event_demon_test.PE2]: content=0 bytes, newCursor=4268, remainingSize=52428800
[2026-09-07T20:39:15,997][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Path [C:\work\users\elyes\event_demon_test.PE2]: content=0 bytes, newCursor=4268, remainingSize=52428800
[2026-09-07T20:39:15,999][INFO ][o.m.e.s.AbstractStrategy] Hostname FRER1900 - End of source [FileSource ${source::monitors.file.simple.sources.autosysEvents}] for connector [MetricsHub-Configured-Connector-Autosys-autosysLog].
Raw result:
<<<LOG:file="C:\work\users\nassim\event_demon_test.PE2">>>
<<<END_LOG>>>

<<<LOG:file="C:\work\users\elyes\event_demon_test.PE2">>>
<<<END_LOG>>>

```
Files input changed
```bash
[2026-09-07T20:41:16,431][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Resolved paths:
+-------------------------------------------+
| Path                                      |
+-------------------------------------------+
| C:\work\users\nassim\event_demon_test.PE2 |
| C:\work\users\elyes\event_demon_test.PE2  |
+-------------------------------------------+
[2026-09-07T20:41:16,431][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Path [C:\work\users\nassim\event_demon_test.PE2]: content=608 bytes, newCursor=4876, remainingSize=52428192
[2026-09-07T20:41:16,432][DEBUG][o.m.e.w.s.FileSourceProcessor] Hostname FRER1900 - Path [C:\work\users\elyes\event_demon_test.PE2]: content=608 bytes, newCursor=4876, remainingSize=52427584
[2026-09-07T20:41:16,432][INFO ][o.m.e.s.AbstractStrategy] Hostname FRER1900 - End of source [FileSource ${source::monitors.file.simple.sources.autosysEvents}] for connector [MetricsHub-Configured-Connector-Autosys-autosysLog].
Raw result:
<<<LOG:file="C:\work\users\nassim\event_demon_test.PE2">>>
2026-09-04 12:03:00 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:01 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:02 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:03 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:04 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:10:00 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0
2026-09-04 12:11:01 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0
2026-09-04 12:13:02 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0

<<<END_LOG>>>

<<<LOG:file="C:\work\users\elyes\event_demon_test.PE2">>>
2026-09-04 12:03:00 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:01 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:02 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:03 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:03:04 JOBFAILURE JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 1
2026-09-04 12:10:00 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0
2026-09-04 12:11:01 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0
2026-09-04 12:13:02 MUST_START JOB: TEST_JOB MACHINE: FRER1900 EXITCODE: 0

<<<END_LOG>>>
```