### PR TITLE
Issue #1325: Harden the legacy MCP SSE transport and serve Streamable HTTP alongside

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@
 curl -fsSL https://get.metricshub.com | bash
 ```
 
+## MCP Server
+
+The agent exposes its tools to AI assistants through an MCP server on the web port (`31888` by default, HTTPS, authenticated with an API key created by `metricshub-api-key create <alias>` and passed as `Authorization: Bearer <key>`):
+
+| Transport | Endpoint | Status |
+| --- | --- | --- |
+| Streamable HTTP (recommended) | `https://<host>:31888/mcp` | Default since 3.9.07 (`spring.ai.mcp.server.protocol: STREAMABLE`) |
+| HTTP with SSE (legacy) | `https://<host>:31888/sse` then `POST /mcp/message` | Served alongside for existing clients; hardened against clients that reconnect their event stream without re-initializing |
+
+The legacy transport can be tuned or disabled under the `web:` section of `metricshub.yaml`:
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `mcp.sse.enabled` | `true` | Serve the legacy SSE endpoints next to `/mcp` |
+| `mcp.sse.message-timeout` | `5m` | Maximum wait for the handling of one message posted on `/mcp/message` (answered with HTTP 504 afterwards; the handling itself is not interrupted) |
+| `mcp.sse.ping-timeout` | `5m` | A session whose keep-alive ping is not answered within this delay is closed |
+| `mcp.sse.initialization-timeout` | `2m` | A session that never completes the `initialize` handshake is closed after this delay |
+| `spring.ai.mcp.server.keep-alive-interval` | `30s` | Keep-alive ping interval of the legacy SSE transport (`spring.ai.mcp.server.streamable-http.keep-alive-interval` for Streamable HTTP) |
+
 ## Project Structure
 
 This is a multi-module project:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The legacy transport can be tuned or disabled under the `web:` section of `metri
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `mcp.sse.enabled` | `true` | Serve the legacy SSE endpoints next to `/mcp` |
+| `mcp.sse.enabled` | `true` | Serve the legacy SSE endpoints next to `/mcp` (ignored when `spring.ai.mcp.server.protocol` is `SSE`, where they are the only endpoints) |
 | `mcp.sse.message-timeout` | `5m` | Maximum wait for the handling of one message posted on `/mcp/message` (answered with HTTP 504 afterwards; the handling itself is not interrupted) |
 | `mcp.sse.ping-timeout` | `5m` | A session whose keep-alive ping is not answered within this delay is closed |
 | `mcp.sse.initialization-timeout` | `2m` | A session that never completes the `initialize` handshake is closed after this delay |

--- a/metricshub-agent/pom.xml
+++ b/metricshub-agent/pom.xml
@@ -298,7 +298,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
-			<version>3.5.0</version>
+			<version>${spring.boot.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/config/SecurityConfig.java
@@ -37,6 +37,7 @@ import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerF
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -91,9 +92,9 @@ public class SecurityConfig {
 	 */
 	@Bean
 	@Order(1)
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain filterChain(HttpSecurity http, Environment environment) throws Exception {
 		return http
-			.securityMatcher("/api/**", "/sse", "/mcp/message")
+			.securityMatcher(securedPaths(environment))
 			.csrf(csrf -> csrf.disable())
 			.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class)
@@ -104,6 +105,23 @@ public class SecurityConfig {
 				ex.authenticationEntryPoint(jsonAuthEntryPoint()).accessDeniedHandler(jsonForbiddenHandler())
 			)
 			.build();
+	}
+
+	/**
+	 * Builds the list of paths that require authentication: the REST API and the MCP endpoints. The MCP endpoints are
+	 * user-configurable through the {@code web} configuration, so they are read from the environment rather than
+	 * hardcoded; a relocated endpoint must never fall through to the permit-all chain.
+	 *
+	 * @param environment the Spring environment
+	 * @return the secured path patterns
+	 */
+	static String[] securedPaths(final Environment environment) {
+		return new String[] {
+			"/api/**",
+			environment.getProperty("spring.ai.mcp.server.sse-endpoint", "/sse"),
+			environment.getProperty("spring.ai.mcp.server.sse-message-endpoint", "/mcp/message"),
+			environment.getProperty("spring.ai.mcp.server.streamable-http.mcp-endpoint", "/mcp")
+		};
 	}
 
 	/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/controller/RestExceptionHandler.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/controller/RestExceptionHandler.java
@@ -21,8 +21,11 @@ package org.metricshub.web.controller;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.metricshub.web.dto.ErrorResponse;
 import org.metricshub.web.exception.ConfigFilesException;
 import org.metricshub.web.exception.LogFilesException;
@@ -45,6 +48,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
  */
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice
+@Slf4j
 public class RestExceptionHandler {
 
 	/**
@@ -209,6 +213,29 @@ public class RestExceptionHandler {
 	@ExceptionHandler(TextPlainException.class)
 	public ResponseEntity<String> handleTextPlainException(final TextPlainException ex) {
 		return ResponseEntity.status(ex.getStatus()).contentType(MediaType.TEXT_PLAIN).body(ex.getMessage());
+	}
+
+	/**
+	 * Handle I/O errors raised while writing the response. Once the response is committed (typically an SSE stream
+	 * whose client aborted the connection), nothing can be sent back and Tomcat would otherwise log the exception as a
+	 * SEVERE error with a full stack trace for every abrupt client disconnect: log it at debug level instead. An I/O
+	 * error before the response is committed is a genuine server error.
+	 *
+	 * @param ex       the I/O exception
+	 * @param response the HTTP response
+	 * @return {@code null} when the response is already committed, an error response otherwise
+	 */
+	@ExceptionHandler(IOException.class)
+	public ResponseEntity<Object> handleIoException(final IOException ex, final HttpServletResponse response) {
+		if (response.isCommitted()) {
+			log.debug("Client connection aborted after the response was committed: {}", ex.getMessage());
+			return null;
+		}
+		log.error("I/O error while handling the request", ex);
+		return new ResponseEntity<>(
+			ErrorResponse.builder().httpStatus(HttpStatus.INTERNAL_SERVER_ERROR).message(ex.getMessage()).build(),
+			HttpStatus.INTERNAL_SERVER_ERROR
+		);
 	}
 
 	private static Map<String, String> fieldErrorsToMap(

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServer.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServer.java
@@ -1,0 +1,94 @@
+package org.metricshub.web.mcp.transport;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import io.modelcontextprotocol.server.McpSyncServer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Holds the MCP server that serves the legacy "HTTP with SSE" transport alongside the Streamable HTTP transport
+ * auto-configured by Spring AI, and shuts it down with the application context.
+ * <p>
+ * The SSE streams are closed on {@link ContextClosedEvent}, i.e. before the embedded web server stops, so that a
+ * graceful shutdown does not wait for open event streams; {@link DisposableBean#destroy()} is kept as a fallback.
+ * </p>
+ * <p>
+ * The transport provider is deliberately not exposed as a Spring bean: Spring AI injects a single
+ * {@code McpServerTransportProviderBase} bean into the auto-configured server, so a second provider bean would make
+ * that injection ambiguous.
+ * </p>
+ */
+@Slf4j
+public class LegacySseMcpServer implements ApplicationListener<ContextClosedEvent>, DisposableBean {
+
+	private final LegacySseServerTransportProvider transportProvider;
+	private final McpSyncServer server;
+	private final AtomicBoolean closed = new AtomicBoolean();
+
+	/**
+	 * Creates the holder.
+	 *
+	 * @param transportProvider the legacy SSE transport provider
+	 * @param server            the MCP server bound to the transport provider
+	 */
+	public LegacySseMcpServer(final LegacySseServerTransportProvider transportProvider, final McpSyncServer server) {
+		this.transportProvider = transportProvider;
+		this.server = server;
+	}
+
+	/**
+	 * @return the router function serving the SSE and message endpoints
+	 */
+	public RouterFunction<ServerResponse> getRouterFunction() {
+		return transportProvider.getRouterFunction();
+	}
+
+	/**
+	 * @return the number of SSE sessions currently open
+	 */
+	public int activeSessionCount() {
+		return transportProvider.activeSessionCount();
+	}
+
+	@Override
+	public void onApplicationEvent(final ContextClosedEvent event) {
+		close();
+	}
+
+	@Override
+	public void destroy() {
+		close();
+	}
+
+	private void close() {
+		if (closed.compareAndSet(false, true)) {
+			log.debug("Shutting down the legacy MCP SSE server");
+			server.closeGracefully();
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServerConfiguration.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServerConfiguration.java
@@ -62,12 +62,13 @@ import org.springframework.web.servlet.function.ServerResponse;
  * Spring AI SSE auto-configuration back off, and Spring AI binds its auto-configured MCP server to it.</li>
  * </ul>
  * <p>
- * Set {@code mcp.sse.enabled=false} to stop serving the legacy transport.
+ * Set {@code mcp.sse.enabled=false} to stop serving the legacy transport alongside Streamable HTTP. The switch is
+ * ignored (with a warning) when the protocol is {@code SSE}: backing off would hand the endpoints back to the SDK
+ * transport this class replaces.
  * </p>
  */
 @Configuration
 @EnableConfigurationProperties({ McpSseProperties.class, McpServerSseProperties.class })
-@ConditionalOnProperty(prefix = McpSseProperties.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 // Same guard as the Spring AI HTTP transports: the MCP server must be enabled and not in stdio mode, otherwise the
 // Spring AI beans this configuration depends on do not exist
 @Conditional(McpServerStdioDisabledCondition.class)
@@ -107,6 +108,13 @@ public class LegacySseMcpServerConfiguration {
 	 */
 	@Configuration
 	@ConditionalOnProperty(prefix = SPRING_AI_MCP_SERVER_PREFIX, name = "protocol", havingValue = "STREAMABLE")
+	// mcp.sse.enabled=false only makes sense here: Streamable HTTP keeps serving the tools without the legacy endpoints
+	@ConditionalOnProperty(
+		prefix = McpSseProperties.PREFIX,
+		name = "enabled",
+		havingValue = "true",
+		matchIfMissing = true
+	)
 	static class AlongsideStreamableHttpConfiguration {
 
 		/**
@@ -260,6 +268,13 @@ public class LegacySseMcpServerConfiguration {
 			final McpServerSseProperties sseProperties,
 			final McpSseProperties legacySseProperties
 		) {
+			if (!legacySseProperties.isEnabled()) {
+				// Backing off here would hand /sse back to the SDK transport that hangs request threads
+				log.warn(
+					"mcp.sse.enabled=false is ignored: the legacy SSE transport is the only MCP transport when " +
+						"spring.ai.mcp.server.protocol=SSE. Set spring.ai.mcp.server.protocol=STREAMABLE to stop serving it."
+				);
+			}
 			log.info(
 				"Hardened legacy MCP SSE transport served on GET {} and POST {}",
 				sseProperties.getSseEndpoint(),

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServerConfiguration.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseMcpServerConfiguration.java
@@ -1,0 +1,282 @@
+package org.metricshub.web.mcp.transport;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServer.SyncSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncCompletionSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncPromptSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.mcp.server.common.autoconfigure.McpServerStdioDisabledCondition;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerChangeNotificationProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties.ApiType;
+import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerSseProperties;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Registers the hardened legacy MCP "HTTP with SSE" transport ({@link LegacySseServerTransportProvider}).
+ * <p>
+ * Two modes are supported, depending on {@code spring.ai.mcp.server.protocol}:
+ * </p>
+ * <ul>
+ * <li>{@code STREAMABLE} (the shipped default): Spring AI auto-configures the Streamable HTTP transport and its MCP
+ * server on {@code /mcp}; this configuration adds a second MCP server, exposing the same tools, resources, prompts and
+ * completions, on the legacy SSE endpoints so that existing clients keep working.</li>
+ * <li>{@code SSE}: the hardened transport is exposed as the {@code McpServerTransportProvider} bean, which makes the
+ * Spring AI SSE auto-configuration back off, and Spring AI binds its auto-configured MCP server to it.</li>
+ * </ul>
+ * <p>
+ * Set {@code mcp.sse.enabled=false} to stop serving the legacy transport.
+ * </p>
+ */
+@Configuration
+@EnableConfigurationProperties({ McpSseProperties.class, McpServerSseProperties.class })
+@ConditionalOnProperty(prefix = McpSseProperties.PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
+// Same guard as the Spring AI HTTP transports: the MCP server must be enabled and not in stdio mode, otherwise the
+// Spring AI beans this configuration depends on do not exist
+@Conditional(McpServerStdioDisabledCondition.class)
+@Slf4j
+public class LegacySseMcpServerConfiguration {
+
+	private static final String SPRING_AI_MCP_SERVER_PREFIX = "spring.ai.mcp.server";
+
+	/**
+	 * Builds the hardened legacy SSE transport provider from the Spring AI SSE properties and the MetricsHub
+	 * hardening properties.
+	 *
+	 * @param mcpServerObjectMapper the object mapper dedicated to the MCP server
+	 * @param sseProperties         the Spring AI SSE properties (endpoints, base URL, keep-alive interval)
+	 * @param legacySseProperties   the MetricsHub hardening properties
+	 * @return the transport provider
+	 */
+	static LegacySseServerTransportProvider createTransportProvider(
+		final ObjectMapper mcpServerObjectMapper,
+		final McpServerSseProperties sseProperties,
+		final McpSseProperties legacySseProperties
+	) {
+		return LegacySseServerTransportProvider.builder()
+			.jsonMapper(new JacksonMcpJsonMapper(mcpServerObjectMapper))
+			.baseUrl(sseProperties.getBaseUrl())
+			.sseEndpoint(sseProperties.getSseEndpoint())
+			.messageEndpoint(sseProperties.getSseMessageEndpoint())
+			.keepAliveInterval(sseProperties.getKeepAliveInterval())
+			.messageTimeout(legacySseProperties.getMessageTimeout())
+			.pingTimeout(legacySseProperties.getPingTimeout())
+			.initializationTimeout(legacySseProperties.getInitializationTimeout())
+			.build();
+	}
+
+	/**
+	 * Serves the legacy SSE transport alongside the Streamable HTTP transport auto-configured by Spring AI.
+	 */
+	@Configuration
+	@ConditionalOnProperty(prefix = SPRING_AI_MCP_SERVER_PREFIX, name = "protocol", havingValue = "STREAMABLE")
+	static class AlongsideStreamableHttpConfiguration {
+
+		/**
+		 * Builds a second MCP server, bound to the legacy SSE transport, exposing the same specifications as the
+		 * auto-configured Streamable HTTP server.
+		 *
+		 * @param mcpServerObjectMapper       the object mapper dedicated to the MCP server
+		 * @param sseProperties               the Spring AI SSE properties
+		 * @param legacySseProperties         the MetricsHub hardening properties
+		 * @param serverProperties            the Spring AI MCP server properties
+		 * @param changeNotificationProperties the Spring AI change notification properties
+		 * @param tools                       the tool specifications
+		 * @param resources                   the resource specifications
+		 * @param resourceTemplates           the resource template specifications
+		 * @param prompts                     the prompt specifications
+		 * @param completions                 the completion specifications
+		 * @return the holder of the legacy SSE MCP server
+		 */
+		@Bean
+		LegacySseMcpServer legacySseMcpServer(
+			@Qualifier("mcpServerObjectMapper") final ObjectMapper mcpServerObjectMapper,
+			final McpServerSseProperties sseProperties,
+			final McpSseProperties legacySseProperties,
+			final McpServerProperties serverProperties,
+			final McpServerChangeNotificationProperties changeNotificationProperties,
+			final ObjectProvider<List<SyncToolSpecification>> tools,
+			final ObjectProvider<List<SyncResourceSpecification>> resources,
+			final ObjectProvider<List<SyncResourceTemplateSpecification>> resourceTemplates,
+			final ObjectProvider<List<SyncPromptSpecification>> prompts,
+			final ObjectProvider<List<SyncCompletionSpecification>> completions
+		) {
+			if (serverProperties.getType() != ApiType.SYNC) {
+				throw new IllegalStateException(
+					"The legacy MCP SSE transport only supports spring.ai.mcp.server.type=SYNC. " +
+						"Use the SYNC server type or disable the legacy transport with mcp.sse.enabled=false."
+				);
+			}
+
+			final LegacySseServerTransportProvider transportProvider = createTransportProvider(
+				mcpServerObjectMapper,
+				sseProperties,
+				legacySseProperties
+			);
+
+			final ServerCapabilities.Builder capabilities = ServerCapabilities.builder();
+			final SyncSpecification<?> serverBuilder = McpServer.sync(transportProvider).serverInfo(
+				serverProperties.getName(),
+				serverProperties.getVersion()
+			);
+
+			if (serverProperties.getCapabilities().isTool()) {
+				capabilities.tools(changeNotificationProperties.isToolChangeNotification());
+				final List<SyncToolSpecification> toolSpecifications = flatten(tools);
+				if (!toolSpecifications.isEmpty()) {
+					serverBuilder.tools(toolSpecifications);
+				}
+			}
+
+			if (serverProperties.getCapabilities().isResource()) {
+				capabilities.resources(false, changeNotificationProperties.isResourceChangeNotification());
+				final List<SyncResourceSpecification> resourceSpecifications = flatten(resources);
+				if (!resourceSpecifications.isEmpty()) {
+					serverBuilder.resources(resourceSpecifications);
+				}
+				final List<SyncResourceTemplateSpecification> resourceTemplateSpecifications = flatten(resourceTemplates);
+				if (!resourceTemplateSpecifications.isEmpty()) {
+					serverBuilder.resourceTemplates(resourceTemplateSpecifications);
+				}
+			}
+
+			if (serverProperties.getCapabilities().isPrompt()) {
+				capabilities.prompts(changeNotificationProperties.isPromptChangeNotification());
+				final List<SyncPromptSpecification> promptSpecifications = flatten(prompts);
+				if (!promptSpecifications.isEmpty()) {
+					serverBuilder.prompts(promptSpecifications);
+				}
+			}
+
+			if (serverProperties.getCapabilities().isCompletion()) {
+				capabilities.completions();
+				final List<SyncCompletionSpecification> completionSpecifications = flatten(completions);
+				if (!completionSpecifications.isEmpty()) {
+					serverBuilder.completions(completionSpecifications);
+				}
+			}
+
+			final McpSyncServer server = serverBuilder
+				.capabilities(capabilities.build())
+				.instructions(serverProperties.getInstructions())
+				.requestTimeout(serverProperties.getRequestTimeout())
+				// Same execution model as the Spring AI auto-configuration in a servlet environment
+				.immediateExecution(true)
+				.build();
+
+			log.info(
+				"Legacy MCP SSE transport served on GET {} and POST {} alongside the Streamable HTTP transport",
+				sseProperties.getSseEndpoint(),
+				sseProperties.getSseMessageEndpoint()
+			);
+
+			return new LegacySseMcpServer(transportProvider, server);
+		}
+
+		/**
+		 * Exposes the SSE and message endpoints of the legacy transport.
+		 *
+		 * @param legacySseMcpServer the holder of the legacy SSE MCP server
+		 * @return the router function
+		 */
+		@Bean
+		RouterFunction<ServerResponse> legacySseRouterFunction(final LegacySseMcpServer legacySseMcpServer) {
+			return legacySseMcpServer.getRouterFunction();
+		}
+
+		/**
+		 * Concatenates all the lists provided by an {@link ObjectProvider}.
+		 *
+		 * @param provider the provider
+		 * @param <T>      the element type
+		 * @return the concatenated list, never {@code null}
+		 */
+		private static <T> List<T> flatten(final ObjectProvider<List<T>> provider) {
+			return provider.stream().flatMap(List::stream).toList();
+		}
+	}
+
+	/**
+	 * Replaces the Spring AI SSE transport provider with the hardened one when the MCP protocol is {@code SSE}.
+	 */
+	@Configuration
+	@ConditionalOnProperty(
+		prefix = SPRING_AI_MCP_SERVER_PREFIX,
+		name = "protocol",
+		havingValue = "SSE",
+		matchIfMissing = true
+	)
+	static class ReplaceSdkSseTransportConfiguration {
+
+		/**
+		 * Exposes the hardened transport provider as the {@code McpServerTransportProvider} bean consumed by the
+		 * Spring AI auto-configured MCP server.
+		 *
+		 * @param mcpServerObjectMapper the object mapper dedicated to the MCP server
+		 * @param sseProperties         the Spring AI SSE properties
+		 * @param legacySseProperties   the MetricsHub hardening properties
+		 * @return the transport provider
+		 */
+		@Bean
+		LegacySseServerTransportProvider legacySseServerTransportProvider(
+			@Qualifier("mcpServerObjectMapper") final ObjectMapper mcpServerObjectMapper,
+			final McpServerSseProperties sseProperties,
+			final McpSseProperties legacySseProperties
+		) {
+			log.info(
+				"Hardened legacy MCP SSE transport served on GET {} and POST {}",
+				sseProperties.getSseEndpoint(),
+				sseProperties.getSseMessageEndpoint()
+			);
+			return createTransportProvider(mcpServerObjectMapper, sseProperties, legacySseProperties);
+		}
+
+		/**
+		 * Exposes the SSE and message endpoints of the legacy transport.
+		 *
+		 * @param transportProvider the transport provider
+		 * @return the router function
+		 */
+		@Bean
+		RouterFunction<ServerResponse> legacySseRouterFunction(final LegacySseServerTransportProvider transportProvider) {
+			return transportProvider.getRouterFunction();
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -1,0 +1,1070 @@
+package org.metricshub.web.mcp.transport;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.server.McpTransportContextExtractor;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import io.modelcontextprotocol.spec.ProtocolVersions;
+import io.modelcontextprotocol.util.Assert;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+import org.springframework.web.servlet.function.ServerResponse.SseBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Hardened, MetricsHub-owned fork of the MCP Java SDK 0.17.0
+ * {@code io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider}
+ * (Copyright 2024-2024 the original author or authors, MIT License).
+ * <p>
+ * It implements the legacy MCP "HTTP with SSE" transport on top of Spring WebMVC: clients open an SSE stream on the
+ * SSE endpoint, receive an {@code endpoint} event pointing to the message endpoint of their session, and POST their
+ * JSON-RPC messages there. The SDK implementation lets a Tomcat request thread block forever when a client sends a
+ * request on a session that never completed the {@code initialize} / {@code notifications/initialized} handshake
+ * (typically an SSE client that reconnected its event stream without re-initializing), and never detects SSE
+ * connections silently dropped by the network. Both defects eventually exhaust Tomcat's connection limit and make the
+ * port refuse connections while the JVM is alive.
+ * </p>
+ * <p>
+ * Modifications compared to the SDK class:
+ * </p>
+ * <ul>
+ * <li>Each session tracks its MCP lifecycle state. Requests and notifications sent on a session that is not
+ * initialized are rejected with HTTP 400 and a JSON-RPC error instead of blocking the request thread until the exchange
+ * is established. Pre-initialization {@code ping} requests are answered directly, as allowed by the specification.</li>
+ * <li>The wait for the handling of a message is bounded by {@code messageTimeout}: an asynchronous completion that
+ * does not arrive in time releases the request thread with HTTP 504 (the handling is not cancelled, a late result is
+ * still written to the SSE stream). Tool executions run synchronously on the request thread and are not interrupted.</li>
+ * <li>Keep-alive pings close the SSE session when they cannot be delivered or are not answered within
+ * {@code pingTimeout}, so that connections dropped by the network are released from Tomcat's connection counter.</li>
+ * <li>Sessions that never complete the handshake are closed after {@code initializationTimeout}.</li>
+ * </ul>
+ */
+@Slf4j
+public class LegacySseServerTransportProvider implements McpServerTransportProvider {
+
+	/**
+	 * Event type for JSON-RPC messages sent through the SSE connection.
+	 */
+	public static final String MESSAGE_EVENT_TYPE = "message";
+
+	/**
+	 * Event type for sending the message endpoint URI to clients.
+	 */
+	public static final String ENDPOINT_EVENT_TYPE = "endpoint";
+
+	/**
+	 * Query parameter carrying the session identifier on the message endpoint.
+	 */
+	public static final String SESSION_ID = "sessionId";
+
+	/**
+	 * Default SSE endpoint path as specified by the MCP transport specification.
+	 */
+	public static final String DEFAULT_SSE_ENDPOINT = "/sse";
+
+	/**
+	 * Default bound applied to the handling of a single JSON-RPC message.
+	 */
+	public static final Duration DEFAULT_MESSAGE_TIMEOUT = Duration.ofMinutes(5);
+
+	/**
+	 * Default time granted to a client to answer a keep-alive ping. Generous on purpose: a client that is merely
+	 * suspended (laptop lid closed) must not lose its session, while a connection dropped by the network is still
+	 * reclaimed within minutes.
+	 */
+	public static final Duration DEFAULT_PING_TIMEOUT = Duration.ofMinutes(5);
+
+	/**
+	 * Default time granted to a client to complete the initialization handshake.
+	 */
+	public static final Duration DEFAULT_INITIALIZATION_TIMEOUT = Duration.ofMinutes(2);
+
+	/**
+	 * Interval of the maintenance loop when keep-alive pings are disabled.
+	 */
+	private static final Duration DEFAULT_MAINTENANCE_INTERVAL = Duration.ofSeconds(30);
+
+	private static final TypeRef<Object> OBJECT_TYPE_REF = new TypeRef<>() {};
+
+	/**
+	 * MCP lifecycle state of a session, as observed from the messages posted by the client.
+	 */
+	public enum SessionState {
+		/**
+		 * The SSE stream is open but no {@code initialize} request has been received.
+		 */
+		CREATED,
+		/**
+		 * The {@code initialize} request has been received but not the {@code notifications/initialized}
+		 * notification.
+		 */
+		INITIALIZING,
+		/**
+		 * The handshake is complete; regular requests are accepted.
+		 */
+		INITIALIZED
+	}
+
+	private final McpJsonMapper jsonMapper;
+
+	private final String messageEndpoint;
+
+	private final String sseEndpoint;
+
+	private final String baseUrl;
+
+	private final Duration messageTimeout;
+
+	private final Duration pingTimeout;
+
+	private final Duration initializationTimeout;
+
+	private final RouterFunction<ServerResponse> routerFunction;
+
+	private McpServerSession.Factory sessionFactory;
+
+	/**
+	 * Map of active client sessions, keyed by session ID.
+	 */
+	private final ConcurrentHashMap<String, SseSession> sessions = new ConcurrentHashMap<>();
+
+	private final McpTransportContextExtractor<ServerRequest> contextExtractor;
+
+	/**
+	 * Flag indicating if the transport is shutting down.
+	 */
+	private volatile boolean isClosing = false;
+
+	private final boolean keepAliveEnabled;
+
+	private Disposable maintenanceTask;
+
+	private LegacySseServerTransportProvider(
+		final McpJsonMapper jsonMapper,
+		final String baseUrl,
+		final String messageEndpoint,
+		final String sseEndpoint,
+		final Duration keepAliveInterval,
+		final Duration messageTimeout,
+		final Duration pingTimeout,
+		final Duration initializationTimeout,
+		final McpTransportContextExtractor<ServerRequest> contextExtractor
+	) {
+		Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+		Assert.notNull(baseUrl, "Message base URL must not be null");
+		Assert.notNull(messageEndpoint, "Message endpoint must not be null");
+		Assert.notNull(sseEndpoint, "SSE endpoint must not be null");
+		Assert.notNull(messageTimeout, "Message timeout must not be null");
+		Assert.notNull(pingTimeout, "Ping timeout must not be null");
+		Assert.notNull(initializationTimeout, "Initialization timeout must not be null");
+		Assert.notNull(contextExtractor, "Context extractor must not be null");
+
+		this.jsonMapper = jsonMapper;
+		this.baseUrl = baseUrl;
+		this.messageEndpoint = messageEndpoint;
+		this.sseEndpoint = sseEndpoint;
+		this.messageTimeout = messageTimeout;
+		this.pingTimeout = pingTimeout;
+		this.initializationTimeout = initializationTimeout;
+		this.contextExtractor = contextExtractor;
+		this.keepAliveEnabled = keepAliveInterval != null;
+		this.routerFunction = RouterFunctions.route()
+			.GET(this.sseEndpoint, this::handleSseConnection)
+			.POST(this.messageEndpoint, this::handleMessage)
+			.build();
+
+		startMaintenanceLoop(keepAliveInterval != null ? keepAliveInterval : DEFAULT_MAINTENANCE_INTERVAL);
+	}
+
+	@Override
+	public List<String> protocolVersions() {
+		return List.of(ProtocolVersions.MCP_2024_11_05);
+	}
+
+	@Override
+	public void setSessionFactory(final McpServerSession.Factory sessionFactory) {
+		this.sessionFactory = sessionFactory;
+	}
+
+	/**
+	 * Broadcasts a notification to all connected clients through their SSE connections. Errors on one session are
+	 * logged and do not prevent the delivery to the other sessions.
+	 *
+	 * @param method The method name for the notification
+	 * @param params The parameters for the notification
+	 * @return A Mono that completes when the broadcast attempt is finished
+	 */
+	@Override
+	public Mono<Void> notifyClients(final String method, final Object params) {
+		if (sessions.isEmpty()) {
+			log.debug("No active MCP SSE session to broadcast {} to", method);
+			return Mono.empty();
+		}
+
+		log.debug("Broadcasting {} to {} active MCP SSE sessions", method, sessions.size());
+
+		return Flux.fromIterable(sessions.values())
+			// The server must not send anything but pings and logging to a client that has not completed the handshake
+			.filter(sseSession -> sseSession.state().get() == SessionState.INITIALIZED)
+			.flatMap(sseSession ->
+				sseSession
+					.session()
+					.sendNotification(method, params)
+					.doOnError(e ->
+						log.error("Failed to send {} to MCP SSE session {}: {}", method, sseSession.id(), e.getMessage())
+					)
+					.onErrorComplete()
+			)
+			.then();
+	}
+
+	/**
+	 * Initiates a graceful shutdown of the transport: stops the maintenance loop, refuses new connections, closes all
+	 * active SSE connections and forgets the sessions.
+	 *
+	 * @return A Mono that completes when all cleanup operations are finished
+	 */
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Flux.fromIterable(sessions.values())
+			.doFirst(() -> {
+				this.isClosing = true;
+				if (this.maintenanceTask != null) {
+					this.maintenanceTask.dispose();
+				}
+				log.debug(
+					"Initiating graceful shutdown of the legacy MCP SSE transport with {} active sessions",
+					sessions.size()
+				);
+			})
+			.flatMap(sseSession -> sseSession.session().closeGracefully())
+			.then()
+			.doOnSuccess(v -> {
+				log.debug("Graceful shutdown of the legacy MCP SSE transport completed");
+				sessions.clear();
+			});
+	}
+
+	/**
+	 * Returns the RouterFunction that defines the HTTP endpoints for this transport: {@code GET} on the SSE endpoint
+	 * to establish the event stream and {@code POST} on the message endpoint to receive JSON-RPC messages.
+	 *
+	 * @return The configured RouterFunction for handling HTTP requests
+	 */
+	public RouterFunction<ServerResponse> getRouterFunction() {
+		return this.routerFunction;
+	}
+
+	/**
+	 * @return the number of SSE sessions currently tracked by this transport
+	 */
+	public int activeSessionCount() {
+		return sessions.size();
+	}
+
+	/**
+	 * Returns the lifecycle state of a session.
+	 *
+	 * @param sessionId the session identifier
+	 * @return the state, or an empty optional when the session is unknown
+	 */
+	public Optional<SessionState> sessionState(final String sessionId) {
+		final SseSession sseSession = sessions.get(sessionId);
+		return sseSession == null ? Optional.empty() : Optional.of(sseSession.state().get());
+	}
+
+	/**
+	 * Handles new SSE connection requests from clients by creating a new session and establishing an SSE connection,
+	 * then sending the initial {@code endpoint} event that tells the client where to POST its messages.
+	 *
+	 * @param request The incoming server request
+	 * @return A ServerResponse configured for SSE communication, or an error response if the server is shutting down
+	 */
+	private ServerResponse handleSseConnection(final ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		return ServerResponse.sse(
+			sseBuilder -> {
+				final WebMvcMcpSessionTransport sessionTransport = new WebMvcMcpSessionTransport(sseBuilder);
+				final McpServerSession session = sessionFactory.create(sessionTransport);
+				final String sessionId = session.getId();
+				final SseSession sseSession = new SseSession(sessionId, session, sessionTransport);
+
+				sseBuilder.onComplete(() -> forgetSession(sseSession, "completed"));
+				sseBuilder.onTimeout(() -> forgetSession(sseSession, "timed out"));
+				sseBuilder.onError(e -> forgetSession(sseSession, "failed: " + e.getMessage()));
+				this.sessions.put(sessionId, sseSession);
+				log.debug(
+					"Opened MCP SSE session {} from {}. Active sessions: {}",
+					sessionId,
+					describeRemote(request),
+					sessions.size()
+				);
+
+				try {
+					sessionTransport.sendEndpointEvent(buildEndpointUrl(sessionId));
+				} catch (Exception e) {
+					log.error("Failed to send the initial endpoint event to MCP SSE session {}: {}", sessionId, e.getMessage());
+					forgetSession(sseSession, "failed to send the endpoint event");
+					sseBuilder.error(e);
+				}
+			},
+			Duration.ZERO
+		);
+	}
+
+	/**
+	 * Constructs the full message endpoint URL by combining the base URL, message path and the session identifier.
+	 *
+	 * @param sessionId the unique session identifier
+	 * @return the fully qualified endpoint URL as a string
+	 */
+	private String buildEndpointUrl(final String sessionId) {
+		return UriComponentsBuilder.fromUriString(this.baseUrl)
+			.path(this.messageEndpoint)
+			.queryParam(SESSION_ID, sessionId)
+			.build()
+			.toUriString();
+	}
+
+	/**
+	 * Handles incoming JSON-RPC messages from clients: resolves the session, enforces the MCP lifecycle, then
+	 * processes the message through the session with a bounded wait.
+	 *
+	 * @param request The incoming server request containing the JSON-RPC message
+	 * @return A ServerResponse indicating success (200 OK) or the appropriate error status
+	 */
+	private ServerResponse handleMessage(final ServerRequest request) {
+		if (this.isClosing) {
+			return ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).body("Server is shutting down");
+		}
+
+		final Optional<String> sessionIdParam = request.param(SESSION_ID);
+		if (sessionIdParam.isEmpty()) {
+			return ServerResponse.badRequest().body(new McpError("Session ID missing in message endpoint"));
+		}
+
+		final String sessionId = sessionIdParam.get();
+		final SseSession sseSession = sessions.get(sessionId);
+		if (sseSession == null) {
+			return ServerResponse.status(HttpStatus.NOT_FOUND).body(new McpError("Session not found: " + sessionId));
+		}
+
+		final JSONRPCMessage message;
+		try {
+			message = McpSchema.deserializeJsonRpcMessage(jsonMapper, request.body(String.class));
+		} catch (IllegalArgumentException | IOException | ServletException e) {
+			log.error("Failed to deserialize the MCP message posted on SSE session {}: {}", sessionId, e.getMessage());
+			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
+		}
+
+		if (!trackLifecycle(sseSession, message)) {
+			if (message instanceof JSONRPCRequest pingRequest && McpSchema.METHOD_PING.equals(pingRequest.method())) {
+				return answerPing(sseSession, pingRequest);
+			}
+			if (message instanceof JSONRPCNotification notification) {
+				// Nothing can be done with a notification before the handshake; drop it silently like the SDK does for
+				// notifications without a handler, rather than failing the client's POST.
+				log.debug(
+					"Dropped MCP notification '{}' posted on uninitialized SSE session {} (state {})",
+					notification.method(),
+					sseSession.id(),
+					sseSession.state().get()
+				);
+				return ServerResponse.accepted().build();
+			}
+			return rejectUninitialized(request, sseSession, message);
+		}
+
+		return dispatch(request, sseSession, message);
+	}
+
+	/**
+	 * Updates the lifecycle state of the session according to the message and tells whether the message may be
+	 * handed over to the session.
+	 *
+	 * @param sseSession the session the message was posted on
+	 * @param message    the JSON-RPC message
+	 * @return {@code true} when the session may process the message, {@code false} when the session is not
+	 *         initialized and the message is neither part of the handshake nor a response
+	 */
+	private static boolean trackLifecycle(final SseSession sseSession, final JSONRPCMessage message) {
+		final AtomicReference<SessionState> state = sseSession.state();
+
+		// Responses to server-initiated requests (pings, sampling...) never wait on the initialization.
+		if (message instanceof JSONRPCResponse) {
+			return true;
+		}
+
+		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
+			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+			return true;
+		}
+
+		if (
+			message instanceof JSONRPCNotification notification &&
+			McpSchema.METHOD_NOTIFICATION_INITIALIZED.equals(notification.method())
+		) {
+			state.set(SessionState.INITIALIZED);
+			return true;
+		}
+
+		return state.get() == SessionState.INITIALIZED;
+	}
+
+	/**
+	 * Answers a {@code ping} request received before the initialization handshake is complete. The SDK session would
+	 * wait for the handshake before answering, which is exactly the situation we must never block on.
+	 *
+	 * @param sseSession  the session the ping was posted on
+	 * @param pingRequest the ping request
+	 * @return 200 OK once the response has been written to the SSE stream
+	 */
+	private ServerResponse answerPing(final SseSession sseSession, final JSONRPCRequest pingRequest) {
+		log.debug("Answering a pre-initialization ping on MCP SSE session {}", sseSession.id());
+		sseSession
+			.transport()
+			.sendMessage(new JSONRPCResponse(McpSchema.JSONRPC_VERSION, pingRequest.id(), Map.of(), null))
+			.block();
+		return ServerResponse.ok().build();
+	}
+
+	/**
+	 * Rejects a message posted on a session that has not completed the initialization handshake.
+	 *
+	 * @param request    the HTTP request
+	 * @param sseSession the session the message was posted on
+	 * @param message    the rejected JSON-RPC message
+	 * @return 400 Bad Request carrying a JSON-RPC error
+	 */
+	private ServerResponse rejectUninitialized(
+		final ServerRequest request,
+		final SseSession sseSession,
+		final JSONRPCMessage message
+	) {
+		final String method = methodOf(message);
+		final Object id = message instanceof JSONRPCRequest jsonRpcRequest ? jsonRpcRequest.id() : null;
+
+		log.warn(
+			"Rejected MCP message '{}' posted on SSE session {} in state {} from {}: the session is not initialized. " +
+				"The client probably reconnected its SSE stream without re-initializing (send 'initialize' and " +
+				"'notifications/initialized' first).",
+			method,
+			sseSession.id(),
+			sseSession.state().get(),
+			describeRemote(request)
+		);
+
+		final JSONRPCResponse errorResponse = new JSONRPCResponse(
+			McpSchema.JSONRPC_VERSION,
+			id,
+			null,
+			new JSONRPCResponse.JSONRPCError(
+				McpSchema.ErrorCodes.INVALID_REQUEST,
+				String.format(
+					"MCP session %s is not initialized: send 'initialize' and 'notifications/initialized' before '%s'",
+					sseSession.id(),
+					method
+				),
+				null
+			)
+		);
+
+		return jsonResponse(HttpStatus.BAD_REQUEST, errorResponse);
+	}
+
+	/**
+	 * Hands the message over to the session and waits for its completion for at most {@code messageTimeout}. The
+	 * handling itself is never cancelled: a synchronous tool execution runs on this thread until it returns, and an
+	 * asynchronous completion that arrives after the deadline is still written to the SSE stream.
+	 *
+	 * @param request    the HTTP request
+	 * @param sseSession the session the message was posted on
+	 * @param message    the JSON-RPC message
+	 * @return 200 OK, 504 when the message timed out or 500 on any other failure
+	 */
+	private ServerResponse dispatch(
+		final ServerRequest request,
+		final SseSession sseSession,
+		final JSONRPCMessage message
+	) {
+		final String method = methodOf(message);
+		try {
+			final McpTransportContext transportContext = this.contextExtractor.extract(request);
+
+			// Watchdog rather than Mono.timeout(): the handling is never cancelled, so a completion that arrives after
+			// the deadline is still written to the SSE stream. Synchronous tool executions run inline on this thread
+			// (immediateExecution) and are therefore never interrupted; the deadline only bounds asynchronous waits.
+			final Sinks.Empty<Void> completion = Sinks.empty();
+			sseSession
+				.session()
+				.handle(message)
+				.contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
+				.subscribe(ignored -> {}, completion::tryEmitError, completion::tryEmitEmpty);
+			completion.asMono().timeout(messageTimeout).block();
+
+			return ServerResponse.ok().build();
+		} catch (Exception e) {
+			if (Exceptions.unwrap(e) instanceof TimeoutException) {
+				log.error(
+					"MCP message '{}' posted on SSE session {} did not complete within {}; releasing the request thread " +
+						"(a late result is still delivered on the SSE stream)",
+					method,
+					sseSession.id(),
+					messageTimeout
+				);
+				final Object id = message instanceof JSONRPCRequest jsonRpcRequest ? jsonRpcRequest.id() : null;
+				final JSONRPCResponse errorResponse = new JSONRPCResponse(
+					McpSchema.JSONRPC_VERSION,
+					id,
+					null,
+					new JSONRPCResponse.JSONRPCError(
+						McpSchema.ErrorCodes.INTERNAL_ERROR,
+						String.format("MCP message '%s' did not complete within %s", method, messageTimeout),
+						null
+					)
+				);
+				return jsonResponse(HttpStatus.GATEWAY_TIMEOUT, errorResponse);
+			}
+
+			log.error(
+				"Error handling MCP message '{}' posted on SSE session {}: {}",
+				method,
+				sseSession.id(),
+				e.getMessage()
+			);
+			return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new McpError(e.getMessage()));
+		}
+	}
+
+	/**
+	 * Serializes a JSON-RPC response as the body of an HTTP response.
+	 *
+	 * @param status   the HTTP status
+	 * @param response the JSON-RPC response
+	 * @return the HTTP response
+	 */
+	private ServerResponse jsonResponse(final HttpStatus status, final JSONRPCResponse response) {
+		try {
+			return ServerResponse.status(status)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(jsonMapper.writeValueAsString(response));
+		} catch (IOException e) {
+			return ServerResponse.status(status).body(new McpError(response.error().message()));
+		}
+	}
+
+	/**
+	 * @param message a JSON-RPC message
+	 * @return the method of the message, or {@code response} for responses
+	 */
+	private static String methodOf(final JSONRPCMessage message) {
+		if (message instanceof JSONRPCRequest request) {
+			return request.method();
+		}
+		if (message instanceof JSONRPCNotification notification) {
+			return notification.method();
+		}
+		return "response";
+	}
+
+	/**
+	 * @param request the HTTP request
+	 * @return a printable description of the remote peer
+	 */
+	private static String describeRemote(final ServerRequest request) {
+		return request.remoteAddress().map(Object::toString).orElse("unknown remote");
+	}
+
+	/**
+	 * Starts the maintenance loop that pings the connected clients and evicts the sessions that never completed the
+	 * initialization handshake.
+	 *
+	 * @param interval the loop interval
+	 */
+	private void startMaintenanceLoop(final Duration interval) {
+		this.maintenanceTask = Flux.interval(interval, interval, Schedulers.boundedElastic()).subscribe(
+			tick -> runMaintenance(),
+			error -> log.error("The maintenance loop of the legacy MCP SSE transport failed: {}", error.getMessage(), error)
+		);
+	}
+
+	/**
+	 * Runs one maintenance pass: closes the sessions that did not complete the initialization handshake in time and,
+	 * when keep-alive is enabled, pings the other sessions. A session whose ping fails or times out is closed so that
+	 * the connection is released from Tomcat's connection counter.
+	 */
+	void runMaintenance() {
+		runMaintenance(Instant.now());
+	}
+
+	/**
+	 * Runs one maintenance pass at the given instant.
+	 *
+	 * @param now the current time, injectable for tests
+	 */
+	void runMaintenance(final Instant now) {
+		if (this.isClosing) {
+			return;
+		}
+
+		for (final SseSession sseSession : sessions.values()) {
+			// Never let one session break the loop: an exception escaping here would terminate the Flux.interval
+			// subscription and silently disable the keep-alive for the lifetime of the process.
+			try {
+				maintain(sseSession, now);
+			} catch (Exception e) {
+				log.warn("Maintenance of MCP SSE session {} failed: {}", sseSession.id(), e.getMessage(), e);
+			}
+		}
+	}
+
+	/**
+	 * Runs one maintenance pass on one session.
+	 *
+	 * @param sseSession the session
+	 * @param now        the current time
+	 */
+	private void maintain(final SseSession sseSession, final Instant now) {
+		if (
+			sseSession.state().get() != SessionState.INITIALIZED &&
+			sseSession.createdAt().plus(initializationTimeout).isBefore(now)
+		) {
+			closeSession(
+				sseSession,
+				String.format(
+					"the client did not complete the MCP initialization handshake within %s (state %s)",
+					initializationTimeout,
+					sseSession.state().get()
+				)
+			);
+		} else if (keepAliveEnabled) {
+			ping(sseSession);
+		}
+	}
+
+	/**
+	 * Sends a keep-alive ping to the client of the session and closes the session when the ping is not answered within
+	 * {@code pingTimeout} or cannot be delivered. A JSON-RPC error answer counts as an answer.
+	 *
+	 * @param sseSession the session to ping
+	 */
+	private void ping(final SseSession sseSession) {
+		sseSession
+			.session()
+			.sendRequest(McpSchema.METHOD_PING, null, OBJECT_TYPE_REF)
+			// The timeout signal closes the SSE stream (servlet I/O): keep it off Reactor's non-blocking parallel threads
+			.timeout(pingTimeout, Schedulers.boundedElastic())
+			.subscribe(
+				result -> log.trace("Keep-alive ping answered by MCP SSE session {}", sseSession.id()),
+				error -> {
+					if (Exceptions.unwrap(error) instanceof McpError) {
+						// The client answered, even if with a JSON-RPC error (e.g. a client without a ping handler):
+						// the connection is alive, which is all the keep-alive needs to know.
+						log.debug(
+							"MCP SSE session {} answered the keep-alive ping with an error ({}); keeping the session",
+							sseSession.id(),
+							error.getMessage()
+						);
+						return;
+					}
+					closeSession(sseSession, "the keep-alive ping was not answered: " + error.getMessage());
+				}
+			);
+	}
+
+	/**
+	 * Closes the SSE stream of a session and forgets it.
+	 *
+	 * @param sseSession the session to close
+	 * @param reason     why the session is closed, for the logs
+	 */
+	private void closeSession(final SseSession sseSession, final String reason) {
+		if (sessions.remove(sseSession.id(), sseSession)) {
+			log.warn("Closing MCP SSE session {} because {}. Active sessions: {}", sseSession.id(), reason, sessions.size());
+			sseSession.transport().close();
+		}
+	}
+
+	/**
+	 * Forgets a session whose SSE stream has ended.
+	 *
+	 * @param sseSession the session
+	 * @param cause      what happened to the stream, for the logs
+	 */
+	private void forgetSession(final SseSession sseSession, final String cause) {
+		if (sessions.remove(sseSession.id(), sseSession)) {
+			log.debug("MCP SSE stream of session {} {}. Active sessions: {}", sseSession.id(), cause, sessions.size());
+		}
+	}
+
+	/**
+	 * A tracked SSE session: the SDK session, its transport, its lifecycle state and its creation time.
+	 *
+	 * @param id        the session identifier
+	 * @param session   the SDK session
+	 * @param transport the SSE transport of the session
+	 * @param state     the lifecycle state
+	 * @param createdAt when the SSE stream was opened
+	 */
+	record SseSession(
+		String id,
+		McpServerSession session,
+		WebMvcMcpSessionTransport transport,
+		AtomicReference<SessionState> state,
+		Instant createdAt
+	) {
+		SseSession(final String id, final McpServerSession session, final WebMvcMcpSessionTransport transport) {
+			this(id, session, transport, new AtomicReference<>(SessionState.CREATED), Instant.now());
+		}
+	}
+
+	/**
+	 * Implementation of McpServerTransport for WebMVC SSE sessions. This class handles the transport-level
+	 * communication for a specific client session.
+	 */
+	class WebMvcMcpSessionTransport implements McpServerTransport {
+
+		private final SseBuilder sseBuilder;
+
+		/**
+		 * Lock to ensure thread-safe access to the SSE builder when sending messages. This prevents concurrent
+		 * modifications that could lead to corrupted SSE events.
+		 */
+		private final ReentrantLock sseBuilderLock = new ReentrantLock();
+
+		/**
+		 * Set once the SSE stream has been completed by this transport; nothing must be written afterwards.
+		 */
+		private volatile boolean closed;
+
+		/**
+		 * Creates a new session transport with the specified SSE builder.
+		 *
+		 * @param sseBuilder The SSE builder for sending server events to the client
+		 */
+		WebMvcMcpSessionTransport(final SseBuilder sseBuilder) {
+			this.sseBuilder = sseBuilder;
+		}
+
+		/**
+		 * Writes the initial {@code endpoint} event, under the same lock as the messages so that a concurrent
+		 * broadcast or keep-alive ping cannot interleave with it.
+		 *
+		 * @param endpointUrl the message endpoint URL of the session
+		 * @throws IOException when the event cannot be written
+		 */
+		void sendEndpointEvent(final String endpointUrl) throws IOException {
+			sseBuilderLock.lock();
+			try {
+				sseBuilder.event(ENDPOINT_EVENT_TYPE).data(endpointUrl);
+			} finally {
+				sseBuilderLock.unlock();
+			}
+		}
+
+		/**
+		 * Sends a JSON-RPC message to the client through the SSE connection.
+		 *
+		 * @param message The JSON-RPC message to send
+		 * @return A Mono that completes when the message has been sent
+		 */
+		@Override
+		public Mono<Void> sendMessage(final JSONRPCMessage message) {
+			return Mono.fromRunnable(() -> {
+				sseBuilderLock.lock();
+				try {
+					if (closed) {
+						log.debug("Dropped an MCP message for a closed SSE stream");
+						return;
+					}
+					final String jsonText;
+					try {
+						jsonText = jsonMapper.writeValueAsString(message);
+					} catch (IOException e) {
+						log.error("Failed to serialize an MCP message for the SSE stream: {}", e.getMessage());
+						return;
+					}
+					try {
+						sseBuilder.event(MESSAGE_EVENT_TYPE).data(jsonText);
+					} catch (IOException e) {
+						// The client is gone (connection aborted): end the stream quietly so that Tomcat releases the
+						// connection, rather than failing the async request, which Tomcat logs as a SEVERE error with
+						// a full stack trace for every abrupt client disconnect.
+						log.debug("MCP SSE stream write failed ({}); completing the stream", e.getMessage());
+						close();
+					} catch (Exception e) {
+						log.error("Failed to send an MCP message over SSE: {}", e.getMessage());
+						sseBuilder.error(e);
+					}
+				} finally {
+					sseBuilderLock.unlock();
+				}
+			});
+		}
+
+		/**
+		 * Converts data from one type to another using the configured McpJsonMapper.
+		 *
+		 * @param data    The source data object to convert
+		 * @param typeRef The target type reference
+		 * @param <T>     The target type
+		 * @return The converted object of type T
+		 */
+		@Override
+		public <T> T unmarshalFrom(final Object data, final TypeRef<T> typeRef) {
+			return jsonMapper.convertValue(data, typeRef);
+		}
+
+		/**
+		 * Initiates a graceful shutdown of the transport.
+		 *
+		 * @return A Mono that completes when the shutdown is complete
+		 */
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.fromRunnable(this::close);
+		}
+
+		/**
+		 * Closes the transport immediately by completing the SSE stream.
+		 */
+		@Override
+		public void close() {
+			sseBuilderLock.lock();
+			try {
+				if (closed) {
+					return;
+				}
+				closed = true;
+				sseBuilder.complete();
+			} catch (Exception e) {
+				log.warn("Failed to complete the SSE stream: {}", e.getMessage());
+			} finally {
+				sseBuilderLock.unlock();
+			}
+		}
+	}
+
+	/**
+	 * Creates a new Builder instance for configuring and creating instances of LegacySseServerTransportProvider.
+	 *
+	 * @return A new Builder instance
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for creating instances of LegacySseServerTransportProvider.
+	 */
+	public static class Builder {
+
+		private McpJsonMapper jsonMapper;
+
+		private String baseUrl = "";
+
+		private String messageEndpoint;
+
+		private String sseEndpoint = DEFAULT_SSE_ENDPOINT;
+
+		private Duration keepAliveInterval;
+
+		private Duration messageTimeout = DEFAULT_MESSAGE_TIMEOUT;
+
+		private Duration pingTimeout = DEFAULT_PING_TIMEOUT;
+
+		private Duration initializationTimeout = DEFAULT_INITIALIZATION_TIMEOUT;
+
+		private McpTransportContextExtractor<ServerRequest> contextExtractor = serverRequest -> McpTransportContext.EMPTY;
+
+		/**
+		 * Sets the JSON mapper to use for message serialization/deserialization.
+		 *
+		 * @param jsonMapper The JSON mapper to use
+		 * @return This builder instance for method chaining
+		 */
+		public Builder jsonMapper(final McpJsonMapper jsonMapper) {
+			Assert.notNull(jsonMapper, "McpJsonMapper must not be null");
+			this.jsonMapper = jsonMapper;
+			return this;
+		}
+
+		/**
+		 * Sets the base URL advertised to clients in the endpoint event.
+		 *
+		 * @param baseUrl The base URL to use
+		 * @return This builder instance for method chaining
+		 */
+		public Builder baseUrl(final String baseUrl) {
+			Assert.notNull(baseUrl, "Base URL must not be null");
+			this.baseUrl = baseUrl;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint path where clients will send their messages.
+		 *
+		 * @param messageEndpoint The message endpoint path
+		 * @return This builder instance for method chaining
+		 */
+		public Builder messageEndpoint(final String messageEndpoint) {
+			Assert.hasText(messageEndpoint, "Message endpoint must not be empty");
+			this.messageEndpoint = messageEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the endpoint path where clients will establish SSE connections. Defaults to
+		 * {@link #DEFAULT_SSE_ENDPOINT}.
+		 *
+		 * @param sseEndpoint The SSE endpoint path
+		 * @return This builder instance for method chaining
+		 */
+		public Builder sseEndpoint(final String sseEndpoint) {
+			Assert.hasText(sseEndpoint, "SSE endpoint must not be empty");
+			this.sseEndpoint = sseEndpoint;
+			return this;
+		}
+
+		/**
+		 * Sets the interval of the keep-alive pings. Keep-alive pings are disabled when not specified.
+		 *
+		 * @param keepAliveInterval The interval duration for keep-alive pings, or {@code null} to disable them
+		 * @return This builder instance for method chaining
+		 */
+		public Builder keepAliveInterval(final Duration keepAliveInterval) {
+			this.keepAliveInterval = keepAliveInterval;
+			return this;
+		}
+
+		/**
+		 * Sets the bound applied to the handling of one JSON-RPC message. Defaults to
+		 * {@link #DEFAULT_MESSAGE_TIMEOUT}.
+		 *
+		 * @param messageTimeout the message timeout
+		 * @return This builder instance for method chaining
+		 */
+		public Builder messageTimeout(final Duration messageTimeout) {
+			Assert.notNull(messageTimeout, "Message timeout must not be null");
+			this.messageTimeout = messageTimeout;
+			return this;
+		}
+
+		/**
+		 * Sets the time granted to a client to answer a keep-alive ping before its session is closed. Defaults to
+		 * {@link #DEFAULT_PING_TIMEOUT}.
+		 *
+		 * @param pingTimeout the ping timeout
+		 * @return This builder instance for method chaining
+		 */
+		public Builder pingTimeout(final Duration pingTimeout) {
+			Assert.notNull(pingTimeout, "Ping timeout must not be null");
+			this.pingTimeout = pingTimeout;
+			return this;
+		}
+
+		/**
+		 * Sets the time granted to a client to complete the initialization handshake before its session is closed.
+		 * Defaults to {@link #DEFAULT_INITIALIZATION_TIMEOUT}.
+		 *
+		 * @param initializationTimeout the initialization timeout
+		 * @return This builder instance for method chaining
+		 */
+		public Builder initializationTimeout(final Duration initializationTimeout) {
+			Assert.notNull(initializationTimeout, "Initialization timeout must not be null");
+			this.initializationTimeout = initializationTimeout;
+			return this;
+		}
+
+		/**
+		 * Sets the context extractor that lets the MCP feature implementations inspect HTTP transport level
+		 * metadata of the request being processed.
+		 *
+		 * @param contextExtractor The contextExtractor to fill in a {@link McpTransportContext}
+		 * @return this builder instance
+		 */
+		public Builder contextExtractor(final McpTransportContextExtractor<ServerRequest> contextExtractor) {
+			Assert.notNull(contextExtractor, "contextExtractor must not be null");
+			this.contextExtractor = contextExtractor;
+			return this;
+		}
+
+		/**
+		 * Builds a new instance of LegacySseServerTransportProvider with the configured settings.
+		 *
+		 * @return A new LegacySseServerTransportProvider instance
+		 * @throws IllegalStateException if messageEndpoint is not set
+		 */
+		public LegacySseServerTransportProvider build() {
+			if (messageEndpoint == null) {
+				throw new IllegalStateException("MessageEndpoint must be set");
+			}
+			return new LegacySseServerTransportProvider(
+				jsonMapper == null ? McpJsonMapper.getDefault() : jsonMapper,
+				baseUrl,
+				messageEndpoint,
+				sseEndpoint,
+				keepAliveInterval,
+				messageTimeout,
+				pingTimeout,
+				initializationTimeout,
+				contextExtractor
+			);
+		}
+	}
+}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -451,9 +451,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		}
 
 		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
-			// The transition to INITIALIZING is recorded by dispatch() once the initialize request has been handled
-			// successfully, so that an initialized notification racing a pending or failed initialize cannot complete
-			// the handshake
+			// Recorded before the dispatch: the client receives the initialize response over the SSE stream and may
+			// post notifications/initialized before the request thread returns. A failed initialize resets the state.
+			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
 			return true;
 		}
 
@@ -561,14 +561,13 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 				.subscribe(ignored -> {}, completion::tryEmitError, completion::tryEmitEmpty);
 			completion.asMono().timeout(messageTimeout).block();
 
-			// Only a successfully handled initialize starts the handshake; a failed or timed-out one leaves the
-			// session as it was, so the client has to initialize again
-			if (message instanceof JSONRPCRequest handled && McpSchema.METHOD_INITIALIZE.equals(handled.method())) {
-				sseSession.state().compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
-			}
-
 			return ServerResponse.ok().build();
 		} catch (Exception e) {
+			// A failed or timed-out initialize must not leave the session half-initialized, even if an initialized
+			// notification slipped in meanwhile: the client has to start the handshake again.
+			if (message instanceof JSONRPCRequest failed && McpSchema.METHOD_INITIALIZE.equals(failed.method())) {
+				sseSession.state().set(SessionState.CREATED);
+			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
 				log.error(
 					"MCP message '{}' posted on SSE session {} did not complete within {}; releasing the request thread " +

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -568,7 +568,11 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			// A failed or timed-out initialize leaves the SDK session in an unknown state (its handling is not cancelled
 			// and may still complete later), so the session cannot be reused: close the stream, the client reconnects
 			// and starts the handshake again on a fresh session.
-			if (message instanceof JSONRPCRequest failed && McpSchema.METHOD_INITIALIZE.equals(failed.method())) {
+			if (
+				message instanceof JSONRPCRequest failed &&
+				McpSchema.METHOD_INITIALIZE.equals(failed.method()) &&
+				sseSession.ownsPendingHandshake(failed.id())
+			) {
 				closeSession(sseSession, "its initialize request failed or timed out (" + e.getMessage() + ")");
 			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
@@ -791,8 +795,20 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		 * @param initializeRequestId the JSON-RPC id of the initialize request
 		 */
 		void onInitializeRequest(final Object initializeRequestId) {
-			pendingInitializeId.set(initializeRequestId);
-			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+			// Only the attempt that starts the handshake owns it: a duplicate initialize on an initialized session is
+			// left to the SDK and cannot alter the state, whatever its outcome
+			if (state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING)) {
+				pendingInitializeId.set(initializeRequestId);
+			}
+		}
+
+		/**
+		 * @param initializeRequestId the JSON-RPC id of an initialize request
+		 * @return whether that request is the one that started the pending handshake
+		 */
+		boolean ownsPendingHandshake(final Object initializeRequestId) {
+			final Object pending = pendingInitializeId.get();
+			return pending != null && pending.equals(initializeRequestId);
 		}
 
 		/**
@@ -806,7 +822,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			if (initializeRequestId != null && initializeRequestId.equals(response.id())) {
 				pendingInitializeId.compareAndSet(initializeRequestId, null);
 				if (response.error() != null) {
-					state.set(SessionState.CREATED);
+					state.compareAndSet(SessionState.INITIALIZING, SessionState.CREATED);
 				}
 			}
 		}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -451,7 +451,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		}
 
 		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
-			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+			// The transition to INITIALIZING is recorded by dispatch() once the initialize request has been handled
+			// successfully, so that an initialized notification racing a pending or failed initialize cannot complete
+			// the handshake
 			return true;
 		}
 
@@ -559,15 +561,14 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 				.subscribe(ignored -> {}, completion::tryEmitError, completion::tryEmitEmpty);
 			completion.asMono().timeout(messageTimeout).block();
 
+			// Only a successfully handled initialize starts the handshake; a failed or timed-out one leaves the
+			// session as it was, so the client has to initialize again
+			if (message instanceof JSONRPCRequest handled && McpSchema.METHOD_INITIALIZE.equals(handled.method())) {
+				sseSession.state().compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+			}
+
 			return ServerResponse.ok().build();
 		} catch (Exception e) {
-			// A failed or timed-out initialize must not leave the session half-initialized: the client has to start
-			// the handshake again, and an initialized notification alone cannot complete it.
-			if (
-				message instanceof JSONRPCRequest failedRequest && McpSchema.METHOD_INITIALIZE.equals(failedRequest.method())
-			) {
-				sseSession.state().compareAndSet(SessionState.INITIALIZING, SessionState.CREATED);
-			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
 				log.error(
 					"MCP message '{}' posted on SSE session {} did not complete within {}; releasing the request thread " +

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -139,6 +139,24 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 	private static final TypeRef<Object> OBJECT_TYPE_REF = new TypeRef<>() {};
 
 	/**
+	 * What an {@code initialize} request may do with the handshake of its session.
+	 */
+	enum HandshakeClaim {
+		/**
+		 * The request started the handshake and owns its outcome.
+		 */
+		CLAIMED,
+		/**
+		 * Another initialize owns a handshake whose outcome is not settled yet; the request is refused.
+		 */
+		PENDING,
+		/**
+		 * No handshake is pending; the request is left to the SDK session and cannot alter the lifecycle state.
+		 */
+		SETTLED
+	}
+
+	/**
 	 * MCP lifecycle state of a session, as observed from the messages posted by the client.
 	 */
 	public enum SessionState {
@@ -421,10 +439,10 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		if (
 			message instanceof JSONRPCRequest initializeRequest &&
 			McpSchema.METHOD_INITIALIZE.equals(initializeRequest.method()) &&
-			sseSession.claimHandshake(initializeRequest.id()) == SessionState.INITIALIZING
+			sseSession.claimHandshake(initializeRequest.id()) == HandshakeClaim.PENDING
 		) {
-			// A single handshake at a time: the initialize that lost the atomic claim would race the owning one for the
-			// SDK session and make the outcome of the owning request meaningless
+			// A single handshake at a time: the initialize that lost the claim would race the owning one for the SDK
+			// session and make the outcome of the owning request meaningless
 			log.warn(
 				"Rejected a second MCP initialize request posted on SSE session {} from {} while its handshake is pending",
 				sseSession.id(),
@@ -826,19 +844,19 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		 * settled by {@link #onResponseSent}.
 		 *
 		 * @param initializeRequestId the JSON-RPC id of the initialize request
-		 * @return {@code CREATED} when the request claimed the handshake, {@code INITIALIZING} when another initialize
-		 *         is pending, {@code INITIALIZED} when the session is already initialized
+		 * @return what the request may do, see {@link HandshakeClaim}
 		 */
-		SessionState claimHandshake(final Object initializeRequestId) {
-			// Only the attempt that wins the CREATED -> INITIALIZING transition owns the handshake. A concurrent
-			// initialize observes INITIALIZING and is refused; a duplicate initialize on an initialized session is left
-			// to the SDK and cannot alter the state, whatever its outcome. The witness value of the atomic operation is
-			// returned rather than a fresh read, which could report a state the losing attempt never observed.
-			final SessionState witnessed = state.compareAndExchange(SessionState.CREATED, SessionState.INITIALIZING);
-			if (witnessed == SessionState.CREATED) {
+		HandshakeClaim claimHandshake(final Object initializeRequestId) {
+			// Only the attempt that wins the CREATED -> INITIALIZING transition owns the handshake; the outcome of the
+			// atomic operation is used rather than a fresh read, which could report a state the loser never observed.
+			if (state.compareAndExchange(SessionState.CREATED, SessionState.INITIALIZING) == SessionState.CREATED) {
 				pendingInitializeId.set(initializeRequestId);
+				return HandshakeClaim.CLAIMED;
 			}
-			return witnessed;
+			// Another initialize owns the handshake until its response has been observed, even if an early initialized
+			// notification already moved the state on: a concurrent attempt is refused rather than racing it in the
+			// SDK. Once the handshake is settled, a duplicate initialize is left to the SDK and cannot alter the state.
+			return pendingInitializeId.get() != null ? HandshakeClaim.PENDING : HandshakeClaim.SETTLED;
 		}
 
 		/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -561,6 +561,13 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 
 			return ServerResponse.ok().build();
 		} catch (Exception e) {
+			// A failed or timed-out initialize must not leave the session half-initialized: the client has to start
+			// the handshake again, and an initialized notification alone cannot complete it.
+			if (
+				message instanceof JSONRPCRequest failedRequest && McpSchema.METHOD_INITIALIZE.equals(failedRequest.method())
+			) {
+				sseSession.state().compareAndSet(SessionState.INITIALIZING, SessionState.CREATED);
+			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
 				log.error(
 					"MCP message '{}' posted on SSE session {} did not complete within {}; releasing the request thread " +

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -275,7 +274,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 
 		return Flux.fromIterable(sessions.values())
 			// The server must not send anything but pings and logging to a client that has not completed the handshake
-			.filter(sseSession -> sseSession.state().get() == SessionState.INITIALIZED)
+			.filter(sseSession -> sseSession.state() == SessionState.INITIALIZED)
 			.flatMap(sseSession ->
 				sseSession
 					.session()
@@ -340,7 +339,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 	 */
 	public Optional<SessionState> sessionState(final String sessionId) {
 		final SseSession sseSession = sessions.get(sessionId);
-		return sseSession == null ? Optional.empty() : Optional.of(sseSession.state().get());
+		return sseSession == null ? Optional.empty() : Optional.of(sseSession.state());
 	}
 
 	/**
@@ -474,7 +473,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 					"Dropped MCP notification '{}' posted on uninitialized SSE session {} (state {})",
 					notification.method(),
 					sseSession.id(),
-					sseSession.state().get()
+					sseSession.state()
 				);
 				return ServerResponse.accepted().build();
 			}
@@ -494,8 +493,6 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 	 *         initialized and the message is neither part of the handshake nor a response
 	 */
 	private static boolean trackLifecycle(final SseSession sseSession, final JSONRPCMessage message) {
-		final AtomicReference<SessionState> state = sseSession.state();
-
 		// Responses to server-initiated requests (pings, sampling...) never wait on the initialization.
 		if (message instanceof JSONRPCResponse) {
 			return true;
@@ -519,7 +516,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			return sseSession.onInitializedNotification();
 		}
 
-		return state.get() == SessionState.INITIALIZED;
+		return sseSession.state() == SessionState.INITIALIZED;
 	}
 
 	/**
@@ -561,7 +558,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 				"'notifications/initialized' first).",
 			method,
 			sseSession.id(),
-			sseSession.state().get(),
+			sseSession.state(),
 			describeRemote(request)
 		);
 
@@ -747,15 +744,14 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 	 */
 	private void maintain(final SseSession sseSession, final Instant now) {
 		if (
-			sseSession.state().get() != SessionState.INITIALIZED &&
-			sseSession.createdAt().plus(initializationTimeout).isBefore(now)
+			sseSession.state() != SessionState.INITIALIZED && sseSession.createdAt().plus(initializationTimeout).isBefore(now)
 		) {
 			closeSession(
 				sseSession,
 				String.format(
 					"the client did not complete the MCP initialization handshake within %s (state %s)",
 					initializationTimeout,
-					sseSession.state().get()
+					sseSession.state()
 				)
 			);
 		} else if (keepAliveEnabled) {
@@ -819,54 +815,113 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 	}
 
 	/**
-	 * A tracked SSE session: the SDK session, its transport, its lifecycle state and its creation time.
-	 *
-	 * @param id        the session identifier
-	 * @param session   the SDK session
-	 * @param transport the SSE transport of the session
-	 * @param state     the lifecycle state
-	 * @param createdAt when the SSE stream was opened
+	 * A tracked SSE session: the SDK session, its transport, its creation time and the MCP lifecycle state observed
+	 * from the messages exchanged with the client. The lifecycle transitions are serialized, so that the state and the
+	 * ownership of the pending handshake are always published together.
 	 */
-	record SseSession(
-		String id,
-		McpServerSession session,
-		WebMvcMcpSessionTransport transport,
-		AtomicReference<SessionState> state,
-		AtomicReference<Object> pendingInitializeId,
-		Instant createdAt
-	) {
+	static final class SseSession {
+
+		private final String id;
+		private final McpServerSession session;
+		private final WebMvcMcpSessionTransport transport;
+		private final Instant createdAt;
+
+		/**
+		 * The lifecycle transitions read and write several fields together, so they are serialized rather than
+		 * composed of separate atomic operations: they are short and never perform I/O.
+		 */
+		private final ReentrantLock lifecycleLock = new ReentrantLock();
+
+		private SessionState state = SessionState.CREATED;
+
+		/**
+		 * The id of the initialize request that owns the handshake, until its response is written to the client.
+		 */
+		private Object pendingInitializeId;
+
+		/**
+		 * Whether the client has been told that its initialize succeeded; only then can the handshake be completed.
+		 */
+		private boolean initializeAnswered;
+
 		SseSession(final String id, final McpServerSession session, final WebMvcMcpSessionTransport transport) {
-			this(id, session, transport, new AtomicReference<>(SessionState.CREATED), new AtomicReference<>(), Instant.now());
+			this.id = id;
+			this.session = session;
+			this.transport = transport;
+			this.createdAt = Instant.now();
+		}
+
+		String id() {
+			return id;
+		}
+
+		McpServerSession session() {
+			return session;
+		}
+
+		WebMvcMcpSessionTransport transport() {
+			return transport;
+		}
+
+		Instant createdAt() {
+			return createdAt;
 		}
 
 		/**
-		 * Atomically claims the handshake for the given initialize request; the outcome of a claimed handshake is
-		 * settled by {@link #onResponseSent}.
+		 * @return the lifecycle state of the session
+		 */
+		SessionState state() {
+			lifecycleLock.lock();
+			try {
+				return state;
+			} finally {
+				lifecycleLock.unlock();
+			}
+		}
+
+		/**
+		 * Claims the handshake for the given initialize request; the outcome of a claimed handshake is settled by
+		 * {@link #onResponseSent}.
 		 *
 		 * @param initializeRequestId the JSON-RPC id of the initialize request
 		 * @return what the request may do, see {@link HandshakeClaim}
 		 */
 		HandshakeClaim claimHandshake(final Object initializeRequestId) {
-			// Only the attempt that wins the CREATED -> INITIALIZING transition owns the handshake; the outcome of the
-			// atomic operation is used rather than a fresh read, which could report a state the loser never observed.
-			if (state.compareAndExchange(SessionState.CREATED, SessionState.INITIALIZING) == SessionState.CREATED) {
-				pendingInitializeId.set(initializeRequestId);
-				return HandshakeClaim.CLAIMED;
+			lifecycleLock.lock();
+			try {
+				if (state == SessionState.CREATED) {
+					state = SessionState.INITIALIZING;
+					pendingInitializeId = initializeRequestId;
+					initializeAnswered = false;
+					return HandshakeClaim.CLAIMED;
+				}
+				// Another initialize owns the handshake until its response has been written: a concurrent attempt is
+				// refused rather than racing it in the SDK. Once the handshake is settled, a duplicate initialize is
+				// left to the SDK and cannot alter the state.
+				return pendingInitializeId != null ? HandshakeClaim.PENDING : HandshakeClaim.SETTLED;
+			} finally {
+				lifecycleLock.unlock();
 			}
-			// Another initialize owns the handshake until its response has been observed, even if an early initialized
-			// notification already moved the state on: a concurrent attempt is refused rather than racing it in the
-			// SDK. Once the handshake is settled, a duplicate initialize is left to the SDK and cannot alter the state.
-			return pendingInitializeId.get() != null ? HandshakeClaim.PENDING : HandshakeClaim.SETTLED;
 		}
 
 		/**
-		 * Completes the handshake if one is in progress. The pending initialize stays tracked until its response is
-		 * observed: a notification posted before an error response must not leave the session initialized.
+		 * Completes the handshake when the client has been told that its initialize succeeded. A notification posted
+		 * before that (no handshake, or one whose response is still being computed) is dropped, so that the SDK session
+		 * is never exposed as initialized while its initialization exchange may not exist.
 		 *
-		 * @return whether the notification completed a pending handshake (a notification that did not is dropped)
+		 * @return whether the notification completed a pending handshake
 		 */
 		boolean onInitializedNotification() {
-			return state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
+			lifecycleLock.lock();
+			try {
+				if (state == SessionState.INITIALIZING && initializeAnswered) {
+					state = SessionState.INITIALIZED;
+					return true;
+				}
+				return false;
+			} finally {
+				lifecycleLock.unlock();
+			}
 		}
 
 		/**
@@ -874,25 +929,35 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		 * @return whether that request is the one that started the pending handshake
 		 */
 		boolean ownsPendingHandshake(final Object initializeRequestId) {
-			final Object pending = pendingInitializeId.get();
-			return pending != null && pending.equals(initializeRequestId);
+			lifecycleLock.lock();
+			try {
+				return pendingInitializeId != null && pendingInitializeId.equals(initializeRequestId);
+			} finally {
+				lifecycleLock.unlock();
+			}
 		}
 
 		/**
-		 * Records the outcome of the handshake from the response the SDK session writes to the client: an initialize
-		 * request rejected at the JSON-RPC level (error response) has not started a handshake.
+		 * Records the outcome of the handshake from the response the SDK session writes to the client: a successful
+		 * response lets the client complete the handshake, an error response means no handshake ever started.
 		 *
 		 * @param response the JSON-RPC response about to be written to the SSE stream
 		 */
 		void onResponseSent(final JSONRPCResponse response) {
-			final Object initializeRequestId = pendingInitializeId.get();
-			if (initializeRequestId != null && initializeRequestId.equals(response.id())) {
-				pendingInitializeId.compareAndSet(initializeRequestId, null);
-				if (response.error() != null) {
-					// Unconditional on purpose: only the request that started the handshake gets here, and an early
-					// initialized notification may already have moved the state on; the rejected handshake wins
-					state.set(SessionState.CREATED);
+			lifecycleLock.lock();
+			try {
+				if (pendingInitializeId == null || !pendingInitializeId.equals(response.id())) {
+					return;
 				}
+				pendingInitializeId = null;
+				if (response.error() != null) {
+					state = SessionState.CREATED;
+					initializeAnswered = false;
+				} else {
+					initializeAnswered = true;
+				}
+			} finally {
+				lifecycleLock.unlock();
 			}
 		}
 	}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -349,6 +349,11 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 				sseBuilder.onTimeout(() -> forgetSession(sseSession, "timed out"));
 				sseBuilder.onError(e -> forgetSession(sseSession, "failed: " + e.getMessage()));
 				this.sessions.put(sessionId, sseSession);
+				if (this.isClosing) {
+					// The shutdown started between the check above and the registration: do not leave a stream open
+					closeSession(sseSession, "the server is shutting down");
+					return;
+				}
 				log.debug(
 					"Opened MCP SSE session {} from {}. Active sessions: {}",
 					sessionId,
@@ -465,7 +470,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		) {
 			// Only a handshake that actually started can complete: an initialized notification on a fresh session (or
 			// after a rejected initialize) leaves the session uninitialized so that later requests keep being refused
-			state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
+			sseSession.onInitializedNotification();
 			return true;
 		}
 
@@ -803,6 +808,14 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		}
 
 		/**
+		 * Completes the handshake if one is in progress. The pending initialize stays tracked until its response is
+		 * observed: a notification posted before an error response must not leave the session initialized.
+		 */
+		void onInitializedNotification() {
+			state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
+		}
+
+		/**
 		 * @param initializeRequestId the JSON-RPC id of an initialize request
 		 * @return whether that request is the one that started the pending handshake
 		 */
@@ -822,7 +835,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			if (initializeRequestId != null && initializeRequestId.equals(response.id())) {
 				pendingInitializeId.compareAndSet(initializeRequestId, null);
 				if (response.error() != null) {
-					state.compareAndSet(SessionState.INITIALIZING, SessionState.CREATED);
+					// Unconditional on purpose: only the request that started the handshake gets here, and an early
+					// initialized notification may already have moved the state on; the rejected handshake wins
+					state.set(SessionState.CREATED);
 				}
 			}
 		}

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -418,6 +418,33 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			return ServerResponse.badRequest().body(new McpError("Invalid message format"));
 		}
 
+		if (
+			message instanceof JSONRPCRequest initializeRequest &&
+			McpSchema.METHOD_INITIALIZE.equals(initializeRequest.method()) &&
+			sseSession.state().get() == SessionState.INITIALIZING
+		) {
+			// A single handshake at a time: a second initialize while one is pending would race the first one for the
+			// SDK session and make the outcome of the owning request meaningless
+			log.warn(
+				"Rejected a second MCP initialize request posted on SSE session {} from {} while its handshake is pending",
+				sseSession.id(),
+				describeRemote(request)
+			);
+			return jsonResponse(
+				HttpStatus.CONFLICT,
+				new JSONRPCResponse(
+					McpSchema.JSONRPC_VERSION,
+					initializeRequest.id(),
+					null,
+					new JSONRPCResponse.JSONRPCError(
+						McpSchema.ErrorCodes.INVALID_REQUEST,
+						String.format("MCP session %s already has an initialize request in progress", sseSession.id()),
+						null
+					)
+				)
+			);
+		}
+
 		if (!trackLifecycle(sseSession, message)) {
 			if (message instanceof JSONRPCRequest pingRequest && McpSchema.METHOD_PING.equals(pingRequest.method())) {
 				return answerPing(sseSession, pingRequest);

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -832,12 +832,13 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		SessionState claimHandshake(final Object initializeRequestId) {
 			// Only the attempt that wins the CREATED -> INITIALIZING transition owns the handshake. A concurrent
 			// initialize observes INITIALIZING and is refused; a duplicate initialize on an initialized session is left
-			// to the SDK and cannot alter the state, whatever its outcome.
-			if (state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING)) {
+			// to the SDK and cannot alter the state, whatever its outcome. The witness value of the atomic operation is
+			// returned rather than a fresh read, which could report a state the losing attempt never observed.
+			final SessionState witnessed = state.compareAndExchange(SessionState.CREATED, SessionState.INITIALIZING);
+			if (witnessed == SessionState.CREATED) {
 				pendingInitializeId.set(initializeRequestId);
-				return SessionState.CREATED;
 			}
-			return state.get();
+			return witnessed;
 		}
 
 		/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -453,8 +453,8 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 
 		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
 			// Recorded before the dispatch: the client receives the initialize response over the SSE stream and may
-			// post notifications/initialized before the request thread returns. A rejected, failed or timed-out
-			// initialize resets the state (see SseSession.onResponseSent / onInitializeFailed).
+			// post notifications/initialized before the request thread returns. A rejected initialize resets the
+			// state (see SseSession.onResponseSent); a failed or timed-out one closes the session (see dispatch).
 			sseSession.onInitializeRequest(request.id());
 			return true;
 		}
@@ -565,10 +565,11 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 
 			return ServerResponse.ok().build();
 		} catch (Exception e) {
-			// A failed or timed-out initialize must not leave the session half-initialized, even if an initialized
-			// notification slipped in meanwhile: the client has to start the handshake again.
+			// A failed or timed-out initialize leaves the SDK session in an unknown state (its handling is not cancelled
+			// and may still complete later), so the session cannot be reused: close the stream, the client reconnects
+			// and starts the handshake again on a fresh session.
 			if (message instanceof JSONRPCRequest failed && McpSchema.METHOD_INITIALIZE.equals(failed.method())) {
-				sseSession.onInitializeFailed();
+				closeSession(sseSession, "its initialize request failed or timed out (" + e.getMessage() + ")");
 			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
 				log.error(
@@ -808,14 +809,6 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 					state.set(SessionState.CREATED);
 				}
 			}
-		}
-
-		/**
-		 * Resets the handshake after an initialize request that failed or timed out.
-		 */
-		void onInitializeFailed() {
-			pendingInitializeId.set(null);
-			state.set(SessionState.CREATED);
 		}
 	}
 

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -343,6 +343,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 				final McpServerSession session = sessionFactory.create(sessionTransport);
 				final String sessionId = session.getId();
 				final SseSession sseSession = new SseSession(sessionId, session, sessionTransport);
+				sessionTransport.attach(sseSession);
 
 				sseBuilder.onComplete(() -> forgetSession(sseSession, "completed"));
 				sseBuilder.onTimeout(() -> forgetSession(sseSession, "timed out"));
@@ -452,8 +453,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 
 		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
 			// Recorded before the dispatch: the client receives the initialize response over the SSE stream and may
-			// post notifications/initialized before the request thread returns. A failed initialize resets the state.
-			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+			// post notifications/initialized before the request thread returns. A rejected, failed or timed-out
+			// initialize resets the state (see SseSession.onResponseSent / onInitializeFailed).
+			sseSession.onInitializeRequest(request.id());
 			return true;
 		}
 
@@ -566,7 +568,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			// A failed or timed-out initialize must not leave the session half-initialized, even if an initialized
 			// notification slipped in meanwhile: the client has to start the handshake again.
 			if (message instanceof JSONRPCRequest failed && McpSchema.METHOD_INITIALIZE.equals(failed.method())) {
-				sseSession.state().set(SessionState.CREATED);
+				sseSession.onInitializeFailed();
 			}
 			if (Exceptions.unwrap(e) instanceof TimeoutException) {
 				log.error(
@@ -775,10 +777,45 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		McpServerSession session,
 		WebMvcMcpSessionTransport transport,
 		AtomicReference<SessionState> state,
+		AtomicReference<Object> pendingInitializeId,
 		Instant createdAt
 	) {
 		SseSession(final String id, final McpServerSession session, final WebMvcMcpSessionTransport transport) {
-			this(id, session, transport, new AtomicReference<>(SessionState.CREATED), Instant.now());
+			this(id, session, transport, new AtomicReference<>(SessionState.CREATED), new AtomicReference<>(), Instant.now());
+		}
+
+		/**
+		 * Starts the handshake for the given initialize request: the outcome is settled by {@link #onResponseSent}.
+		 *
+		 * @param initializeRequestId the JSON-RPC id of the initialize request
+		 */
+		void onInitializeRequest(final Object initializeRequestId) {
+			pendingInitializeId.set(initializeRequestId);
+			state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING);
+		}
+
+		/**
+		 * Records the outcome of the handshake from the response the SDK session writes to the client: an initialize
+		 * request rejected at the JSON-RPC level (error response) has not started a handshake.
+		 *
+		 * @param response the JSON-RPC response about to be written to the SSE stream
+		 */
+		void onResponseSent(final JSONRPCResponse response) {
+			final Object initializeRequestId = pendingInitializeId.get();
+			if (initializeRequestId != null && initializeRequestId.equals(response.id())) {
+				pendingInitializeId.compareAndSet(initializeRequestId, null);
+				if (response.error() != null) {
+					state.set(SessionState.CREATED);
+				}
+			}
+		}
+
+		/**
+		 * Resets the handshake after an initialize request that failed or timed out.
+		 */
+		void onInitializeFailed() {
+			pendingInitializeId.set(null);
+			state.set(SessionState.CREATED);
 		}
 	}
 
@@ -800,6 +837,20 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		 * Set once the SSE stream has been completed by this transport; nothing must be written afterwards.
 		 */
 		private volatile boolean closed;
+
+		/**
+		 * The tracked session this transport belongs to, informed of the responses written to the client.
+		 */
+		private volatile SseSession sseSession;
+
+		/**
+		 * Attaches the tracked session once it exists (the SDK session is created with the transport).
+		 *
+		 * @param owner the tracked session
+		 */
+		void attach(final SseSession owner) {
+			this.sseSession = owner;
+		}
 
 		/**
 		 * Creates a new session transport with the specified SSE builder.
@@ -847,6 +898,10 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 					} catch (IOException e) {
 						log.error("Failed to serialize an MCP message for the SSE stream: {}", e.getMessage());
 						return;
+					}
+					final SseSession owner = sseSession;
+					if (owner != null && message instanceof JSONRPCResponse response) {
+						owner.onResponseSent(response);
 					}
 					try {
 						sseBuilder.event(MESSAGE_EVENT_TYPE).data(jsonText);

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -531,7 +531,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		log.debug("Answering a pre-initialization ping on MCP SSE session {}", sseSession.id());
 		sseSession
 			.transport()
-			.sendMessage(new JSONRPCResponse(McpSchema.JSONRPC_VERSION, pingRequest.id(), Map.of(), null))
+			.sendTransportMessage(new JSONRPCResponse(McpSchema.JSONRPC_VERSION, pingRequest.id(), Map.of(), null))
 			.block();
 		return ServerResponse.ok().build();
 	}
@@ -1028,6 +1028,29 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		 */
 		@Override
 		public Mono<Void> sendMessage(final JSONRPCMessage message) {
+			return send(message, true);
+		}
+
+		/**
+		 * Sends a message the transport itself produced, such as the answer to a pre-initialization ping. It is not
+		 * part of the exchange handled by the SDK session, so it never settles the handshake, even when the client
+		 * reused the id of its pending initialize request.
+		 *
+		 * @param message The JSON-RPC message to send
+		 * @return A Mono that completes when the message has been sent
+		 */
+		Mono<Void> sendTransportMessage(final JSONRPCMessage message) {
+			return send(message, false);
+		}
+
+		/**
+		 * Writes a JSON-RPC message to the SSE stream.
+		 *
+		 * @param message     The JSON-RPC message to send
+		 * @param fromSession Whether the message comes from the SDK session, and may therefore settle the handshake
+		 * @return A Mono that completes when the message has been sent
+		 */
+		private Mono<Void> send(final JSONRPCMessage message, final boolean fromSession) {
 			return Mono.fromRunnable(() -> {
 				sseBuilderLock.lock();
 				try {
@@ -1043,7 +1066,7 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 						return;
 					}
 					final SseSession owner = sseSession;
-					if (owner != null && message instanceof JSONRPCResponse response) {
+					if (fromSession && owner != null && message instanceof JSONRPCResponse response) {
 						owner.onResponseSent(response);
 					}
 					try {

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -459,7 +459,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			message instanceof JSONRPCNotification notification &&
 			McpSchema.METHOD_NOTIFICATION_INITIALIZED.equals(notification.method())
 		) {
-			state.set(SessionState.INITIALIZED);
+			// Only a handshake that actually started can complete: an initialized notification on a fresh session (or
+			// after a rejected initialize) leaves the session uninitialized so that later requests keep being refused
+			state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
 			return true;
 		}
 

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProvider.java
@@ -421,9 +421,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		if (
 			message instanceof JSONRPCRequest initializeRequest &&
 			McpSchema.METHOD_INITIALIZE.equals(initializeRequest.method()) &&
-			sseSession.state().get() == SessionState.INITIALIZING
+			sseSession.claimHandshake(initializeRequest.id()) == SessionState.INITIALIZING
 		) {
-			// A single handshake at a time: a second initialize while one is pending would race the first one for the
+			// A single handshake at a time: the initialize that lost the atomic claim would race the owning one for the
 			// SDK session and make the outcome of the owning request meaningless
 			log.warn(
 				"Rejected a second MCP initialize request posted on SSE session {} from {} while its handshake is pending",
@@ -484,10 +484,10 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		}
 
 		if (message instanceof JSONRPCRequest request && McpSchema.METHOD_INITIALIZE.equals(request.method())) {
-			// Recorded before the dispatch: the client receives the initialize response over the SSE stream and may
-			// post notifications/initialized before the request thread returns. A rejected initialize resets the
-			// state (see SseSession.onResponseSent); a failed or timed-out one closes the session (see dispatch).
-			sseSession.onInitializeRequest(request.id());
+			// The handshake was claimed atomically in handleMessage (see SseSession.claimHandshake) before the
+			// dispatch: the client receives the initialize response over the SSE stream and may post
+			// notifications/initialized before the request thread returns. A rejected initialize resets the state
+			// (see SseSession.onResponseSent); a failed or timed-out one closes the session (see dispatch).
 			return true;
 		}
 
@@ -496,9 +496,9 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 			McpSchema.METHOD_NOTIFICATION_INITIALIZED.equals(notification.method())
 		) {
 			// Only a handshake that actually started can complete: an initialized notification on a fresh session (or
-			// after a rejected initialize) leaves the session uninitialized so that later requests keep being refused
-			sseSession.onInitializedNotification();
-			return true;
+			// after a rejected initialize) is dropped, so that the SDK session is never marked initialized without a
+			// successful initialize and later requests keep being refused
+			return sseSession.onInitializedNotification();
 		}
 
 		return state.get() == SessionState.INITIALIZED;
@@ -822,24 +822,32 @@ public class LegacySseServerTransportProvider implements McpServerTransportProvi
 		}
 
 		/**
-		 * Starts the handshake for the given initialize request: the outcome is settled by {@link #onResponseSent}.
+		 * Atomically claims the handshake for the given initialize request; the outcome of a claimed handshake is
+		 * settled by {@link #onResponseSent}.
 		 *
 		 * @param initializeRequestId the JSON-RPC id of the initialize request
+		 * @return {@code CREATED} when the request claimed the handshake, {@code INITIALIZING} when another initialize
+		 *         is pending, {@code INITIALIZED} when the session is already initialized
 		 */
-		void onInitializeRequest(final Object initializeRequestId) {
-			// Only the attempt that starts the handshake owns it: a duplicate initialize on an initialized session is
-			// left to the SDK and cannot alter the state, whatever its outcome
+		SessionState claimHandshake(final Object initializeRequestId) {
+			// Only the attempt that wins the CREATED -> INITIALIZING transition owns the handshake. A concurrent
+			// initialize observes INITIALIZING and is refused; a duplicate initialize on an initialized session is left
+			// to the SDK and cannot alter the state, whatever its outcome.
 			if (state.compareAndSet(SessionState.CREATED, SessionState.INITIALIZING)) {
 				pendingInitializeId.set(initializeRequestId);
+				return SessionState.CREATED;
 			}
+			return state.get();
 		}
 
 		/**
 		 * Completes the handshake if one is in progress. The pending initialize stays tracked until its response is
 		 * observed: a notification posted before an error response must not leave the session initialized.
+		 *
+		 * @return whether the notification completed a pending handshake (a notification that did not is dropped)
 		 */
-		void onInitializedNotification() {
-			state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
+		boolean onInitializedNotification() {
+			return state.compareAndSet(SessionState.INITIALIZING, SessionState.INITIALIZED);
 		}
 
 		/**

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/McpSseProperties.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/McpSseProperties.java
@@ -47,9 +47,9 @@ public class McpSseProperties {
 	public static final String PREFIX = "mcp.sse";
 
 	/**
-	 * Whether the legacy SSE transport is served. When the MCP protocol is {@code STREAMABLE}, the legacy transport is
-	 * served alongside the Streamable HTTP transport; when the protocol is {@code SSE}, the hardened transport replaces
-	 * the SDK one.
+	 * Whether the legacy SSE transport is served alongside the Streamable HTTP transport when the MCP protocol is
+	 * {@code STREAMABLE}. Ignored when the protocol is {@code SSE}: the hardened transport then always replaces the
+	 * SDK one, since it is the only MCP transport.
 	 */
 	private boolean enabled = true;
 

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/McpSseProperties.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/transport/McpSseProperties.java
@@ -1,0 +1,75 @@
+package org.metricshub.web.mcp.transport;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * MetricsHub Agent
+ * ჻჻჻჻჻჻
+ * Copyright 2023 - 2026 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.time.Duration;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Settings of the legacy MCP "HTTP with SSE" transport served by {@link LegacySseServerTransportProvider}.
+ * <p>
+ * The endpoints ({@code spring.ai.mcp.server.sse-endpoint}, {@code spring.ai.mcp.server.sse-message-endpoint}), the
+ * advertised base URL and the keep-alive interval ({@code spring.ai.mcp.server.keep-alive-interval}) keep their Spring
+ * AI keys. The keys below only cover the MetricsHub hardening of the transport.
+ * </p>
+ */
+@ConfigurationProperties(prefix = McpSseProperties.PREFIX)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class McpSseProperties {
+
+	/**
+	 * Prefix of the properties.
+	 */
+	public static final String PREFIX = "mcp.sse";
+
+	/**
+	 * Whether the legacy SSE transport is served. When the MCP protocol is {@code STREAMABLE}, the legacy transport is
+	 * served alongside the Streamable HTTP transport; when the protocol is {@code SSE}, the hardened transport replaces
+	 * the SDK one.
+	 */
+	private boolean enabled = true;
+
+	/**
+	 * Maximum time a request thread waits for the handling of one JSON-RPC message posted on the message endpoint. A
+	 * message whose handling has not completed in time is answered with HTTP 504; the handling itself is not cancelled
+	 * (a synchronous tool execution is never interrupted and a late result is still delivered on the SSE stream).
+	 */
+	private Duration messageTimeout = LegacySseServerTransportProvider.DEFAULT_MESSAGE_TIMEOUT;
+
+	/**
+	 * Time granted to a client to answer a keep-alive ping (an error answer counts as an answer). A session whose ping
+	 * cannot be delivered or is not answered in time is closed, which releases its connection. Keep it generous enough
+	 * to survive a suspended client. Pings are sent every {@code spring.ai.mcp.server.keep-alive-interval}.
+	 */
+	private Duration pingTimeout = LegacySseServerTransportProvider.DEFAULT_PING_TIMEOUT;
+
+	/**
+	 * Time granted to a client to complete the {@code initialize} / {@code notifications/initialized} handshake after
+	 * opening its SSE stream. Sessions that are still not initialized after this delay are closed.
+	 */
+	private Duration initializationTimeout = LegacySseServerTransportProvider.DEFAULT_INITIALIZATION_TIMEOUT;
+}

--- a/metricshub-agent/src/main/resources/application.yaml
+++ b/metricshub-agent/src/main/resources/application.yaml
@@ -14,14 +14,22 @@ web:
   spring.ai.mcp.server.resource-change-notification: true
   spring.ai.mcp.server.tool-change-notification: true
   spring.ai.mcp.server.prompt-change-notification: true
+  spring.ai.mcp.server.protocol: STREAMABLE
+  spring.ai.mcp.server.streamable-http.mcp-endpoint: /mcp
+  spring.ai.mcp.server.streamable-http.keep-alive-interval: 30s
   spring.ai.mcp.server.sse-endpoint: /sse
   spring.ai.mcp.server.sse-message-endpoint: /mcp/message
+  spring.ai.mcp.server.keep-alive-interval: 30s
   spring.ai.mcp.server.type: sync
   spring.ai.mcp.server.capabilities.completion: true
   spring.ai.mcp.server.capabilities.prompt: true
   spring.ai.mcp.server.capabilities.resource: true
   spring.ai.mcp.server.capabilities.tool: true
   spring.ai.mcp.server.request-timeout: 5m
+  mcp.sse.enabled: true
+  mcp.sse.message-timeout: 5m
+  mcp.sse.ping-timeout: 5m
+  mcp.sse.initialization-timeout: 2m
   jwt.short_expire: 3600
   jwt.long_expire: 86400
   jwt.secret: eyJhbGciOiJIUzI1NiJ9.ew0KICAic3ViIjogInNlbnRyeSIsDQogICJuYW1lIjogIlNlbnRyeSBTb2Z3YXJlIiwNCiAgImlhdCI6IDE1MTYyMzkwMjINCn0.UUUxmysmx49zKKRt8_pQln-WqXjaTVQlwgjg3SbidF4

--- a/metricshub-agent/src/test/java/org/metricshub/web/config/SecurityConfigTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/config/SecurityConfigTest.java
@@ -1,5 +1,6 @@
 package org.metricshub.web.config;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -13,6 +14,7 @@ import org.metricshub.web.security.ReadOnlyAccessFilter;
 import org.metricshub.web.security.jwt.JwtComponent;
 import org.metricshub.web.service.UserService;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.mock.env.MockEnvironment;
 
 class SecurityConfigTest {
 
@@ -109,6 +111,27 @@ class SecurityConfigTest {
 			IllegalStateException.class,
 			() -> tlsWebServerCustomizer.customize(factory),
 			"Missing keystore password should throw"
+		);
+	}
+
+	@Test
+	void testSecuredPathsShouldCoverTheApiAndTheDefaultMcpEndpoints() {
+		assertArrayEquals(
+			new String[] { "/api/**", "/sse", "/mcp/message", "/mcp" },
+			SecurityConfig.securedPaths(new MockEnvironment())
+		);
+	}
+
+	@Test
+	void testSecuredPathsShouldFollowRelocatedMcpEndpoints() {
+		final var environment = new MockEnvironment()
+			.withProperty("spring.ai.mcp.server.sse-endpoint", "/events")
+			.withProperty("spring.ai.mcp.server.sse-message-endpoint", "/messages")
+			.withProperty("spring.ai.mcp.server.streamable-http.mcp-endpoint", "/mcp-v2");
+
+		assertArrayEquals(
+			new String[] { "/api/**", "/events", "/messages", "/mcp-v2" },
+			SecurityConfig.securedPaths(environment)
 		);
 	}
 }

--- a/metricshub-agent/src/test/java/org/metricshub/web/controller/RestExceptionHandlerTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/controller/RestExceptionHandlerTest.java
@@ -3,8 +3,10 @@ package org.metricshub.web.controller;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import org.metricshub.web.dto.ErrorResponse;
 import org.metricshub.web.exception.TextPlainException;
@@ -12,6 +14,7 @@ import org.metricshub.web.exception.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
 
 class RestExceptionHandlerTest {
@@ -65,6 +68,32 @@ class RestExceptionHandlerTest {
 					((ErrorResponse) response.getBody()).getMessage(),
 					"Message should match the exception message"
 				)
+		);
+	}
+
+	@Test
+	void testShouldSwallowIoExceptionOnceTheResponseIsCommitted() {
+		final RestExceptionHandler handler = new RestExceptionHandler();
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		response.setCommitted(true);
+
+		// A client that aborted its SSE stream: nothing can be sent back, and nothing must reach Tomcat's SEVERE log
+		assertNull(handler.handleIoException(new IOException("Connection reset by peer"), response));
+	}
+
+	@Test
+	void testShouldAnswerIoExceptionBeforeTheResponseIsCommitted() {
+		final RestExceptionHandler handler = new RestExceptionHandler();
+
+		final ResponseEntity<Object> response = handler.handleIoException(
+			new IOException("Disk full"),
+			new MockHttpServletResponse()
+		);
+
+		assertAll(
+			() -> assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode()),
+			() -> assertNotNull(response.getBody()),
+			() -> assertEquals("Disk full", ((ErrorResponse) response.getBody()).getMessage())
 		);
 	}
 

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -153,6 +153,25 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldIgnoreAnInitializedNotificationRacingAPendingInitialize() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		session.handleResult = Mono.never();
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().messageTimeout(Duration.ofMillis(200))
+		);
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// The initialize never completes (504) while the notification is posted: neither must advance the state
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isGatewayTimeout());
+		session.handleResult = Mono.empty();
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void shouldResetTheHandshakeWhenInitializeFails() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.error(new IllegalStateException("initialize rejected"));

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -265,6 +265,34 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldNotLetAPingAnswerSettleTheHandshakeWhenItReusesTheInitializeId() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// The client posts a pre-initialization ping reusing the id of its pending initialize, then claims the
+		// handshake is complete; only the response to the initialize itself may settle it
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, PING.replace("\"id\":3", "\"id\":1")).andExpect(status().isOk());
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isAccepted());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+			session.sendResponse(
+				1,
+				new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
+			);
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		// The rejected initialize still settles the handshake, so the session stays unusable
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void shouldRefuseASecondInitializeWhileTheHandshakeIsPending() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -153,19 +153,51 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
-	void shouldIgnoreAnInitializedNotificationRacingAPendingInitialize() throws Exception {
+	void shouldAcceptAnInitializedNotificationPostedWhileTheInitializeResponseIsStillInFlight() throws Exception {
 		final RecordingSession session = new RecordingSession();
-		session.handleResult = Mono.never();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// The client receives the initialize response over SSE and posts the notification before the initialize POST
+		// returns: simulated by posting it from within the session's handling of initialize
+		session.onHandle = () -> {
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		session.onHandle = null;
+
+		assertEquals(
+			Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZED),
+			provider.sessionState(sessionId)
+		);
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
+	void shouldResetTheHandshakeWhenInitializeFailsAfterAnEarlyInitializedNotification() throws Exception {
+		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(
 			session,
 			LegacySseServerTransportProvider.builder().messageTimeout(Duration.ofMillis(200))
 		);
 		final String sessionId = openSse(mockMvc).sessionId();
 
-		// The initialize never completes (504) while the notification is posted: neither must advance the state
+		// A buggy client posts the notification while its initialize is still pending, and the initialize then times out
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+			// The initialize itself never completes
+			session.handleResult = Mono.never();
+		};
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isGatewayTimeout());
-		session.handleResult = Mono.empty();
-		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
 
 		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
 		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
@@ -418,6 +450,7 @@ class LegacySseServerTransportProviderTest {
 		final AtomicReference<String> lastRequestMethod = new AtomicReference<>();
 		final List<String> notified = new CopyOnWriteArrayList<>();
 		volatile Mono<Void> handleResult = Mono.empty();
+		volatile Runnable onHandle;
 		volatile Mono<Object> pingResult = Mono.just(Map.of());
 
 		RecordingSession() {
@@ -427,6 +460,10 @@ class LegacySseServerTransportProviderTest {
 		@Override
 		public Mono<Void> handle(final JSONRPCMessage message) {
 			handled.add(message);
+			final Runnable hook = onHandle;
+			if (hook != null && message instanceof JSONRPCRequest) {
+				hook.run();
+			}
 			return handleResult;
 		}
 

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -178,6 +178,36 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldResetTheHandshakeWhenInitializeIsRejectedWithAJsonRpcError() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// The SDK session answers initialize with a JSON-RPC error over SSE and completes normally
+		session.onHandle = () -> {
+			session.onHandle = null;
+			session.transport
+				.get()
+				.sendMessage(
+					new JSONRPCResponse(
+						McpSchema.JSONRPC_VERSION,
+						1,
+						null,
+						new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
+					)
+				)
+				.block();
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+
+		// The rejected handshake cannot be completed by the notification
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void shouldResetTheHandshakeWhenInitializeFailsAfterAnEarlyInitializedNotification() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -160,8 +160,9 @@ class LegacySseServerTransportProviderTest {
 		final String sessionId = openSse(mockMvc).sessionId();
 
 		// The client receives the initialize response over SSE and posts the notification before the initialize POST
-		// returns: simulated by posting it from within the session's handling of initialize
+		// returns: simulated by answering and posting it from within the session's handling of initialize
 		session.onHandle = () -> {
+			session.sendResponse(1, null);
 			try {
 				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
 			} catch (Exception e) {
@@ -221,7 +222,8 @@ class LegacySseServerTransportProviderTest {
 		session.onHandle = () -> {
 			session.onHandle = null;
 			try {
-				postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isOk());
+				// Not answered yet: the notification is dropped and cannot complete the handshake
+				postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isAccepted());
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
@@ -246,21 +248,15 @@ class LegacySseServerTransportProviderTest {
 		session.onHandle = () -> {
 			session.onHandle = null;
 			try {
-				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+				// Not answered yet: the notification is dropped
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isAccepted());
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
-			session.transport
-				.get()
-				.sendMessage(
-					new JSONRPCResponse(
-						McpSchema.JSONRPC_VERSION,
-						1,
-						null,
-						new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
-					)
-				)
-				.block();
+			session.sendResponse(
+				1,
+				new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
+			);
 		};
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
 
@@ -282,6 +278,7 @@ class LegacySseServerTransportProviderTest {
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
+			session.sendResponse(1, null);
 		};
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
 
@@ -297,25 +294,27 @@ class LegacySseServerTransportProviderTest {
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
 		final String sessionId = openSse(mockMvc).sessionId();
 
-		// An early initialized notification moves the state on while the response to the owning initialize is still
-		// pending: a second initialize must not slip through that window
+		// An initialized notification arriving before the owning initialize was answered is dropped, and a second
+		// initialize must not slip through that window either
 		session.onHandle = () -> {
 			session.onHandle = null;
 			try {
-				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isAccepted());
 				assertEquals(
-					Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZED),
+					Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZING),
 					provider.sessionState(sessionId)
 				);
 				postMessage(mockMvc, sessionId, INITIALIZE.replace("\"id\":1", "\"id\":9")).andExpect(status().isConflict());
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
+			session.sendResponse(1, null);
 		};
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
 
-		// Only the owning initialize and the notification reached the session
-		assertEquals(2, session.handled.size());
+		// Only the owning initialize reached the session; the client completes the handshake once it is answered
+		assertEquals(1, session.handled.size());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
 		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
 	}
 
@@ -405,7 +404,9 @@ class LegacySseServerTransportProviderTest {
 	@Test
 	void shouldCloseTheSessionWhenInitializeFails() throws Exception {
 		final RecordingSession session = new RecordingSession();
+		// The handling fails without ever answering the client
 		session.handleResult = Mono.error(new IllegalStateException("initialize rejected"));
+		session.answerInitialize = false;
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
 		final SseConnection sse = openSse(mockMvc);
 
@@ -422,6 +423,7 @@ class LegacySseServerTransportProviderTest {
 	void shouldReleaseTheRequestThreadWhenTheSessionNeverCompletes() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.never();
+		session.answerInitialize = false;
 		final MockMvc mockMvc = setUp(
 			session,
 			LegacySseServerTransportProvider.builder().messageTimeout(Duration.ofMillis(200))
@@ -644,6 +646,7 @@ class LegacySseServerTransportProviderTest {
 		final List<String> notified = new CopyOnWriteArrayList<>();
 		volatile Mono<Void> handleResult = Mono.empty();
 		volatile Runnable onHandle;
+		volatile boolean answerInitialize = true;
 		volatile Mono<Object> pingResult = Mono.just(Map.of());
 
 		RecordingSession() {
@@ -656,8 +659,28 @@ class LegacySseServerTransportProviderTest {
 			final Runnable hook = onHandle;
 			if (hook != null && message instanceof JSONRPCRequest) {
 				hook.run();
+			} else if (
+				answerInitialize &&
+				message instanceof JSONRPCRequest request &&
+				McpSchema.METHOD_INITIALIZE.equals(request.method())
+			) {
+				// The SDK session answers the initialize over the SSE stream before its Mono completes
+				sendResponse(request.id(), null);
 			}
 			return handleResult;
+		}
+
+		/**
+		 * Writes a JSON-RPC response to the client, as the SDK session does.
+		 *
+		 * @param id    the id of the request being answered
+		 * @param error the error to answer with, or {@code null} for a success response
+		 */
+		void sendResponse(final Object id, final JSONRPCResponse.JSONRPCError error) {
+			transport
+				.get()
+				.sendMessage(new JSONRPCResponse(McpSchema.JSONRPC_VERSION, id, error == null ? Map.of() : null, error))
+				.block();
 		}
 
 		@Override

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -140,6 +140,19 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldNotConsiderTheHandshakeCompleteWithoutAnInitializeRequest() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// notifications/initialized on a fresh session: forwarded, but the session stays uninitialized
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+		assertEquals(1, session.handled.size());
+	}
+
+	@Test
 	void shouldReleaseTheRequestThreadWhenTheSessionNeverCompletes() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.never();

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -268,6 +268,29 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldRefuseASecondInitializeWhileTheHandshakeIsPending() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// The second initialize is posted while the first one is still being handled
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZE.replace("\"id\":1", "\"id\":9")).andExpect(status().isConflict());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		// Only the first initialize reached the session, and the handshake completes normally
+		assertEquals(1, session.handled.size());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
 	void shouldKeepAnInitializedSessionWhenADuplicateInitializeIsRejected() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -1,0 +1,424 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.modelcontextprotocol.json.TypeRef;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCMessage;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCNotification;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCRequest;
+import io.modelcontextprotocol.spec.McpSchema.JSONRPCResponse;
+import io.modelcontextprotocol.spec.McpServerSession;
+import io.modelcontextprotocol.spec.McpServerTransport;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import reactor.core.publisher.Mono;
+
+class LegacySseServerTransportProviderTest {
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+	private static final Pattern SESSION_ID_PATTERN = Pattern.compile("sessionId=([\\w-]+)");
+
+	private static final String INITIALIZE =
+		"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\"," +
+		"\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}";
+	private static final String INITIALIZED = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}";
+	private static final String TOOLS_LIST = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}";
+	private static final String PING = "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"ping\"}";
+	private static final String CANCELLED_NOTIFICATION =
+		"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":1}}";
+	private static final String PING_RESPONSE = "{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{}}";
+
+	private LegacySseServerTransportProvider provider;
+
+	@AfterEach
+	void tearDown() {
+		if (provider != null) {
+			provider.closeGracefully().block(Duration.ofSeconds(5));
+		}
+	}
+
+	@Test
+	void shouldRejectRequestOnUninitializedSession() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		final long start = System.nanoTime();
+		final MvcResult result = postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest()).andReturn();
+		final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+		assertTrue(elapsedMs < 5_000, "The rejection must be immediate, took " + elapsedMs + " ms");
+		final String body = result.getResponse().getContentAsString();
+		assertTrue(body.contains("\"code\":-32600"), body);
+		assertTrue(body.contains("not initialized"), body);
+		assertTrue(body.contains("\"id\":2"), body);
+		assertTrue(session.handled.isEmpty(), "The message must not reach the session");
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+	}
+
+	@Test
+	void shouldDropNotificationOnUninitializedSessionButForwardResponses() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// A notification cannot be acted upon before the handshake: accepted and dropped, never a failed POST
+		postMessage(mockMvc, sessionId, CANCELLED_NOTIFICATION).andExpect(status().isAccepted());
+		assertTrue(session.handled.isEmpty());
+
+		postMessage(mockMvc, sessionId, PING_RESPONSE).andExpect(status().isOk());
+		assertEquals(1, session.handled.size());
+		assertTrue(session.handled.get(0) instanceof JSONRPCResponse);
+	}
+
+	@Test
+	void shouldAnswerPingBeforeInitializationWithoutInvolvingTheSession() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final SseConnection sse = openSse(mockMvc);
+
+		postMessage(mockMvc, sse.sessionId(), PING).andExpect(status().isOk());
+
+		assertTrue(session.handled.isEmpty(), "The ping must be answered by the transport itself");
+		final String stream = sse.result().getResponse().getContentAsString();
+		assertTrue(stream.contains("\"id\":3"), stream);
+		assertTrue(stream.contains("\"result\":{}"), stream);
+	}
+
+	@Test
+	void shouldForwardMessagesOnceTheHandshakeIsComplete() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		assertEquals(
+			Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZING),
+			provider.sessionState(sessionId)
+		);
+
+		// Still not initialized: regular requests are rejected
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		assertEquals(
+			Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZED),
+			provider.sessionState(sessionId)
+		);
+
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+
+		assertEquals(3, session.handled.size());
+		assertEquals("initialize", ((JSONRPCRequest) session.handled.get(0)).method());
+		assertEquals("notifications/initialized", ((JSONRPCNotification) session.handled.get(1)).method());
+		assertEquals("tools/list", ((JSONRPCRequest) session.handled.get(2)).method());
+	}
+
+	@Test
+	void shouldReleaseTheRequestThreadWhenTheSessionNeverCompletes() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		session.handleResult = Mono.never();
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().messageTimeout(Duration.ofMillis(200))
+		);
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		final long start = System.nanoTime();
+		final MvcResult result = postMessage(mockMvc, sessionId, INITIALIZE)
+			.andExpect(status().isGatewayTimeout())
+			.andReturn();
+		final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+		assertTrue(elapsedMs < 5_000, "The request thread must be released by the timeout, took " + elapsedMs + " ms");
+		final String body = result.getResponse().getContentAsString();
+		assertTrue(body.contains("did not complete"), body);
+		assertTrue(body.contains("\"id\":1"), body);
+	}
+
+	@Test
+	void shouldCloseSessionsThatNeverCompleteTheHandshake() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().initializationTimeout(Duration.ofMinutes(2))
+		);
+		final Instant opened = Instant.now();
+		final SseConnection sse = openSse(mockMvc);
+		assertEquals(1, provider.activeSessionCount());
+
+		// The initialization timeout is not elapsed yet: the session is kept
+		provider.runMaintenance(opened.plus(Duration.ofMinutes(1)));
+		assertEquals(1, provider.activeSessionCount());
+
+		provider.runMaintenance(opened.plus(Duration.ofMinutes(3)));
+
+		assertEquals(0, provider.activeSessionCount());
+		assertTrue(provider.sessionState(sse.sessionId()).isEmpty());
+		assertStreamCompleted(sse);
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isNotFound());
+	}
+
+	@Test
+	void shouldCloseSessionWhenTheKeepAlivePingFails() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		session.pingResult = Mono.error(new IOException("Broken pipe"));
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().keepAliveInterval(Duration.ofMinutes(10))
+		);
+		final SseConnection sse = openSse(mockMvc);
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isOk());
+
+		provider.runMaintenance();
+
+		assertEquals("ping", session.lastRequestMethod.get());
+		assertEquals(0, provider.activeSessionCount());
+		assertStreamCompleted(sse);
+	}
+
+	@Test
+	void shouldKeepSessionWhoseClientAnswersTheKeepAlivePingWithAnError() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		// A client without a ping handler answers with a JSON-RPC error: it is alive nonetheless
+		session.pingResult = Mono.error(
+			new McpError(new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.METHOD_NOT_FOUND, "Method not found", null))
+		);
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().keepAliveInterval(Duration.ofMinutes(10))
+		);
+		final String sessionId = openSse(mockMvc).sessionId();
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+
+		provider.runMaintenance();
+
+		assertEquals("ping", session.lastRequestMethod.get());
+		assertEquals(1, provider.activeSessionCount());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
+	void shouldBroadcastNotificationsOnlyToInitializedSessions() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final SseConnection sse = openSse(mockMvc);
+
+		provider.notifyClients("notifications/tools/list_changed", null).block(Duration.ofSeconds(5));
+		assertTrue(session.notified.isEmpty(), "An uninitialized session must not receive broadcasts");
+
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isOk());
+		provider.notifyClients("notifications/tools/list_changed", null).block(Duration.ofSeconds(5));
+
+		assertEquals(List.of("notifications/tools/list_changed"), session.notified);
+	}
+
+	@Test
+	void shouldCloseSessionWhenTheKeepAlivePingIsNotAnswered() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		session.pingResult = Mono.never();
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder()
+				.keepAliveInterval(Duration.ofMinutes(10))
+				.pingTimeout(Duration.ofMillis(100))
+		);
+		final SseConnection sse = openSse(mockMvc);
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isOk());
+
+		provider.runMaintenance();
+
+		await()
+			.atMost(Duration.ofSeconds(5))
+			.until(() -> provider.activeSessionCount() == 0);
+		assertStreamCompleted(sse);
+	}
+
+	@Test
+	void shouldKeepInitializedSessionsWhoseKeepAlivePingIsAnswered() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(
+			session,
+			LegacySseServerTransportProvider.builder().keepAliveInterval(Duration.ofMinutes(10))
+		);
+		final String sessionId = openSse(mockMvc).sessionId();
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+
+		provider.runMaintenance();
+
+		assertEquals("ping", session.lastRequestMethod.get());
+		assertEquals(1, provider.activeSessionCount());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
+	void shouldRejectUnknownOrMissingSessions() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+
+		postMessage(mockMvc, "does-not-exist", INITIALIZE).andExpect(status().isNotFound());
+		mockMvc
+			.perform(post(MESSAGE_ENDPOINT).contentType(MediaType.APPLICATION_JSON).content(INITIALIZE))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	void shouldRejectMalformedMessages() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		postMessage(mockMvc, sessionId, "{\"jsonrpc\":\"2.0\",\"foo\":").andExpect(status().isBadRequest());
+		assertTrue(session.handled.isEmpty());
+	}
+
+	@Test
+	void shouldForgetSessionsWhoseStreamCompletes() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final SseConnection sse = openSse(mockMvc);
+		assertEquals(1, provider.activeSessionCount());
+
+		// Complete the SSE stream, then let the container run the completion callbacks
+		session.transport.get().close();
+		mockMvc.perform(asyncDispatch(sse.result()));
+
+		assertEquals(0, provider.activeSessionCount());
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isNotFound());
+	}
+
+	private MockMvc setUp(final RecordingSession session, final LegacySseServerTransportProvider.Builder builder) {
+		provider = builder.messageEndpoint(MESSAGE_ENDPOINT).build();
+		provider.setSessionFactory(transport -> {
+			session.transport.set(transport);
+			return session;
+		});
+		return MockMvcBuilders.routerFunctions(provider.getRouterFunction()).build();
+	}
+
+	private static SseConnection openSse(final MockMvc mockMvc) throws Exception {
+		final MvcResult result = mockMvc.perform(get("/sse")).andReturn();
+		final String stream = result.getResponse().getContentAsString();
+		assertTrue(stream.contains("event:endpoint"), stream);
+		final Matcher matcher = SESSION_ID_PATTERN.matcher(stream);
+		assertTrue(matcher.find(), stream);
+		return new SseConnection(matcher.group(1), result);
+	}
+
+	private static ResultActions postMessage(final MockMvc mockMvc, final String sessionId, final String body)
+		throws Exception {
+		return mockMvc.perform(
+			post(MESSAGE_ENDPOINT).param("sessionId", sessionId).contentType(MediaType.APPLICATION_JSON).content(body)
+		);
+	}
+
+	/**
+	 * Under MockMvc the completion of the SSE stream dispatches the async request; the async result is only available
+	 * once that dispatch happened.
+	 */
+	private static void assertStreamCompleted(final SseConnection sse) {
+		assertDoesNotThrow(() -> sse.result().getAsyncResult(1_000), "The SSE stream must be completed");
+	}
+
+	private record SseConnection(String sessionId, MvcResult result) {}
+
+	/**
+	 * SDK session stub recording the messages handed over by the transport provider.
+	 */
+	private static final class RecordingSession extends McpServerSession {
+
+		private static final String ID = "session-under-test";
+
+		final List<JSONRPCMessage> handled = new CopyOnWriteArrayList<>();
+		final AtomicReference<McpServerTransport> transport = new AtomicReference<>();
+		final AtomicReference<String> lastRequestMethod = new AtomicReference<>();
+		final List<String> notified = new CopyOnWriteArrayList<>();
+		volatile Mono<Void> handleResult = Mono.empty();
+		volatile Mono<Object> pingResult = Mono.just(Map.of());
+
+		RecordingSession() {
+			super(ID, Duration.ofSeconds(5), new NoopTransport(), null, Map.of(), Map.of());
+		}
+
+		@Override
+		public Mono<Void> handle(final JSONRPCMessage message) {
+			handled.add(message);
+			return handleResult;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> Mono<T> sendRequest(final String method, final Object requestParams, final TypeRef<T> typeRef) {
+			lastRequestMethod.set(method);
+			return (Mono<T>) pingResult;
+		}
+
+		@Override
+		public Mono<Void> sendNotification(final String method, final Object params) {
+			notified.add(method);
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			final McpServerTransport sessionTransport = transport.get();
+			return sessionTransport == null ? Mono.empty() : sessionTransport.closeGracefully();
+		}
+
+		@Override
+		public void close() {
+			final McpServerTransport sessionTransport = transport.get();
+			if (sessionTransport != null) {
+				sessionTransport.close();
+			}
+		}
+	}
+
+	private static final class NoopTransport implements McpServerTransport {
+
+		@Override
+		public Mono<Void> sendMessage(final JSONRPCMessage message) {
+			return Mono.empty();
+		}
+
+		@Override
+		public <T> T unmarshalFrom(final Object data, final TypeRef<T> typeRef) {
+			return null;
+		}
+
+		@Override
+		public Mono<Void> closeGracefully() {
+			return Mono.empty();
+		}
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -292,6 +292,34 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldRefuseASecondInitializeWhileTheOwningResponseIsStillPending() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// An early initialized notification moves the state on while the response to the owning initialize is still
+		// pending: a second initialize must not slip through that window
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+				assertEquals(
+					Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZED),
+					provider.sessionState(sessionId)
+				);
+				postMessage(mockMvc, sessionId, INITIALIZE.replace("\"id\":1", "\"id\":9")).andExpect(status().isConflict());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		// Only the owning initialize and the notification reached the session
+		assertEquals(2, session.handled.size());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
 	void shouldLetTheClientRetryAfterARefusedConcurrentInitializeAndARejectedHandshake() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -153,6 +153,28 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldResetTheHandshakeWhenInitializeFails() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		session.handleResult = Mono.error(new IllegalStateException("initialize rejected"));
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isInternalServerError());
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+
+		// The failed initialize cannot be completed by the notification alone
+		session.handleResult = Mono.empty();
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+
+		// A new initialize restarts the handshake normally
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
 	void shouldReleaseTheRequestThreadWhenTheSessionNeverCompletes() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.never();

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -292,6 +292,45 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldLetTheClientRetryAfterARefusedConcurrentInitializeAndARejectedHandshake() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// A second initialize is refused while the first one is pending, and the first one is then rejected by the SDK
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZE.replace("\"id\":1", "\"id\":9")).andExpect(status().isConflict());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+			session.transport
+				.get()
+				.sendMessage(
+					new JSONRPCResponse(
+						McpSchema.JSONRPC_VERSION,
+						1,
+						null,
+						new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
+					)
+				)
+				.block();
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		// The rejected handshake released the claim: a fresh initialize can take it and complete normally
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		assertEquals(
+			Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZING),
+			provider.sessionState(sessionId)
+		);
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
 	void shouldKeepAnInitializedSessionWhenADuplicateInitializeIsRejected() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -236,10 +236,47 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldResetTheHandshakeWhenInitializeIsRejectedDespiteAnEarlyInitializedNotification() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+
+		// A buggy client posts the notification before the (error) response to its initialize is written
+		session.onHandle = () -> {
+			session.onHandle = null;
+			try {
+				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+			session.transport
+				.get()
+				.sendMessage(
+					new JSONRPCResponse(
+						McpSchema.JSONRPC_VERSION,
+						1,
+						null,
+						new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_PARAMS, "Unsupported protocol version", null)
+					)
+				)
+				.block();
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+	}
+
+	@Test
 	void shouldKeepAnInitializedSessionWhenADuplicateInitializeIsRejected() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
 		final String sessionId = openSse(mockMvc).sessionId();
+		// The SDK session answers the initialize (success) over SSE, like the real one always does
+		session.onHandle = () -> {
+			session.onHandle = null;
+			session.transport.get().sendMessage(new JSONRPCResponse(McpSchema.JSONRPC_VERSION, 1, Map.of(), null)).block();
+		};
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
 		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
 

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -145,11 +145,12 @@ class LegacySseServerTransportProviderTest {
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
 		final String sessionId = openSse(mockMvc).sessionId();
 
-		// notifications/initialized on a fresh session: forwarded, but the session stays uninitialized
-		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		// notifications/initialized on a fresh session: dropped, the session stays uninitialized and the SDK session
+		// is never told it is initialized
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isAccepted());
 		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
 		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
-		assertEquals(1, session.handled.size());
+		assertTrue(session.handled.isEmpty());
 	}
 
 	@Test
@@ -201,8 +202,8 @@ class LegacySseServerTransportProviderTest {
 		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
 		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
 
-		// The rejected handshake cannot be completed by the notification
-		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+		// The rejected handshake cannot be completed by the notification, which is dropped
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isAccepted());
 		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
 		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
 	}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -236,6 +236,45 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
+	void shouldKeepAnInitializedSessionWhenADuplicateInitializeIsRejected() throws Exception {
+		final RecordingSession session = new RecordingSession();
+		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
+		final String sessionId = openSse(mockMvc).sessionId();
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+
+		// A second initialize is rejected by the SDK with a JSON-RPC error and must not disturb the valid session
+		session.onHandle = () -> {
+			session.onHandle = null;
+			session.transport
+				.get()
+				.sendMessage(
+					new JSONRPCResponse(
+						McpSchema.JSONRPC_VERSION,
+						1,
+						null,
+						new JSONRPCResponse.JSONRPCError(McpSchema.ErrorCodes.INVALID_REQUEST, "Already initialized", null)
+					)
+				)
+				.block();
+		};
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
+
+		assertEquals(
+			Optional.of(LegacySseServerTransportProvider.SessionState.INITIALIZED),
+			provider.sessionState(sessionId)
+		);
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+
+		// Even a failing duplicate initialize leaves the valid session open
+		session.handleResult = Mono.error(new IllegalStateException("duplicate initialize"));
+		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isInternalServerError());
+		assertEquals(1, provider.activeSessionCount());
+		session.handleResult = Mono.empty();
+		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+	}
+
+	@Test
 	void shouldCloseTheSessionWhenInitializeFails() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.error(new IllegalStateException("initialize rejected"));

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/LegacySseServerTransportProviderTest.java
@@ -208,51 +208,47 @@ class LegacySseServerTransportProviderTest {
 	}
 
 	@Test
-	void shouldResetTheHandshakeWhenInitializeFailsAfterAnEarlyInitializedNotification() throws Exception {
+	void shouldCloseTheSessionWhenInitializeTimesOutAfterAnEarlyInitializedNotification() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		final MockMvc mockMvc = setUp(
 			session,
 			LegacySseServerTransportProvider.builder().messageTimeout(Duration.ofMillis(200))
 		);
-		final String sessionId = openSse(mockMvc).sessionId();
+		final SseConnection sse = openSse(mockMvc);
 
 		// A buggy client posts the notification while its initialize is still pending, and the initialize then times out
 		session.onHandle = () -> {
 			session.onHandle = null;
 			try {
-				postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
+				postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isOk());
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
 			// The initialize itself never completes
 			session.handleResult = Mono.never();
 		};
-		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isGatewayTimeout());
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isGatewayTimeout());
 
-		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
-		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
+		// The pending SDK handling may still complete later: the session is closed rather than reused
+		assertEquals(0, provider.activeSessionCount());
+		assertStreamCompleted(sse);
+		postMessage(mockMvc, sse.sessionId(), TOOLS_LIST).andExpect(status().isNotFound());
 	}
 
 	@Test
-	void shouldResetTheHandshakeWhenInitializeFails() throws Exception {
+	void shouldCloseTheSessionWhenInitializeFails() throws Exception {
 		final RecordingSession session = new RecordingSession();
 		session.handleResult = Mono.error(new IllegalStateException("initialize rejected"));
 		final MockMvc mockMvc = setUp(session, LegacySseServerTransportProvider.builder());
-		final String sessionId = openSse(mockMvc).sessionId();
+		final SseConnection sse = openSse(mockMvc);
 
-		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isInternalServerError());
-		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
+		postMessage(mockMvc, sse.sessionId(), INITIALIZE).andExpect(status().isInternalServerError());
 
-		// The failed initialize cannot be completed by the notification alone
-		session.handleResult = Mono.empty();
-		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
-		assertEquals(Optional.of(LegacySseServerTransportProvider.SessionState.CREATED), provider.sessionState(sessionId));
-		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isBadRequest());
-
-		// A new initialize restarts the handshake normally
-		postMessage(mockMvc, sessionId, INITIALIZE).andExpect(status().isOk());
-		postMessage(mockMvc, sessionId, INITIALIZED).andExpect(status().isOk());
-		postMessage(mockMvc, sessionId, TOOLS_LIST).andExpect(status().isOk());
+		// The SDK session is in an unknown state: the stream is closed and the client has to reconnect
+		assertEquals(0, provider.activeSessionCount());
+		assertTrue(provider.sessionState(sse.sessionId()).isEmpty());
+		assertStreamCompleted(sse);
+		postMessage(mockMvc, sse.sessionId(), INITIALIZED).andExpect(status().isNotFound());
 	}
 
 	@Test

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpLegacySseDisabledInSseModeTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpLegacySseDisabledInSseModeTest.java
@@ -1,0 +1,58 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * {@code mcp.sse.enabled=false} together with {@code protocol=SSE}: the switch must not hand {@code /sse} back to the
+ * SDK transport that hangs request threads. The hardened transport stays in place (the switch only applies alongside
+ * Streamable HTTP).
+ */
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+	classes = McpTransportTestSupport.TestApplication.class,
+	properties = {
+		"spring.main.banner-mode=off",
+		"spring.ai.mcp.server.enabled=true",
+		"spring.ai.mcp.server.stdio=false",
+		"spring.ai.mcp.server.name=test-mcp-server",
+		"spring.ai.mcp.server.type=sync",
+		"spring.ai.mcp.server.protocol=SSE",
+		"spring.ai.mcp.server.sse-endpoint=/sse",
+		"spring.ai.mcp.server.sse-message-endpoint=/mcp/message",
+		"spring.ai.mcp.server.request-timeout=30s",
+		"mcp.sse.enabled=false"
+	}
+)
+class McpLegacySseDisabledInSseModeTest {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void hardenedTransportShouldStillReplaceTheSdkTransport() {
+		final Map<String, McpServerTransportProvider> providers = applicationContext.getBeansOfType(
+			McpServerTransportProvider.class
+		);
+		assertEquals(1, providers.size(), "Exactly one transport provider is expected: " + providers.keySet());
+		assertTrue(providers.values().iterator().next() instanceof LegacySseServerTransportProvider);
+		assertTrue(applicationContext.getBeansOfType(WebMvcSseServerTransportProvider.class).isEmpty());
+	}
+
+	@Test
+	void legacySseTransportShouldStillRejectRequestsOnUninitializedSessions() throws Exception {
+		McpTransportTestSupport.assertUninitializedSessionIsRejected("http://localhost:" + port);
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpLegacySseOnlyModeTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpLegacySseOnlyModeTest.java
@@ -1,0 +1,77 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpServerTransportProvider;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Boots the minimal web application with {@code spring.ai.mcp.server.protocol=SSE}: the hardened transport must
+ * replace the Spring AI SSE transport provider and be bound to the auto-configured MCP server.
+ */
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+	classes = McpTransportTestSupport.TestApplication.class,
+	properties = {
+		"spring.main.banner-mode=off",
+		"spring.ai.mcp.server.enabled=true",
+		"spring.ai.mcp.server.stdio=false",
+		"spring.ai.mcp.server.name=test-mcp-server",
+		"spring.ai.mcp.server.type=sync",
+		"spring.ai.mcp.server.protocol=SSE",
+		"spring.ai.mcp.server.sse-endpoint=/sse",
+		"spring.ai.mcp.server.sse-message-endpoint=/mcp/message",
+		"spring.ai.mcp.server.request-timeout=30s",
+		"mcp.sse.enabled=true",
+		"mcp.sse.message-timeout=30s"
+	}
+)
+class McpLegacySseOnlyModeTest {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void hardenedTransportShouldReplaceTheSdkTransport() {
+		final Map<String, McpServerTransportProvider> providers = applicationContext.getBeansOfType(
+			McpServerTransportProvider.class
+		);
+		assertEquals(1, providers.size(), "Exactly one transport provider is expected: " + providers.keySet());
+		assertTrue(providers.values().iterator().next() instanceof LegacySseServerTransportProvider);
+		assertTrue(applicationContext.getBeansOfType(WebMvcSseServerTransportProvider.class).isEmpty());
+		assertFalse(applicationContext.containsBean("legacySseMcpServer"));
+	}
+
+	@Test
+	void legacySseTransportShouldServeTheTools() {
+		McpTransportTestSupport.assertToolsAreServed(
+			HttpClientSseClientTransport.builder(baseUrl()).sseEndpoint("/sse").build()
+		);
+	}
+
+	@Test
+	void legacySseTransportShouldRejectRequestsOnUninitializedSessionsInsteadOfHanging() throws Exception {
+		McpTransportTestSupport.assertUninitializedSessionIsRejected(baseUrl());
+	}
+
+	@Test
+	void streamableHttpEndpointShouldNotBeServed() throws Exception {
+		assertEquals(404, McpTransportTestSupport.postJsonRpc(baseUrl() + "/mcp"));
+	}
+
+	private String baseUrl() {
+		return "http://localhost:" + port;
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpServerDisabledTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpServerDisabledTest.java
@@ -1,0 +1,31 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.spec.McpServerTransportProviderBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Disabling the MCP server (a supported {@code web} override) must still let the web application start: the legacy
+ * SSE configuration depends on Spring AI beans that only exist when the MCP server is enabled, so it must back off.
+ */
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+	classes = McpTransportTestSupport.TestApplication.class,
+	properties = { "spring.main.banner-mode=off", "spring.ai.mcp.server.enabled=false", "mcp.sse.enabled=true" }
+)
+class McpServerDisabledTest {
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void legacySseConfigurationShouldBackOffWhenTheMcpServerIsDisabled() {
+		assertTrue(applicationContext.getBeansOfType(LegacySseMcpServer.class).isEmpty());
+		assertTrue(applicationContext.getBeansOfType(LegacySseServerTransportProvider.class).isEmpty());
+		assertTrue(applicationContext.getBeansOfType(McpServerTransportProviderBase.class).isEmpty());
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpTransportTestSupport.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpTransportTestSupport.java
@@ -1,0 +1,210 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.spec.McpClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntSupplier;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Shared fixtures for the MCP transport integration tests: a minimal Spring Boot web application exposing one tool
+ * through the Spring AI MCP auto-configuration and {@link LegacySseMcpServerConfiguration}, plus client-side
+ * assertions.
+ */
+final class McpTransportTestSupport {
+
+	static final String ECHO_TOOL = "echo";
+
+	private McpTransportTestSupport() {}
+
+	/**
+	 * Minimal web application: Spring Boot auto-configuration without security, the MCP server auto-configuration and
+	 * the legacy SSE configuration under test.
+	 */
+	@Configuration
+	@EnableAutoConfiguration(
+		exclude = {
+			SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class
+		}
+	)
+	@Import(LegacySseMcpServerConfiguration.class)
+	static class TestApplication {
+
+		@Bean
+		ToolCallbackProvider testTools() {
+			return MethodToolCallbackProvider.builder().toolObjects(new EchoTool()).build();
+		}
+	}
+
+	static class EchoTool {
+
+		@Tool(name = ECHO_TOOL, description = "Echoes the given text")
+		public String echo(@ToolParam(description = "The text to echo") final String text) {
+			return "echo:" + text;
+		}
+	}
+
+	/**
+	 * Initializes an MCP client over the given transport, lists the tools and calls the echo tool.
+	 *
+	 * @param transport the client transport under test
+	 */
+	static void assertToolsAreServed(final McpClientTransport transport) {
+		try (McpSyncClient client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(30)).build()) {
+			client.initialize();
+
+			// McpSchema.Tool collides with Spring AI's @Tool annotation, hence the qualified name
+			final McpSchema.Tool echoTool = client
+				.listTools()
+				.tools()
+				.stream()
+				.filter(tool -> ECHO_TOOL.equals(tool.name()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("The echo tool must be listed"));
+
+			// The argument name comes from the advertised schema: it depends on whether the test classes were
+			// compiled with parameter names
+			final String argumentName = echoTool.inputSchema().properties().keySet().iterator().next();
+			final CallToolResult result = client.callTool(new CallToolRequest(ECHO_TOOL, Map.of(argumentName, "hello")));
+			assertFalse(Boolean.TRUE.equals(result.isError()), "The tool call must succeed: " + result);
+			assertTrue(
+				result
+					.content()
+					.stream()
+					.filter(TextContent.class::isInstance)
+					.map(TextContent.class::cast)
+					.anyMatch(content -> content.text().contains("echo:hello")),
+				"Unexpected tool result: " + result
+			);
+		}
+	}
+
+	/**
+	 * Initializes an MCP client, lets several keep-alive pings go through the real client, and checks that the session
+	 * is still there and usable afterwards (the client answers the pings, so the server must keep the session).
+	 *
+	 * @param transport          the SSE client transport
+	 * @param activeSessionCount supplier of the server-side session count
+	 * @throws InterruptedException when interrupted while waiting for the pings
+	 */
+	static void assertSessionSurvivesKeepAlivePings(
+		final McpClientTransport transport,
+		final IntSupplier activeSessionCount
+	) throws InterruptedException {
+		try (McpSyncClient client = McpClient.sync(transport).requestTimeout(Duration.ofSeconds(30)).build()) {
+			client.initialize();
+			final int before = activeSessionCount.getAsInt();
+			assertTrue(before >= 1, "The session must be tracked");
+
+			// Several 200 ms keep-alive intervals
+			Thread.sleep(1_500);
+
+			assertEquals(before, activeSessionCount.getAsInt(), "A client answering the pings must keep its session");
+			assertTrue(
+				client
+					.listTools()
+					.tools()
+					.stream()
+					.anyMatch(tool -> ECHO_TOOL.equals(tool.name()))
+			);
+		}
+	}
+
+	/**
+	 * Opens an SSE stream, reads the endpoint event and posts a request without initializing the session, as an SSE
+	 * client that reconnected its event stream does. The SDK transport would block forever; the hardened transport must
+	 * answer 400 immediately.
+	 *
+	 * @param baseUrl the base URL of the server
+	 * @throws Exception when the HTTP exchanges fail
+	 */
+	static void assertUninitializedSessionIsRejected(final String baseUrl) throws Exception {
+		final HttpClient httpClient = HttpClient.newHttpClient();
+
+		final HttpRequest sseRequest = HttpRequest.newBuilder(URI.create(baseUrl + "/sse"))
+			.header("Accept", "text/event-stream")
+			.timeout(Duration.ofSeconds(10))
+			.GET()
+			.build();
+		final HttpResponse<InputStream> sseResponse = httpClient.send(
+			sseRequest,
+			HttpResponse.BodyHandlers.ofInputStream()
+		);
+		assertEquals(200, sseResponse.statusCode());
+
+		try (
+			BufferedReader reader = new BufferedReader(new InputStreamReader(sseResponse.body(), StandardCharsets.UTF_8))
+		) {
+			String messageEndpoint = null;
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (line.startsWith("data:")) {
+					messageEndpoint = line.substring("data:".length()).trim();
+					break;
+				}
+			}
+			assertNotNull(messageEndpoint, "The endpoint event must be received");
+
+			final HttpRequest toolsListRequest = HttpRequest.newBuilder(URI.create(baseUrl + messageEndpoint))
+				.header("Content-Type", "application/json")
+				.timeout(Duration.ofSeconds(10))
+				.POST(HttpRequest.BodyPublishers.ofString("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
+				.build();
+
+			final long start = System.nanoTime();
+			final HttpResponse<String> response = httpClient.send(toolsListRequest, HttpResponse.BodyHandlers.ofString());
+			final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+			assertEquals(400, response.statusCode(), response.body());
+			assertTrue(response.body().contains("not initialized"), response.body());
+			assertTrue(elapsedMs < 5_000, "The rejection must be immediate, took " + elapsedMs + " ms");
+		}
+	}
+
+	/**
+	 * Posts a JSON-RPC message to a path and returns the HTTP status.
+	 *
+	 * @param url the URL to post to
+	 * @return the HTTP status code
+	 * @throws Exception when the HTTP exchange fails
+	 */
+	static int postJsonRpc(final String url) throws Exception {
+		final HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+			.header("Content-Type", "application/json")
+			.header("Accept", "application/json, text/event-stream")
+			.timeout(Duration.ofSeconds(10))
+			.POST(HttpRequest.BodyPublishers.ofString("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}"))
+			.build();
+		return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString()).statusCode();
+	}
+}

--- a/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpTransportsCoexistenceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/mcp/transport/McpTransportsCoexistenceTest.java
@@ -1,0 +1,98 @@
+package org.metricshub.web.mcp.transport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTransport;
+import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpServerTransportProviderBase;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * Boots a minimal Spring Boot web application with the Spring AI MCP auto-configuration in {@code STREAMABLE} mode
+ * plus {@link LegacySseMcpServerConfiguration}, and checks that both transports serve the same tools and that the
+ * legacy SSE transport no longer hangs on uninitialized sessions.
+ */
+@SpringBootTest(
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+	classes = McpTransportTestSupport.TestApplication.class,
+	properties = {
+		"spring.main.banner-mode=off",
+		"spring.ai.mcp.server.enabled=true",
+		"spring.ai.mcp.server.stdio=false",
+		"spring.ai.mcp.server.name=test-mcp-server",
+		"spring.ai.mcp.server.type=sync",
+		"spring.ai.mcp.server.protocol=STREAMABLE",
+		"spring.ai.mcp.server.streamable-http.mcp-endpoint=/mcp",
+		"spring.ai.mcp.server.sse-endpoint=/sse",
+		"spring.ai.mcp.server.sse-message-endpoint=/mcp/message",
+		"spring.ai.mcp.server.request-timeout=30s",
+		// Fast keep-alive so that the ping round trip with a real client is exercised within the test
+		"spring.ai.mcp.server.keep-alive-interval=200ms",
+		"mcp.sse.enabled=true",
+		"mcp.sse.message-timeout=30s",
+		"mcp.sse.ping-timeout=5s"
+	}
+)
+class McpTransportsCoexistenceTest {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private LegacySseMcpServer legacySseMcpServer;
+
+	@Autowired
+	private ApplicationContext applicationContext;
+
+	@Test
+	void legacySseTransportShouldServeTheTools() {
+		McpTransportTestSupport.assertToolsAreServed(
+			HttpClientSseClientTransport.builder(baseUrl()).sseEndpoint("/sse").build()
+		);
+	}
+
+	@Test
+	void streamableHttpTransportShouldServeTheTools() {
+		McpTransportTestSupport.assertToolsAreServed(
+			HttpClientStreamableHttpTransport.builder(baseUrl()).endpoint("/mcp").build()
+		);
+	}
+
+	@Test
+	void legacySseTransportShouldRejectRequestsOnUninitializedSessionsInsteadOfHanging() throws Exception {
+		McpTransportTestSupport.assertUninitializedSessionIsRejected(baseUrl());
+	}
+
+	@Test
+	void legacySseSessionShouldSurviveKeepAlivePingsAnsweredByARealClient() throws Exception {
+		McpTransportTestSupport.assertSessionSurvivesKeepAlivePings(
+			HttpClientSseClientTransport.builder(baseUrl()).sseEndpoint("/sse").build(),
+			legacySseMcpServer::activeSessionCount
+		);
+	}
+
+	@Test
+	void legacySseProviderShouldNotCompeteWithTheStreamableProviderBean() {
+		assertNotNull(legacySseMcpServer);
+		// The legacy provider is held by the holder bean only, so that Spring AI's single-provider injection stays
+		// unambiguous and binds the auto-configured server to the Streamable HTTP transport
+		assertTrue(applicationContext.getBeansOfType(LegacySseServerTransportProvider.class).isEmpty());
+		final Map<String, McpServerTransportProviderBase> providers = applicationContext.getBeansOfType(
+			McpServerTransportProviderBase.class
+		);
+		assertEquals(1, providers.size(), "Exactly one transport provider bean is expected: " + providers.keySet());
+		assertTrue(providers.values().iterator().next() instanceof WebMvcStreamableServerTransportProvider);
+	}
+
+	private String baseUrl() {
+		return "http://localhost:" + port;
+	}
+}


### PR DESCRIPTION
Fixes #1325.

## Problem

On two production agents (3.9.04), port 31888 refused connections (`ECONNREFUSED`, even on loopback, firewall off) while the JVM was alive and `netstat` showed `LISTENING`. Thread dumps show:

- the Tomcat `Acceptor` parked in `LimitLatch.countUpOrAwait` (the connection counter reached `maxConnections`, so Tomcat stopped calling `accept()` and the kernel answered RST);
- 79 request threads parked for up to 3.8 days in `WebMvcSseServerTransportProvider.handleMessage` → `Mono.block()`, with no tool running underneath.

Root cause (MCP Java SDK 0.17.0 / Spring AI 1.1.2, unchanged upstream): a request posted on an SSE session that never completed the `initialize` / `notifications/initialized` handshake waits forever on the session's `exchangeSink`, and the SDK blocks the Tomcat thread on it without a timeout. TypeScript-SDK SSE clients trigger exactly that after an `EventSource` auto-reconnect (new server session, no re-initialization, typescript-sdk#510). Without keep-alive, dead SSE connections were never detected either, so they kept counting against Tomcat's connection limit.

## Fix

- `LegacySseServerTransportProvider`: MetricsHub-owned fork of the SDK SSE transport (MIT, attribution kept) that
  - tracks each session's lifecycle state and rejects requests on uninitialized sessions with HTTP 400 + JSON-RPC error (pre-initialization `ping` is answered directly, pre-initialization notifications are accepted and dropped, broadcasts only reach initialized sessions),
  - bounds the wait for `session.handle(...)` with `mcp.sse.message-timeout` (default 5m) → HTTP 504 instead of a thread held forever; the handling is not cancelled, so a synchronous tool execution is never interrupted and a late result is still delivered on the SSE stream,
  - sends keep-alive pings (`spring.ai.mcp.server.keep-alive-interval`, now 30s) and closes the SSE session when a ping cannot be delivered or is not answered within `mcp.sse.ping-timeout` (5m, generous on purpose so a suspended laptop keeps its session; an error answer counts as an answer), releasing the connection from Tomcat's counter,
  - closes sessions that never complete the handshake within `mcp.sse.initialization-timeout` (2m),
  - closes its streams on `ContextClosedEvent`, before Tomcat stops.
- Streamable HTTP becomes the default MCP transport (`spring.ai.mcp.server.protocol: STREAMABLE`, endpoint `/mcp`, keep-alive 30s); the hardened legacy `/sse` + `/mcp/message` endpoints stay registered alongside through a second `McpSyncServer` sharing the same tool specifications (`mcp.sse.enabled`, default `true`). When a user explicitly sets `protocol: SSE`, the hardened provider replaces the SDK one. The legacy configuration backs off when the MCP server is disabled or in stdio mode.
- `SecurityConfig`: the authenticated matcher now covers `/mcp` and is built from the configured endpoint properties, so a relocated MCP endpoint cannot fall through to the permit-all chain.
- `spring-boot-starter-test` aligned with `${spring.boot.version}`.

## Tests

- `LegacySseServerTransportProviderTest` (MockMvc + stub session): rejection before init, pre-init ping, full handshake, 504 on a never-completing session, eviction of never-initialized sessions, session closed on ping failure/timeout, 404/400 on unknown/missing session, stream completion cleanup.
- `McpTransportsCoexistenceTest` (`@SpringBootTest`, real Tomcat, STREAMABLE + legacy SSE, 200 ms keep-alive): Java SDK SSE client and Streamable client both list/call tools; a raw `tools/list` on an uninitialized SSE session gets 400 immediately (this exact request hung forever before); a real client survives the keep-alive pings; the legacy provider is not exposed as a transport-provider bean.
- `McpLegacySseOnlyModeTest` (`protocol=SSE`): the hardened provider replaces the SDK one, `/mcp` is not served.
- `McpServerDisabledTest` (`spring.ai.mcp.server.enabled=false`): the web application still starts, no legacy beans.
- `SecurityConfigTest`: secured paths follow the configured MCP endpoints.
- Manual run of the packaged agent (TLS + API key) on this branch: `POST /mcp` and `GET /sse` without a key → 401; `tools/list` on an uninitialized SSE session → 400 in 0.25 s; pre-init `ping` answered on the stream; full handshake + `tools/list` → 200; Streamable `initialize` → 200 with `Mcp-Session-Id`; after killing the SSE client, `jstack` shows no thread in `handleMessage`, the Acceptor is `RUNNABLE` and no thread waits on `LimitLatch`.

## Follow-ups (not in this PR)

- TypeScript-SDK based clients (M8B) should migrate to `StreamableHTTPClientTransport` at `https://<host>:31888/mcp`; until then they must recreate their client when they get 400 "not initialized" after an SSE reconnect.
- Documentation site: `/mcp` as the recommended endpoint, `/sse` as legacy, new `mcp.sse.*` keys.
- Tool schemas advertise `arg0`/`arg1` because the build does not emit method parameter names (`-parameters`); tracked separately.
- `MultiHostToolExecutor` joins futures without a wall-clock bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Saturation Tests

### Script 
[saturate.sh](https://github.com/user-attachments/files/31969437/saturate.sh)

### Before
```bash
SENTRY+nassim@pc-nassim2 MINGW64 ~
$ ./saturate.sh *********** 50 116244
round 1: abandoned=50 completed=0 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 2: abandoned=100 completed=0 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 3: abandoned=150 completed=0 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 4: abandoned=199 completed=0 no-session=1 lost-sse=0 conns=2 listening=yes probe HTTP=000 curl=28

>>> NEW CONNECTION/REQUEST TIMED OUT
>>> server did not produce an HTTP response before timeout

>>> Port 31888 STILL shows LISTENING:
  TCP    0.0.0.0:31888          0.0.0.0:0              LISTENING       116244
  TCP    [::]:31888             [::]:0                 LISTENING       116244

Current sockets:
  TCP    0.0.0.0:31888          0.0.0.0:0              LISTENING       116244
  TCP    [::]:31888             [::]:0                 LISTENING       116244
  TCP    [::1]:31888            [::1]:51936            TIME_WAIT       0
  TCP    [::1]:31888            [::1]:61819            CLOSE_WAIT      116244
  TCP    [::1]:31888            [::1]:63965            ESTABLISHED     116244
  TCP    [::1]:50144            [::1]:31888            TIME_WAIT       0
  TCP    [::1]:61819            [::1]:31888            FIN_WAIT_2      144580
  TCP    [::1]:63965            [::1]:31888            ESTABLISHED     87776

Thread dump:
>>> parked in handleMessage: 200
>>> acceptor on LimitLatch:  0
>>> full dump: /c/Users/nassim/park/jstack-final.txt

Final counters:
  rounds:        4
  abandoned:     199
  completed:     0
  no-session:    1
  lost-sse:      0
  connections:   2

```

```bash
$ jstack 116244 | grep -c "WebMvcSseServerTransportProvider.handleMessage"
200
```

Dump: [jstack-final.txt](https://github.com/user-attachments/files/31969725/jstack-final.txt)

### After

```bash
SENTRY+nassim@pc-nassim2 MINGW64 ~
$ ./saturate.sh ************** 50 167500
round 1: abandoned=0 completed=50 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 2: abandoned=0 completed=100 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 3: abandoned=0 completed=150 no-session=0 lost-sse=0 conns=10 listening=yes probe HTTP=200 curl=0
round 4: abandoned=0 completed=200 no-session=0 lost-sse=0 conns=2 listening=yes probe HTTP=200 curl=0
round 5: abandoned=0 completed=250 no-session=0 lost-sse=0 conns=22 listening=yes probe HTTP=200 curl=0
round 6: abandoned=0 completed=300 no-session=0 lost-sse=0 conns=24 listening=yes probe HTTP=200 curl=0
```

```bash
$ jstack 167500 | grep -c "WebMvcSseServerTransportProvider.handleMessage"
0
```
 Dump: [jstack-final.txt](https://github.com/user-attachments/files/31969370/jstack-final.txt)

## Latch Tests

### Script
[latch.sh](https://github.com/user-attachments/files/31979249/latch.sh)
### Before

```bash
$ ./latch.sh ************* 125896 10 240

============================================================
 Tomcat LimitLatch / Legacy SSE cleanup validation
============================================================

Server-side connections before test: 0
Port 31888: LISTENING
Opening SSE sessions sequentially...

  SSE 1/10 ... session established
  SSE 2/10 ... session established
  SSE 3/10 ... session established
  SSE 4/10 ... session established
  SSE 5/10 ... session established
  SSE 6/10 ... session established
  SSE 7/10 ... session established
  SSE 8/10 ... session established
  SSE 9/10 ... session established
  SSE 10/10 ... session established

Established SSE sessions: 10
Server-side connections:  10

Checking whether new HTTP connections can still be served...
Initial probe -> HTTP=000 curl=28

>>> Fresh HTTP request is blocked while the listener is still present.
>>> Live established SSE sessions: 10

--- Tomcat acceptor:
"https-jsse-nio-31888-Acceptor" #1198 [67376] daemon prio=5 os_prio=0 cpu=15.62ms elapsed=53.27s tid=0x00000208b56036e0 nid=67376 waiting on condition  [0x000000c3e1fff000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@25.0.3/Native Method)
        - parking to wait for  <0x000000060948fa70> (a org.apache.tomcat.util.threads.LimitLatch$Sync)
        at java.util.concurrent.locks.LockSupport.park(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@25.0.3/Unknown Source)
        at org.apache.tomcat.util.threads.LimitLatch.countUpOrAwait(LimitLatch.java:122)
        at org.apache.tomcat.util.net.AbstractEndpoint.countUpOrAwaitConnection(AbstractEndpoint.java:1572)
        at org.apache.tomcat.util.net.Acceptor.run(Acceptor.java:115)
        at java.lang.Thread.runWith(java.base@25.0.3/Unknown Source)
        at java.lang.Thread.run(java.base@25.0.3/Unknown Source)

>>> CONFIRMED: Tomcat acceptor is waiting in LimitLatch.countUpOrAwait.

============================================================
 Observation phase
============================================================

No established SSE client will be killed by this script.

Waiting for the SERVER to close uninitialized SSE sessions.

Observation window: 240s
Probe interval:     15s

23:37:58  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:38:16  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:38:34  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:38:53  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:39:11  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:39:29  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:39:48  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:40:07  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:40:26  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:40:45  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:41:03  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:41:21  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:41:39  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:41:57  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10

============================================================
 Verdict
============================================================

>>> FAIL: latch remained saturated for the full observation window.

Initial SSE sessions: 10
Final SSE sessions:   10
Observation:          240s

The established SSE clients stayed alive and new HTTP requests never
became serviceable.

If initializationTimeout is still the default PT2M and maintenance runs
normally, a 240-second observation window should be sufficient.

Check the server logs for:

  Closing MCP SSE session ... because the client did not complete
  the MCP initialization handshake ...

Final server-side connections: 10
Port 31888: LISTENING

--- server sockets:
  TCP    0.0.0.0:31888          0.0.0.0:0              LISTENING       125896
  TCP    [::]:31888             [::]:0                 LISTENING       125896
  TCP    [::1]:31888            [::1]:51922            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51941            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51949            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51967            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51975            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51980            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:51984            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:52001            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:52004            ESTABLISHED     125896
  TCP    [::1]:31888            [::1]:52005            ESTABLISHED     125896

--- final acceptor:
"https-jsse-nio-31888-Acceptor" #1198 [67376] daemon prio=5 os_prio=0 cpu=15.62ms elapsed=312.47s tid=0x00000208b56036e0 nid=67376 waiting on condition  [0x000000c3e1fff000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@25.0.3/Native Method)
        - parking to wait for  <0x000000061adb67e0> (a org.apache.tomcat.util.threads.LimitLatch$Sync)
        at java.util.concurrent.locks.LockSupport.park(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@25.0.3/Unknown Source)
        at org.apache.tomcat.util.threads.LimitLatch.countUpOrAwait(LimitLatch.java:122)
        at org.apache.tomcat.util.net.AbstractEndpoint.countUpOrAwaitConnection(AbstractEndpoint.java:1572)
        at org.apache.tomcat.util.net.Acceptor.run(Acceptor.java:115)
        at java.lang.Thread.runWith(java.base@25.0.3/Unknown Source)
        at java.lang.Thread.run(java.base@25.0.3/Unknown Source)

============================================================

Cleaning up test SSE clients...
```

### After 
```bash
$ ./latch.sh ************* 102416 10 240

============================================================
 Tomcat LimitLatch / Legacy SSE cleanup validation
============================================================

Server-side connections before test: 0
Port 31888: LISTENING
Opening SSE sessions sequentially...

  SSE 1/10 ... session established
  SSE 2/10 ... session established
  SSE 3/10 ... session established
  SSE 4/10 ... session established
  SSE 5/10 ... session established
  SSE 6/10 ... session established
  SSE 7/10 ... session established
  SSE 8/10 ... session established
  SSE 9/10 ... session established
  SSE 10/10 ... session established

Established SSE sessions: 10
Server-side connections:  10

Checking whether new HTTP connections can still be served...
Initial probe -> HTTP=000 curl=28

>>> Fresh HTTP request is blocked while the listener is still present.
>>> Live established SSE sessions: 10

--- Tomcat acceptor:
"https-jsse-nio-31888-Acceptor" #1267 [53620] daemon prio=5 os_prio=0 cpu=0.00ms elapsed=71.74s tid=0x000001fa05b48690 nid=53620 waiting on condition  [0x000000180bdfe000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@25.0.3/Native Method)
        - parking to wait for  <0x0000000614989080> (a org.apache.tomcat.util.threads.LimitLatch$Sync)
        at java.util.concurrent.locks.LockSupport.park(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(java.base@25.0.3/Unknown Source)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@25.0.3/Unknown Source)
        at org.apache.tomcat.util.threads.LimitLatch.countUpOrAwait(LimitLatch.java:122)
        at org.apache.tomcat.util.net.AbstractEndpoint.countUpOrAwaitConnection(AbstractEndpoint.java:1572)
        at org.apache.tomcat.util.net.Acceptor.run(Acceptor.java:115)
        at java.lang.Thread.runWith(java.base@25.0.3/Unknown Source)
        at java.lang.Thread.run(java.base@25.0.3/Unknown Source)

>>> CONFIRMED: Tomcat acceptor is waiting in LimitLatch.countUpOrAwait.

============================================================
 Observation phase
============================================================

No established SSE client will be killed by this script.

Waiting for the SERVER to close uninitialized SSE sessions.

Observation window: 240s
Probe interval:     15s

23:29:00  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:29:19  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:29:37  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:29:55  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:30:13  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:30:31  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:30:50  probe HTTP=000 curl=28  live-sse=10/10  server-conns=11
23:31:08  probe HTTP=000 curl=28  live-sse=10/10  server-conns=10
23:31:24  probe HTTP=200 curl=0  live-sse=0/10  server-conns=0
    ^ server-side/client-independent SSE disappearance detected

============================================================
 Verdict
============================================================

>>> PASS: behaviour is consistent with the FIX.

Initial established SSE sessions: 10
Sessions when HTTP recovered:      0
HTTP recovery observed at:         23:31:24
First SSE cleanup observed at:     23:31:24

The test did NOT kill any established SSE client during observation.

One or more original uninitialized SSE streams therefore disappeared
before/when new HTTP capacity became available.

This is the expected behaviour of the hardened provider:

  initialization timeout
          -> closeSession()
          -> SSE transport completes
          -> Tomcat connection slot becomes available

LimitLatch saturation was also confirmed by jstack.

Final server-side connections: 0
Port 31888: LISTENING

--- server sockets:
  TCP    0.0.0.0:31888          0.0.0.0:0              LISTENING       102416
  TCP    [::]:31888             [::]:0                 LISTENING       102416

--- final acceptor:
"https-jsse-nio-31888-Acceptor" #1267 [53620] daemon prio=5 os_prio=0 cpu=0.00ms elapsed=221.07s tid=0x000001fa05b48690 nid=53620 runnable  [0x000000180bdfe000]
   java.lang.Thread.State: RUNNABLE
        at sun.nio.ch.Net.accept(java.base@25.0.3/Native Method)
        at sun.nio.ch.ServerSocketChannelImpl.implAccept(java.base@25.0.3/Unknown Source)
        at sun.nio.ch.ServerSocketChannelImpl.accept(java.base@25.0.3/Unknown Source)
        at org.apache.tomcat.util.net.NioEndpoint.serverSocketAccept(NioEndpoint.java:535)
        at org.apache.tomcat.util.net.NioEndpoint.serverSocketAccept(NioEndpoint.java:70)
        at org.apache.tomcat.util.net.Acceptor.run(Acceptor.java:127)
        at java.lang.Thread.runWith(java.base@25.0.3/Unknown Source)
        at java.lang.Thread.run(java.base@25.0.3/Unknown Source)


============================================================

Cleaning up test SSE clients...
```
