### PR TITLE
Issue #1323: Add a reusable StartupHook extension point

### DIFF
--- a/metricshub-agent/src/main/java/org/metricshub/web/service/AgentStartupRunner.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/AgentStartupRunner.java
@@ -23,6 +23,7 @@ package org.metricshub.web.service;
 
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
@@ -44,8 +45,13 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AgentStartupRunner {
 
-	/** All startup hooks discovered by Spring, in {@link org.springframework.core.annotation.Order} order. */
-	private final List<StartupHook> startupHooks;
+	/**
+	 * Provider over every {@link StartupHook} bean. An {@link ObjectProvider} is used instead of a
+	 * {@code List<StartupHook>} so the runner is instantiable even when no hook is declared (as in the
+	 * community edition): a {@code List} dependency would be treated as required and would fail the
+	 * Spring context startup when no matching bean exists.
+	 */
+	private final ObjectProvider<StartupHook> startupHooks;
 
 	/** Guards against running the hooks more than once. */
 	private boolean started;
@@ -53,9 +59,10 @@ public class AgentStartupRunner {
 	/**
 	 * Creates the runner.
 	 *
-	 * @param startupHooks all {@link StartupHook} beans (an empty list when none are declared)
+	 * @param startupHooks provider over all {@link StartupHook} beans (resolves to nothing when none
+	 *                     are declared)
 	 */
-	public AgentStartupRunner(final List<StartupHook> startupHooks) {
+	public AgentStartupRunner(final ObjectProvider<StartupHook> startupHooks) {
 		this.startupHooks = startupHooks;
 	}
 
@@ -70,13 +77,15 @@ public class AgentStartupRunner {
 		}
 		started = true;
 
-		if (startupHooks.isEmpty()) {
+		// Resolve the hooks lazily, ordered by @Order when present.
+		final List<StartupHook> hooks = startupHooks.orderedStream().toList();
+		if (hooks.isEmpty()) {
 			log.debug("No startup hooks to run.");
 			return;
 		}
 
-		log.info("Running {} startup hook(s).", startupHooks.size());
-		for (final StartupHook hook : startupHooks) {
+		log.info("Running {} startup hook(s).", hooks.size());
+		for (final StartupHook hook : hooks) {
 			try {
 				hook.onStartup();
 			} catch (Exception e) {

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/AgentStartupRunner.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/AgentStartupRunner.java
@@ -1,0 +1,88 @@
+package org.metricshub.web.service;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs every {@link StartupHook} once when the agent has fully started.
+ * <p>
+ * Spring injects all {@code StartupHook} beans (ordered by
+ * {@link org.springframework.core.annotation.Order} when present) and this runner invokes them on
+ * {@link ApplicationReadyEvent}. Because both the community and the enterprise agents boot the same
+ * Spring context, every hook runs in <b>both</b> editions without any edition-specific wiring.
+ * </p>
+ * <p>
+ * Each hook is executed inside its own try/catch: a failing hook is logged and skipped so it never
+ * prevents the agent from starting nor blocks the remaining hooks.
+ * </p>
+ */
+@Service
+@Slf4j
+public class AgentStartupRunner {
+
+	/** All startup hooks discovered by Spring, in {@link org.springframework.core.annotation.Order} order. */
+	private final List<StartupHook> startupHooks;
+
+	/** Guards against running the hooks more than once. */
+	private boolean started;
+
+	/**
+	 * Creates the runner.
+	 *
+	 * @param startupHooks all {@link StartupHook} beans (an empty list when none are declared)
+	 */
+	public AgentStartupRunner(final List<StartupHook> startupHooks) {
+		this.startupHooks = startupHooks;
+	}
+
+	/**
+	 * Runs every startup hook once, after the Spring application is ready. Safe to be invoked again
+	 * (subsequent calls are no-ops), and safe when no hook is declared.
+	 */
+	@EventListener(ApplicationReadyEvent.class)
+	public synchronized void runAll() {
+		if (started) {
+			return;
+		}
+		started = true;
+
+		if (startupHooks.isEmpty()) {
+			log.debug("No startup hooks to run.");
+			return;
+		}
+
+		log.info("Running {} startup hook(s).", startupHooks.size());
+		for (final StartupHook hook : startupHooks) {
+			try {
+				hook.onStartup();
+			} catch (Exception e) {
+				log.error("Startup hook '{}' failed: {}", hook.getClass().getName(), e.getMessage());
+				log.debug("Startup hook error", e);
+			}
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/StartupHook.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/StartupHook.java
@@ -1,0 +1,52 @@
+package org.metricshub.web.service;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Extension point for logic that must run once, when the MetricsHub agent has fully started.
+ * <p>
+ * Any Spring bean that implements this interface is discovered and executed by
+ * {@link AgentStartupRunner} on application startup. Because both the community and the enterprise
+ * agents boot the same Spring context (both call
+ * {@code MetricsHubAgentServer.startServer(...)}), a {@code StartupHook} runs in <b>both</b>
+ * editions with no edition-specific wiring — adding startup logic never requires touching the
+ * enterprise bootstrap.
+ * </p>
+ * <p>
+ * This is the startup-time counterpart of the restart hooks registered through
+ * {@code AgentLifecycleService.addPreRestartHook(...)} / {@code addPostRestartHook(...)}.
+ * </p>
+ * <p>
+ * Implementations that need a specific execution order may be annotated with
+ * {@link org.springframework.core.annotation.Order} (lower values run first). A hook must not rely
+ * on other hooks having run, and any exception it throws is isolated by the runner so it never
+ * prevents the agent from starting or blocks the other hooks.
+ * </p>
+ */
+@FunctionalInterface
+public interface StartupHook {
+	/**
+	 * Invoked once, after the agent has fully started. Implementations should return quickly;
+	 * long-running work should be handed off to a background executor.
+	 */
+	void onStartup();
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/AgentStartupRunnerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/AgentStartupRunnerTest.java
@@ -1,0 +1,53 @@
+package org.metricshub.web.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentStartupRunnerTest {
+
+	@Test
+	void testRunsEveryHookOnce() {
+		final StartupHook first = mock(StartupHook.class);
+		final StartupHook second = mock(StartupHook.class);
+
+		new AgentStartupRunner(List.of(first, second)).runAll();
+
+		verify(first, times(1)).onStartup();
+		verify(second, times(1)).onStartup();
+	}
+
+	@Test
+	void testIsolatesFailingHook() {
+		final StartupHook failing = mock(StartupHook.class);
+		doThrow(new IllegalStateException("boom")).when(failing).onStartup();
+		final StartupHook healthy = mock(StartupHook.class);
+
+		final AgentStartupRunner runner = new AgentStartupRunner(List.of(failing, healthy));
+
+		// A throwing hook must not propagate nor stop the remaining hooks.
+		assertDoesNotThrow(runner::runAll);
+		verify(healthy, times(1)).onStartup();
+	}
+
+	@Test
+	void testRunsHooksOnlyOnce() {
+		final StartupHook hook = mock(StartupHook.class);
+		final AgentStartupRunner runner = new AgentStartupRunner(List.of(hook));
+
+		runner.runAll();
+		runner.runAll();
+
+		verify(hook, times(1)).onStartup();
+	}
+
+	@Test
+	void testNoHooksIsANoop() {
+		assertDoesNotThrow(() -> new AgentStartupRunner(List.of()).runAll());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/AgentStartupRunnerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/AgentStartupRunnerTest.java
@@ -5,18 +5,31 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
 
 class AgentStartupRunnerTest {
+
+	/**
+	 * Builds an {@link ObjectProvider} over the given hooks. {@code orderedStream()} is answered with a
+	 * fresh {@link Stream} on every call so the provider can be resolved more than once.
+	 */
+	private static ObjectProvider<StartupHook> provider(final StartupHook... hooks) {
+		@SuppressWarnings("unchecked")
+		final ObjectProvider<StartupHook> objectProvider = mock(ObjectProvider.class);
+		when(objectProvider.orderedStream()).thenAnswer(invocation -> Stream.of(hooks));
+		return objectProvider;
+	}
 
 	@Test
 	void testRunsEveryHookOnce() {
 		final StartupHook first = mock(StartupHook.class);
 		final StartupHook second = mock(StartupHook.class);
 
-		new AgentStartupRunner(List.of(first, second)).runAll();
+		new AgentStartupRunner(provider(first, second)).runAll();
 
 		verify(first, times(1)).onStartup();
 		verify(second, times(1)).onStartup();
@@ -28,7 +41,7 @@ class AgentStartupRunnerTest {
 		doThrow(new IllegalStateException("boom")).when(failing).onStartup();
 		final StartupHook healthy = mock(StartupHook.class);
 
-		final AgentStartupRunner runner = new AgentStartupRunner(List.of(failing, healthy));
+		final AgentStartupRunner runner = new AgentStartupRunner(provider(failing, healthy));
 
 		// A throwing hook must not propagate nor stop the remaining hooks.
 		assertDoesNotThrow(runner::runAll);
@@ -38,7 +51,7 @@ class AgentStartupRunnerTest {
 	@Test
 	void testRunsHooksOnlyOnce() {
 		final StartupHook hook = mock(StartupHook.class);
-		final AgentStartupRunner runner = new AgentStartupRunner(List.of(hook));
+		final AgentStartupRunner runner = new AgentStartupRunner(provider(hook));
 
 		runner.runAll();
 		runner.runAll();
@@ -48,6 +61,7 @@ class AgentStartupRunnerTest {
 
 	@Test
 	void testNoHooksIsANoop() {
-		assertDoesNotThrow(() -> new AgentStartupRunner(List.of()).runAll());
+		// Community edition: no StartupHook bean is declared, the provider resolves to nothing.
+		assertDoesNotThrow(() -> new AgentStartupRunner(provider()).runAll());
 	}
 }


### PR DESCRIPTION
- A StartupHook interface is added for logic that must be run once when the agent has started.
- An AgentStartupRunner service is added, by which all StartupHook beans are collected and run on ApplicationReadyEvent.
- Each hook is isolated, so a failing hook is logged and skipped without the startup or the other hooks being blocked.
- Both editions are covered, since the shared Spring context is booted by the community and enterprise agents alike.
- Unit tests are added for the runner.