### PR TITLE
Issue #1326: Stop exporting stale simple job metrics after they are no longer collected

### DIFF
--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/AbstractAllAtOnceStrategy.java
@@ -217,9 +217,9 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 	/**
 	 * This method processes a monitor job
 	 *
-	 * @param currentConnector
-	 * @param hostname
-	 * @param monitorJobEntry
+	 * @param currentConnector The connector defining the monitor job
+	 * @param hostname         The host name of the monitored resource
+	 * @param monitorJobEntry  The monitor type and its monitor job
 	 */
 	private void processMonitorJob(
 		final Connector currentConnector,
@@ -266,7 +266,12 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 		// Create the monitors
 		final Mapping mapping = monitorTask.getMapping();
 
-		processSameTypeMonitors(currentConnector, mapping, monitorType, hostname, monitorJob);
+		// Only discovery metrics are flagged so that PrepareCollectStrategy refreshes their collect time on each
+		// collect cycle, as they are never re-collected. Simple tasks run on every collect cycle, so their metrics
+		// must not be flagged, otherwise a metric that is no longer collected would be exported with a stale value.
+		final boolean isDiscovery = monitorTask instanceof Discovery;
+
+		processSameTypeMonitors(currentConnector, mapping, monitorType, hostname, monitorJob, isDiscovery);
 		final long jobEndTime = System.currentTimeMillis();
 		// Set the job duration metric in the host monitor
 		setJobDurationMetric(getJobName(), monitorType, currentConnector.getCompiledFilename(), jobStartTime, jobEndTime);
@@ -279,13 +284,16 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 	 * @param mapping     The mapping instance defining the attributes, metrics, conditional collection, legacy text parameters and resource
 	 * @param monitorType The type of the monitor we currently process
 	 * @param hostname    The host name of the monitored resource
+	 * @param monitorJob  The monitor job defining the discovery or simple task
+	 * @param isDiscovery Whether the task is a discovery, in which case the collected metrics are flagged for a collect time reset
 	 */
 	private void processSameTypeMonitors(
 		final Connector connector,
 		final Mapping mapping,
 		final String monitorType,
 		final String hostname,
-		final MonitorJob monitorJob
+		final MonitorJob monitorJob,
+		final boolean isDiscovery
 	) {
 		final String connectorId = connector.getCompiledFilename();
 
@@ -417,7 +425,15 @@ public abstract class AbstractAllAtOnceStrategy extends AbstractStrategy {
 
 			final MetricFactory metricFactory = new MetricFactory(hostname, telemetryManager.getConnectorStore());
 
-			metricFactory.collectMonitorMetrics(monitorType, connector, monitor, connectorId, metrics, strategyTime, true);
+			metricFactory.collectMonitorMetrics(
+				monitorType,
+				connector,
+				monitor,
+				connectorId,
+				metrics,
+				strategyTime,
+				isDiscovery
+			);
 
 			// Collect legacy parameters
 			monitor.addLegacyParameters(mappingProcessor.interpretNonContextMappingLegacyTextParameters());

--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/collect/PrepareCollectStrategy.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/collect/PrepareCollectStrategy.java
@@ -42,7 +42,7 @@ import org.metricshub.engine.telemetry.TelemetryManager;
  *
  * <p>
  * It iterates through all monitors and metrics managed by the telemetry manager, saving metric values,
- * and updating collect times for discovered metrics.
+ * and updating collect times for discovery metrics.
  * </p>
  */
 @NoArgsConstructor
@@ -86,8 +86,8 @@ public class PrepareCollectStrategy extends AbstractStrategy {
 						// in order to compute delta and rates
 						metric.save();
 
-						// Discovered metrics should be refreshed in the collect
-						// so that they are considered collected
+						// Discovery metrics are never re-collected by the collect jobs: refresh their collect time
+						// so that they are considered updated and keep being exported on each collect cycle
 						if (metric.isResetMetricTime()) {
 							metric.setCollectTime(strategyTime);
 						}

--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/simple/SimpleStrategy.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/simple/SimpleStrategy.java
@@ -40,6 +40,12 @@ import org.metricshub.engine.telemetry.TelemetryManager;
  * <p>
  * The class uses the TelemetryManager to manage monitors and metrics associated with the monitor tasks.
  * </p>
+ *
+ * <p>
+ * The strategy is executed in the discovery cycle and in every collect cycle, so the metrics of the simple jobs are
+ * re-collected each cycle and, unlike discovery metrics, do not need their collect time refreshed by the
+ * {@code PrepareCollectStrategy}.
+ * </p>
  */
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)

--- a/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/MetricFactory.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/MetricFactory.java
@@ -432,7 +432,8 @@ public class MetricFactory {
 	 * @param connectorId connector id
 	 * @param metrics metrics
 	 * @param strategyTime time of the strategy in milliseconds
-	 * @param isDiscovery boolean whether it's a discovery operation
+	 * @param isDiscovery whether the metrics are collected by a discovery job, in which case they are flagged so that
+	 *                    their collect time is refreshed on each collect cycle
 	 */
 	public void collectMonitorMetrics(
 		final String monitorType,
@@ -468,8 +469,8 @@ public class MetricFactory {
 			// Set the metrics in the monitor using the connector metrics
 			final AbstractMetric metric = collectMetricUsingConnector(connector, monitor, strategyTime, name, value);
 
-			// Tell the collect that the refresh time of the discovered
-			// metric must be refreshed
+			// Discovery metrics are never re-collected by the collect jobs, so flag them
+			// for the PrepareCollectStrategy to refresh their collect time on each collect cycle
 			if (isDiscovery && metric != null) {
 				metric.setResetMetricTime(true);
 			}

--- a/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/metric/AbstractMetric.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/metric/AbstractMetric.java
@@ -47,6 +47,13 @@ public abstract class AbstractMetric {
 	private Long collectTime;
 	private Long previousCollectTime;
 	private Map<String, String> attributes = new HashMap<>();
+
+	/**
+	 * Whether the collect time of this metric must be refreshed by the {@code PrepareCollectStrategy} at the start of
+	 * each collect cycle. Set for discovery metrics only, which are never re-collected by the collect jobs but must keep
+	 * being exported. Metrics collected by the collect and simple jobs must not carry this flag, otherwise a metric that
+	 * is no longer collected would be exported with a stale value.
+	 */
 	private boolean resetMetricTime;
 
 	/**

--- a/metricshub-engine/src/test/java/org/metricshub/engine/strategy/collect/PrepareCollectStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/strategy/collect/PrepareCollectStrategyTest.java
@@ -1,6 +1,8 @@
 package org.metricshub.engine.strategy.collect;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metricshub.engine.common.helpers.MetricsHubConstants.DEFAULT_KEYS;
 import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_ID;
 import static org.metricshub.engine.common.helpers.MetricsHubConstants.MONITOR_ATTRIBUTE_NAME;
@@ -27,9 +29,37 @@ import org.metricshub.engine.telemetry.metric.NumberMetric;
 class PrepareCollectStrategyTest {
 
 	private static final String HW_METRIC = "hw.metric";
+	private static final long COLLECT_TIME = System.currentTimeMillis();
+	private static final long PREVIOUS_COLLECT_TIME = COLLECT_TIME - 60 * 1000;
 
 	@Test
 	void testRunRefreshDiscoveredMetrics() {
+		final NumberMetric metric = prepareCollect(true);
+
+		// The discovered metric is not collected by the collect job: its collect time is reset so that it is still exported
+		assertEquals(COLLECT_TIME, metric.getCollectTime());
+		assertEquals(PREVIOUS_COLLECT_TIME, metric.getPreviousCollectTime());
+		assertTrue(metric.isUpdated());
+	}
+
+	@Test
+	void testRunKeepsCollectTimeOfCollectedMetrics() {
+		final NumberMetric metric = prepareCollect(false);
+
+		// The metric is collected by the collect job: its collect time is left untouched until it is actually collected
+		assertEquals(PREVIOUS_COLLECT_TIME, metric.getCollectTime());
+		assertEquals(PREVIOUS_COLLECT_TIME, metric.getPreviousCollectTime());
+		assertFalse(metric.isUpdated());
+	}
+
+	/**
+	 * Collect a metric at {@link #PREVIOUS_COLLECT_TIME} with the given discovery flag, then run the
+	 * {@link PrepareCollectStrategy} at {@link #COLLECT_TIME}.
+	 *
+	 * @param isDiscovery Whether the metric is collected by a discovery job
+	 * @return The prepared metric
+	 */
+	private static NumberMetric prepareCollect(final boolean isDiscovery) {
 		final TestConfiguration snmpConfig = TestConfiguration.builder().build();
 		final ConnectorStore connectorStore = new ConnectorStore();
 		connectorStore.setStore(Map.of());
@@ -50,10 +80,9 @@ class PrepareCollectStrategyTest {
 		final ExtensionManager extensionManager = ExtensionManager.empty();
 
 		final ClientsExecutor clientExecutor = new ClientsExecutor(telemetryManager);
-		final long collectTime = System.currentTimeMillis();
 		final MonitorFactory monitorFactory = MonitorFactory.builder()
 			.attributes(new HashMap<>(Map.of(MONITOR_ATTRIBUTE_ID, "id", MONITOR_ATTRIBUTE_NAME, "name")))
-			.discoveryTime(collectTime - 30 * 60 * 1000)
+			.discoveryTime(COLLECT_TIME - 30 * 60 * 1000)
 			.connectorId(CONNECTOR)
 			.telemetryManager(telemetryManager)
 			.monitorType(ENCLOSURE)
@@ -73,14 +102,12 @@ class PrepareCollectStrategyTest {
 			monitor,
 			MetricsHubConstants.HOST_NAME,
 			Map.of(HW_METRIC, "1"),
-			collectTime,
-			true
+			PREVIOUS_COLLECT_TIME,
+			isDiscovery
 		);
 
-		new PrepareCollectStrategy(telemetryManager, collectTime, clientExecutor, extensionManager).run();
+		new PrepareCollectStrategy(telemetryManager, COLLECT_TIME, clientExecutor, extensionManager).run();
 
-		final NumberMetric metric = monitor.getMetric(HW_METRIC, NumberMetric.class);
-
-		assertEquals(metric.getCollectTime(), collectTime);
+		return monitor.getMetric(HW_METRIC, NumberMetric.class);
 	}
 }

--- a/metricshub-engine/src/test/java/org/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/strategy/discovery/DiscoveryStrategyTest.java
@@ -48,6 +48,7 @@ import org.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.metricshub.engine.strategy.source.SourceTable;
 import org.metricshub.engine.telemetry.Monitor;
 import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.engine.telemetry.metric.AbstractMetric;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -193,6 +194,11 @@ class DiscoveryStrategyTest {
 		assertEquals(1, discoveredMonitors.get(DISK_CONTROLLER.getKey()).size());
 		assertEquals(1, discoveredMonitors.get(PHYSICAL_DISK.getKey()).size());
 		assertEquals(1, discoveredMonitors.get(LOGICAL_DISK.getKey()).size());
+		// Discovered metrics are not collected by the collect job, so they are flagged for a collect time reset on each collect
+		final Monitor physicalDisk = discoveredMonitors.get(PHYSICAL_DISK.getKey()).values().iterator().next();
+		final AbstractMetric physicalDiskSize = physicalDisk.getMetric("hw.physical_disk.size");
+		assertNotNull(physicalDiskSize);
+		assertTrue(physicalDiskSize.isResetMetricTime());
 		// Check discovered monitors order
 		Set<String> expectedOrder = Set.of(
 			HOST.getKey(),

--- a/metricshub-engine/src/test/java/org/metricshub/engine/strategy/simple/SimpleStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/strategy/simple/SimpleStrategyTest.java
@@ -1,7 +1,9 @@
 package org.metricshub.engine.strategy.simple;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.metricshub.engine.common.helpers.KnownMonitorType.CONNECTOR;
 import static org.metricshub.engine.common.helpers.KnownMonitorType.DISK_CONTROLLER;
 import static org.metricshub.engine.common.helpers.KnownMonitorType.ENCLOSURE;
@@ -35,6 +37,7 @@ import org.metricshub.engine.extension.ExtensionManager;
 import org.metricshub.engine.extension.IProtocolExtension;
 import org.metricshub.engine.extension.TestConfiguration;
 import org.metricshub.engine.strategy.AbstractStrategy;
+import org.metricshub.engine.strategy.collect.PrepareCollectStrategy;
 import org.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.metricshub.engine.strategy.source.SourceTable;
 import org.metricshub.engine.telemetry.Monitor;
@@ -50,6 +53,8 @@ class SimpleStrategyTest {
 	private IProtocolExtension protocolExtensionMock;
 
 	private static final Path YAML_TEST_PATH = Paths.get("src", "test", "resources", "test-files", "strategy", "simple");
+	private static final String ENCLOSURE_STATUS_METRIC = "hw.status{hw.type=\"enclosure\"}";
+	private static final String DISK_CONTROLLER_STATUS_METRIC = "hw.status{hw.type=\"disk_controller\"}";
 
 	@Mock
 	private ClientsExecutor clientsExecutorMock;
@@ -165,11 +170,8 @@ class SimpleStrategyTest {
 		final Monitor enclosure = enclosureMonitors.get("TestConnectorWithSimple_enclosure_enclosure-1");
 		final Monitor diskController = diskControllerMonitors.get("TestConnectorWithSimple_disk_controller_1");
 
-		assertEquals(1.0, enclosure.getMetric("hw.status{hw.type=\"enclosure\"}", NumberMetric.class).getValue());
-		assertEquals(
-			1.0,
-			diskController.getMetric("hw.status{hw.type=\"disk_controller\"}", NumberMetric.class).getValue()
-		);
+		assertEquals(1.0, enclosure.getMetric(ENCLOSURE_STATUS_METRIC, NumberMetric.class).getValue());
+		assertEquals(1.0, diskController.getMetric(DISK_CONTROLLER_STATUS_METRIC, NumberMetric.class).getValue());
 
 		// Check that StatusInformation is collected on the connector monitor (criterion processing success case)
 		assertEquals(
@@ -253,5 +255,147 @@ class SimpleStrategyTest {
 				"Test on ec-02 FAILED",
 			connectorMonitor.getLegacyTextParameters().get(STATUS_INFORMATION)
 		);
+	}
+
+	@Test
+	void testRunDoesNotRefreshSimpleMetricsNoLongerCollected() throws Exception {
+		// Create host and connector monitors and set them in the telemetry manager
+		final Monitor hostMonitor = Monitor.builder().type(HOST.getKey()).isEndpoint(true).build();
+		hostMonitor.getAttributes().put(IS_ENDPOINT, "true");
+
+		final Monitor connectorMonitor = Monitor.builder().type(CONNECTOR.getKey()).build();
+		connectorMonitor.getAttributes().put("id", "TestConnectorWithSimple");
+		final Map<String, Map<String, Monitor>> monitors = new HashMap<>(
+			Map.of(
+				HOST.getKey(),
+				Map.of("monitor1", hostMonitor),
+				CONNECTOR.getKey(),
+				Map.of(
+					String.format(AbstractStrategy.CONNECTOR_ID_FORMAT, CONNECTOR.getKey(), "TestConnectorWithSimple"),
+					connectorMonitor
+				)
+			)
+		);
+
+		final TestConfiguration snmpConfig = TestConfiguration.builder().build();
+
+		final TelemetryManager telemetryManager = TelemetryManager.builder()
+			.monitors(monitors)
+			.hostConfiguration(
+				HostConfiguration.builder()
+					.hostId("host-01")
+					.hostname("ec-02")
+					.sequential(false)
+					.configurations(Map.of(TestConfiguration.class, snmpConfig))
+					.build()
+			)
+			.connectorStore(new ConnectorStore(YAML_TEST_PATH))
+			.build();
+
+		final ExtensionManager extensionManager = ExtensionManager.builder()
+			.withProtocolExtensions(List.of(protocolExtensionMock))
+			.build();
+
+		doReturn(true).when(protocolExtensionMock).isValidConfiguration(snmpConfig);
+		doReturn(Set.of(SnmpGetSource.class, SnmpTableSource.class)).when(protocolExtensionMock).getSupportedSources();
+		doReturn(Set.of(SnmpGetNextCriterion.class, SnmpGetCriterion.class))
+			.when(protocolExtensionMock)
+			.getSupportedCriteria();
+
+		// Mock detection criteria result
+		final SnmpGetNextCriterion snmpGetNextCriterion = SnmpGetNextCriterion.builder()
+			.oid("1.3.6.1.4.1.795.10.1.1.3.1.1")
+			.type("snmpGetNext")
+			.build();
+		doReturn(CriterionTestResult.success(snmpGetNextCriterion, "1.3.6.1.4.1.795.10.1.1.3.1.1.0	ASN_OCTET_STR	Test"))
+			.when(protocolExtensionMock)
+			.processCriterion(eq(snmpGetNextCriterion), anyString(), any(TelemetryManager.class), anyBoolean());
+
+		// Mock source table information for enclosure
+		final SnmpTableSource enclosureSource = SnmpTableSource.builder()
+			.oid("1.3.6.1.4.1.795.10.1.1.3.1")
+			.selectColumns("ID,1,3,7,8")
+			.type("snmpTable")
+			.key("${source::monitors.enclosure.simple.sources.source(1)}")
+			.build();
+		doReturn(
+			SourceTable.builder()
+				.table(SourceTable.csvToTable("enclosure-1;1;healthy", MetricsHubConstants.TABLE_SEP))
+				.build()
+		)
+			.when(protocolExtensionMock)
+			.processSource(eq(enclosureSource), anyString(), any(TelemetryManager.class));
+
+		// Mock source table information for disk_controller
+		final SnmpTableSource diskControllerSource = SnmpTableSource.builder()
+			.oid("1.3.6.1.4.1.795.10.1.1.4.1")
+			.selectColumns("ID,1,3,7,8")
+			.type("snmpTable")
+			.key("${source::monitors.disk_controller.simple.sources.source(1)}")
+			.build();
+		doReturn(SourceTable.builder().table(SourceTable.csvToTable("1;1;healthy", MetricsHubConstants.TABLE_SEP)).build())
+			.when(protocolExtensionMock)
+			.processSource(eq(diskControllerSource), anyString(), any(TelemetryManager.class));
+
+		// First collect cycle: both simple jobs collect their metrics
+		final long firstCollectTime = strategyTime;
+		SimpleStrategy.builder()
+			.clientsExecutor(clientsExecutorMock)
+			.strategyTime(firstCollectTime)
+			.telemetryManager(telemetryManager)
+			.extensionManager(extensionManager)
+			.build()
+			.run();
+
+		final Monitor enclosure = telemetryManager
+			.getMonitors()
+			.get(ENCLOSURE.getKey())
+			.get("TestConnectorWithSimple_enclosure_enclosure-1");
+		final Monitor diskController = telemetryManager
+			.getMonitors()
+			.get(DISK_CONTROLLER.getKey())
+			.get("TestConnectorWithSimple_disk_controller_1");
+
+		final NumberMetric enclosureStatus = enclosure.getMetric(ENCLOSURE_STATUS_METRIC, NumberMetric.class);
+		final NumberMetric diskControllerStatus = diskController.getMetric(
+			DISK_CONTROLLER_STATUS_METRIC,
+			NumberMetric.class
+		);
+
+		// Simple metrics are collected on each collect cycle, so they must not be flagged for a collect time reset
+		assertFalse(enclosureStatus.isResetMetricTime());
+		assertFalse(diskControllerStatus.isResetMetricTime());
+		assertEquals(firstCollectTime, enclosureStatus.getCollectTime());
+		assertEquals(firstCollectTime, diskControllerStatus.getCollectTime());
+
+		// Second collect cycle: the enclosure source no longer returns any row
+		final long secondCollectTime = firstCollectTime + 60 * 1000;
+		doReturn(SourceTable.empty())
+			.when(protocolExtensionMock)
+			.processSource(eq(enclosureSource), anyString(), any(TelemetryManager.class));
+
+		new PrepareCollectStrategy(telemetryManager, secondCollectTime, clientsExecutorMock, extensionManager).run();
+		SimpleStrategy.builder()
+			.clientsExecutor(clientsExecutorMock)
+			.strategyTime(secondCollectTime)
+			.telemetryManager(telemetryManager)
+			.extensionManager(extensionManager)
+			.build()
+			.run();
+
+		// The enclosure status was not collected: it keeps its previous collect time and is not reported as updated
+		final NumberMetric staleEnclosureStatus = enclosure.getMetric(ENCLOSURE_STATUS_METRIC, NumberMetric.class);
+		assertEquals(firstCollectTime, staleEnclosureStatus.getCollectTime());
+		assertEquals(firstCollectTime, staleEnclosureStatus.getPreviousCollectTime());
+		assertFalse(staleEnclosureStatus.isUpdated());
+
+		// The disk controller status was collected again: it is reported as updated
+		final NumberMetric refreshedDiskControllerStatus = diskController.getMetric(
+			DISK_CONTROLLER_STATUS_METRIC,
+			NumberMetric.class
+		);
+		assertEquals(secondCollectTime, refreshedDiskControllerStatus.getCollectTime());
+		assertEquals(firstCollectTime, refreshedDiskControllerStatus.getPreviousCollectTime());
+		assertTrue(refreshedDiskControllerStatus.isUpdated());
 	}
 }


### PR DESCRIPTION
Fixes #1326

## Problem

`AbstractAllAtOnceStrategy.processSameTypeMonitors` is shared by `DiscoveryStrategy` and `SimpleStrategy`, and it always called `MetricFactory.collectMonitorMetrics(..., isDiscovery = true)`. Every metric collected by a **simple** job was therefore flagged `resetMetricTime`, like a discovery metric. `PrepareCollectStrategy` then refreshed its `collectTime` at the start of every collect cycle, `AbstractMetric.isUpdated()` stayed `true`, and the agent exporter kept pushing the metric with a fresh timestamp and a **stale value** even when the simple job no longer collected it (row gone, `null` value, conditional collection, source failure).

## Fix

- `processMonitorJob` derives `isDiscovery` from the resolved task (`monitorTask instanceof Discovery`) and forwards it to `processSameTypeMonitors` and `MetricFactory.collectMonitorMetrics`. Only discovery metrics are flagged; simple-job metrics now behave like collect-job metrics (`CollectStrategy` already passed `false`) and are exported only when actually collected.
- Only tasks that are instances of `Discovery` are flagged. Simple tasks, and any other task type a subclass may resolve, are treated like collect.
- Comments and Javadoc describing the `resetMetricTime` contract are clarified in `AbstractAllAtOnceStrategy`, `MetricFactory`, `PrepareCollectStrategy`, `AbstractMetric` and `SimpleStrategy`.

## Tests

- `SimpleStrategyTest.testRunDoesNotRefreshSimpleMetricsNoLongerCollected`: runs a simple job, then `PrepareCollectStrategy` and the simple job again with one source now empty. The metric that was not re-collected keeps its previous collect time and `isUpdated()` is `false`, while the re-collected metric is updated. This test fails on `main` (`resetMetricTime` was `true`) and passes with the fix.
- `DiscoveryStrategyTest.testRun`: asserts discovered metrics are still flagged `resetMetricTime`.
- `PrepareCollectStrategyTest`: the existing test now collects the metric one minute before the prepare run so the collect-time reset is actually observable, and a new case checks that a non-discovery metric keeps its collect time and is not reported as updated.

## Impact

- Behavior change worth a release note: simple-job metrics that stop being collected disappear from the export instead of being replayed with a stale value. Consumers keyed on `isUpdated()` (OTLP recorders, hardware normalizers and estimators) ignore them in the cycles where they were not re-collected.
- `AbstractITJob` asserts `isResetMetricTime` against `expected.json`. The IT connectors of this repository define no simple job, so no fixture changes. The connector repositories pin `resetMetricTime: true` for simple-job metrics and will need their fixtures updated when they adopt this engine (follow-up issues: MetricsHub/community-connectors#411 and MetricsHub/enterprise-connectors#451).

## Validation

Module `metricshub-engine`, JDK 25:

- `mvn prettier:write` executed
- `mvn license:check-file-header` passed
- `mvn checkstyle:check` passed (0 issues)
- `mvn verify` on `metricshub-engine`, `metricshub-hardware`, `metricshub-snmp-extension`, `metricshub-oscommand-extension` with `-am`: BUILD SUCCESS. Engine: 1017 unit tests (2 pre-existing skips) and the engine ITs; `DellOpenManageIT` and `SuperConnectorOsIT` green in the SNMP, OS-command and hardware modules, so the `AbstractITJob` `isResetMetricTime` assertions still hold with the existing fixtures. The last review nits (a Javadoc word and test literals) were re-validated with the engine gates plus the three strategy test classes.

No documentation or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
