### PR TITLE
Issue #1344: OS Command protocol test always fails, even on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,33 +27,6 @@
 curl -fsSL https://get.metricshub.com | bash
 ```
 
-## MCP Server
-
-The agent exposes its tools to AI assistants through an MCP server on the web port (`31888` by default, HTTPS, authenticated with an API key created by `metricshub-api-key create <alias>` and passed as `Authorization: Bearer <key>`):
-
-| Transport | Endpoint | Status |
-| --- | --- | --- |
-| Streamable HTTP (recommended) | `https://<host>:31888/mcp` | Default since 3.9.07 (`spring.ai.mcp.server.protocol: STREAMABLE`) |
-| HTTP with SSE (legacy) | `https://<host>:31888/sse` then `POST /mcp/message` | Served alongside for existing clients; hardened against clients that reconnect their event stream without re-initializing |
-
-The legacy transport can be tuned or disabled under the `web:` section of `metricshub.yaml`:
-
-| Setting | Default | Description |
-| --- | --- | --- |
-| `mcp.sse.enabled` | `true` | Serve the legacy SSE endpoints next to `/mcp` (ignored when `spring.ai.mcp.server.protocol` is `SSE`, where they are the only endpoints) |
-| `mcp.sse.message-timeout` | `5m` | Maximum wait for the handling of one message posted on `/mcp/message` (answered with HTTP 504 afterwards; the handling itself is not interrupted) |
-| `mcp.sse.ping-timeout` | `5m` | A session whose keep-alive ping is not answered within this delay is closed |
-| `mcp.sse.initialization-timeout` | `2m` | A session that never completes the `initialize` handshake is closed after this delay |
-| `spring.ai.mcp.server.keep-alive-interval` | `30s` | Keep-alive ping interval of the legacy SSE transport (`spring.ai.mcp.server.streamable-http.keep-alive-interval` for Streamable HTTP) |
-
-## Protocol Health Checks
-
-SSH and OS Command share an extension, but their configurations are distinct: an OS Command configuration alone does not satisfy an SSH check. The guided configuration UI and MCP checks validate that the configuration matches the requested protocol before executing it.
-
-For a localhost resource configured with SSH, MetricsHub preserves its local command execution optimization. A successful check confirms that commands can execute through the collection path; it does not verify the SSH daemon or credentials.
-
-A localhost resource configured only with OS Command reports `metricshub.host.up{protocol="oscommand"}` during collection. A successful check also contributes to `metricshub.host.observed=1`, which means at least one protocol check succeeded. OS Command alone does not establish the health of a remote host.
-
 ## Project Structure
 
 This is a multi-module project:
@@ -85,14 +58,6 @@ This is a multi-module project:
 
 > [!TIP]
 > Looking for connectors? Check the [MetricsHub Community Connectors](https://github.com/metricshub/community-connectors) repository.
-
-## File log capture
-
-When a file source uses wildcards or multiple paths, LOG mode includes an empty
-`<<<LOG:file="...">>>` / `<<<END_LOG>>>` block for each accessible file on its first
-poll and on subsequent polls with no new content. The first poll initializes the
-cursor without reading existing content. A single literal path retains its
-content-only output format.
 
 ## How to build the Project
 
@@ -240,3 +205,7 @@ To update source files with the proper header, simply execute the below command:
 ```bash
 mvn license:update-file-header
 ```
+
+## Technical Notes
+
+See [Technical Notes](TECHNICAL_NOTES.md) for MCP server settings, file log capture behavior, and OS Command/SSH health checks.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ The legacy transport can be tuned or disabled under the `web:` section of `metri
 | `mcp.sse.initialization-timeout` | `2m` | A session that never completes the `initialize` handshake is closed after this delay |
 | `spring.ai.mcp.server.keep-alive-interval` | `30s` | Keep-alive ping interval of the legacy SSE transport (`spring.ai.mcp.server.streamable-http.keep-alive-interval` for Streamable HTTP) |
 
+## Protocol Health Checks
+
+SSH and OS Command share an extension, but their configurations are distinct: an OS Command configuration alone does not satisfy an SSH check. The guided configuration UI and MCP checks validate that the configuration matches the requested protocol before executing it.
+
+For a localhost resource configured with SSH, MetricsHub preserves its local command execution optimization. A successful check confirms that commands can execute through the collection path; it does not verify the SSH daemon or credentials.
+
+A localhost resource configured only with OS Command reports `metricshub.host.up{protocol="oscommand"}` during collection. A successful check also contributes to `metricshub.host.observed=1`, which means at least one protocol check succeeded. OS Command alone does not establish the health of a remote host.
+
 ## Project Structure
 
 This is a multi-module project:
@@ -232,4 +240,3 @@ To update source files with the proper header, simply execute the below command:
 ```bash
 mvn license:update-file-header
 ```
-

--- a/TECHNICAL_NOTES.md
+++ b/TECHNICAL_NOTES.md
@@ -1,0 +1,62 @@
+# Technical Notes
+
+Detailed behavior and configuration notes for MetricsHub Community.
+
+- [MCP Server](#mcp-server)
+- [File log capture](#file-log-capture)
+- [OS Command and SSH health checks](#os-command-and-ssh-health-checks)
+
+## MCP Server
+
+The agent exposes its tools to AI assistants through an MCP server on the web port (`31888` by default, HTTPS, authenticated with an API key created by `metricshub-api-key create <alias>` and passed as `Authorization: Bearer <key>`):
+
+| Transport | Endpoint | Status |
+| --- | --- | --- |
+| Streamable HTTP (recommended) | `https://<host>:31888/mcp` | Default since 3.9.07 (`spring.ai.mcp.server.protocol: STREAMABLE`) |
+| HTTP with SSE (legacy) | `https://<host>:31888/sse` then `POST /mcp/message` | Served alongside for existing clients; hardened against clients that reconnect their event stream without re-initializing |
+
+The legacy transport can be tuned or disabled under the `web:` section of `metricshub.yaml`:
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `mcp.sse.enabled` | `true` | Serve the legacy SSE endpoints next to `/mcp` (ignored when `spring.ai.mcp.server.protocol` is `SSE`, where they are the only endpoints) |
+| `mcp.sse.message-timeout` | `5m` | Maximum wait for the handling of one message posted on `/mcp/message` (answered with HTTP 504 afterwards; the handling itself is not interrupted) |
+| `mcp.sse.ping-timeout` | `5m` | A session whose keep-alive ping is not answered within this delay is closed |
+| `mcp.sse.initialization-timeout` | `2m` | A session that never completes the `initialize` handshake is closed after this delay |
+| `spring.ai.mcp.server.keep-alive-interval` | `30s` | Keep-alive ping interval of the legacy SSE transport (`spring.ai.mcp.server.streamable-http.keep-alive-interval` for Streamable HTTP) |
+
+## File log capture
+
+When a file source uses wildcards or multiple paths, LOG mode includes an empty
+`<<<LOG:file="...">>>` / `<<<END_LOG>>>` block for each accessible file on its first
+poll and on subsequent polls with no new content. The first poll initializes the
+cursor without reading existing content. A single literal path retains its
+content-only output format.
+
+## OS Command and SSH health checks
+
+### Local execution
+
+A local resource identifies the machine running MetricsHub, whether through `localhost`, a loopback address, or a hostname/IP address resolving to a local network interface. The hostname does not need to be the literal `localhost`.
+
+SSH and OS Command share an extension, but their configurations are distinct. The guided configuration UI and MCP checks validate that the configuration matches the requested protocol before executing it: an OS Command configuration alone cannot satisfy an SSH check, and vice versa.
+
+For SSH-configured local resources, MetricsHub preserves the local command execution optimization used during collection. A successful local check confirms that commands can execute through this collection path; it does not validate the SSH daemon or credentials. Requesting an SSH check does not force a network connection when local execution is used.
+
+### Collection metrics
+
+| Configuration and execution path | Health check | Protocol label |
+| --- | --- | --- |
+| OS Command only, local resource | Local shell command | `oscommand` |
+| SSH configured, local command execution | Local shell command | `ssh` |
+| SSH configured, remote command execution | Command over SSH | `ssh` |
+
+The protocol label identifies the configured protocol being checked, not necessarily the transport used by the local execution optimization. When both SSH and OS Command are configured for collection, the shared extension follows the SSH health-check path.
+
+A performed check reports `metricshub.host.up{protocol="oscommand"}` or `metricshub.host.up{protocol="ssh"}` as `1` on success and `0` on failure. A successful OS Command check therefore contributes to `metricshub.host.observed=1`, just like any other successful protocol check. The observed metric is `0` if no protocol check succeeds.
+
+For a remote resource configured only with OS Command, the health check is skipped: no OS Command host-up metric is emitted, and the skipped check does not count as a successful observation. Running a command on the MetricsHub machine cannot establish the health of a remote host.
+
+### OS Command timeout
+
+The local OS Command health check uses the configured OS Command timeout, including an override supplied by the guided UI or MCP. If the configured timeout is absent or not positive, it defaults to 30 seconds.

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/ProtocolCheckService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/ProtocolCheckService.java
@@ -65,8 +65,8 @@ public class ProtocolCheckService implements IMCPToolService {
 	 * Checks whether the specified host is reachable using the specified protocol.
 	 *
 	 * @param hostname the target host to check
-	 * @param protocol the name of the protocol to check (e.g., http, ipmi, jdbc, jmx, snmp, snmpv3, ssh, wbem, winrm, wmi)
-	 * @param timeout optional timeout for the HTTP check in seconds
+	 * @param protocol the name of the protocol to check (e.g., http, ipmi, jdbc, jmx, oscommand, snmp, snmpv3, ssh, wbem, winrm, wmi)
+	 * @param timeout optional timeout for the protocol check in seconds
 	 * @param poolSize optional pool size for concurrent protocol checks; defaults to {@value #DEFAULT_PROTOCOL_CHECK_POOL_SIZE} when {@code null} or ≤ 0
 	 * @return a {@link ProtocolCheckResponse} indicating whether the host is reachable and how long the check took
 	 */
@@ -74,14 +74,16 @@ public class ProtocolCheckService implements IMCPToolService {
 		name = "CheckProtocol",
 		description = """
 		Determines if the specified hosts are accessible using a given protocol.
-		Supported protocols include: http, ipmi, jdbc, jmx, snmp, snmpv3, ssh, wbem, winrm, and wmi.
+		Supported protocols include: http, ipmi, jdbc, jmx, oscommand, snmp, snmpv3, ssh, wbem, winrm, and wmi.
+		OS Command (oscommand) checks local command execution and applies only to localhost.
+		SSH checks on localhost also use local command execution, following the collection optimization.
 		Provides a response detailing the host reachability status along with the response time.
 		"""
 	)
 	public MultiHostToolResponse<ProtocolCheckResponse> checkProtocol(
 		@ToolParam(description = "The hostname(s) to check") final List<String> hostname,
 		@ToolParam(
-			description = "The name of the protocol to check. Supported protocols include: http, ipmi, jdbc, jmx, snmp, snmpv3, ssh, wbem, winrm, and wmi",
+			description = "The name of the protocol to check. Supported protocols include: http, ipmi, jdbc, jmx, oscommand (localhost only), snmp, snmpv3, ssh, wbem, winrm, and wmi",
 			required = true
 		) final String protocol,
 		@ToolParam(description = "Timeout for the protocol check in seconds", required = false) final Long timeout,

--- a/metricshub-agent/src/main/java/org/metricshub/web/mcp/ProtocolCheckService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/mcp/ProtocolCheckService.java
@@ -75,15 +75,19 @@ public class ProtocolCheckService implements IMCPToolService {
 		description = """
 		Determines if the specified hosts are accessible using a given protocol.
 		Supported protocols include: http, ipmi, jdbc, jmx, oscommand, snmp, snmpv3, ssh, wbem, winrm, and wmi.
-		OS Command (oscommand) checks local command execution and applies only to localhost.
-		SSH checks on localhost also use local command execution, following the collection optimization.
+		OS Command (oscommand) checks command execution on the machine running MetricsHub.
+		The target may be localhost, a loopback address, or a hostname/IP address resolving to that machine.
+		SSH checks targeting that machine also use local command execution, following the collection optimization.
 		Provides a response detailing the host reachability status along with the response time.
 		"""
 	)
 	public MultiHostToolResponse<ProtocolCheckResponse> checkProtocol(
 		@ToolParam(description = "The hostname(s) to check") final List<String> hostname,
 		@ToolParam(
-			description = "The name of the protocol to check. Supported protocols include: http, ipmi, jdbc, jmx, oscommand (localhost only), snmp, snmpv3, ssh, wbem, winrm, and wmi",
+			description = """
+			The name of the protocol to check. Supported protocols include: http, ipmi, jdbc, jmx, oscommand, snmp, snmpv3, ssh, wbem, winrm, and wmi.
+			oscommand applies to the machine running MetricsHub, including localhost, loopback addresses, and hostnames/IPs resolving to that machine.
+			""",
 			required = true
 		) final String protocol,
 		@ToolParam(description = "Timeout for the protocol check in seconds", required = false) final Long timeout,

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
@@ -272,9 +272,8 @@ public class ProtocolHealthCheckService {
 				builder.osCommandExecutesRemotely(true);
 			}
 		} else if ("oscommand".equalsIgnoreCase(protocol)) {
-			// OS Command without SSH only runs commands locally: the check is an explicit,
-			// on-demand local shell test, never part of the collected protocol health metrics.
-			builder.mustCheckOsCommandStatus(true).osCommandExecutesLocally(isLocal);
+			// OS Command without SSH only runs commands locally
+			builder.osCommandExecutesLocally(isLocal);
 		}
 
 		return builder.build();

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
@@ -271,6 +271,10 @@ public class ProtocolHealthCheckService {
 			} else {
 				builder.osCommandExecutesRemotely(true);
 			}
+		} else if ("oscommand".equalsIgnoreCase(protocol)) {
+			// OS Command without SSH only runs commands locally: the check is an explicit,
+			// on-demand local shell test, never part of the collected protocol health metrics.
+			builder.mustCheckOsCommandStatus(true).osCommandExecutesLocally(isLocal);
 		}
 
 		return builder.build();

--- a/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
+++ b/metricshub-agent/src/main/java/org/metricshub/web/service/ProtocolHealthCheckService.java
@@ -149,12 +149,6 @@ public class ProtocolHealthCheckService {
 		final IProtocolExtension extension
 	) {
 		try {
-			if (!extension.isValidConfiguration(configuration)) {
-				return ProtocolCheckResponse.builder()
-					.hostname(hostname)
-					.errorMessage("Invalid protocol configuration")
-					.build();
-			}
 			return executeProtocolCheck(
 				hostname,
 				protocol,
@@ -214,6 +208,10 @@ public class ProtocolHealthCheckService {
 		final IConfiguration configuration,
 		final IProtocolExtension extension
 	) {
+		if (!configuration.isCorrespondingProtocol(protocol) || !extension.isValidConfiguration(configuration)) {
+			return ProtocolCheckResponse.builder().hostname(hostname).errorMessage("Invalid protocol configuration").build();
+		}
+
 		final long resolvedTimeout = NumberHelper.getPositiveOrDefault(
 			timeoutOverride,
 			DEFAULT_PROTOCOL_CHECK_TIMEOUT

--- a/metricshub-agent/src/test/java/org/metricshub/web/service/ProtocolHealthCheckServiceTest.java
+++ b/metricshub-agent/src/test/java/org/metricshub/web/service/ProtocolHealthCheckServiceTest.java
@@ -27,23 +27,45 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.metricshub.agent.context.AgentContext;
+import org.metricshub.engine.client.ClientsExecutor;
+import org.metricshub.engine.configuration.HostConfiguration;
+import org.metricshub.engine.configuration.IConfiguration;
 import org.metricshub.engine.extension.ExtensionManager;
+import org.metricshub.engine.strategy.collect.ProtocolHealthCheckStrategy;
+import org.metricshub.engine.telemetry.HostProperties;
+import org.metricshub.engine.telemetry.Monitor;
+import org.metricshub.engine.telemetry.TelemetryManager;
+import org.metricshub.engine.telemetry.metric.NumberMetric;
 import org.metricshub.extension.http.HttpConfiguration;
 import org.metricshub.extension.http.HttpExtension;
+import org.metricshub.extension.oscommand.OsCommandConfiguration;
+import org.metricshub.extension.oscommand.OsCommandExtension;
+import org.metricshub.extension.oscommand.OsCommandService;
 import org.metricshub.extension.oscommand.SshConfiguration;
 import org.metricshub.web.AgentContextHolder;
 import org.metricshub.web.mcp.ProtocolCheckResponse;
+import org.mockito.MockedConstruction;
 
 class ProtocolHealthCheckServiceTest {
 
@@ -185,5 +207,134 @@ class ProtocolHealthCheckServiceTest {
 
 		assertEquals(HOSTNAME, response.getHostname());
 		assertFalse(response.isReachable());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ssh", "oscommand" })
+	void testCheckFromAgentContextRejectsSiblingProtocolConfiguration(final String protocol) throws Exception {
+		final IConfiguration configuration = "ssh".equals(protocol)
+			? OsCommandConfiguration.builder().build()
+			: SshConfiguration.sshConfigurationBuilder().build();
+		final OsCommandExtension extension = configureLocalCommandChecks(Map.of(configuration.getClass(), configuration));
+
+		final ProtocolCheckResponse response = service.checkFromAgentContext("localhost", protocol, 5L, extension);
+
+		assertFalse(response.isReachable());
+		verify(extension, never()).checkProtocol(any());
+		verify(extension, never()).buildConfiguration(anyString(), any(), any());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "ssh", "oscommand" })
+	void testCheckWithInlineConfigurationRejectsSiblingProtocolConfiguration(final String protocol) {
+		final String siblingProtocol = "ssh".equals(protocol) ? "oscommand" : "ssh";
+		final IConfiguration configuration = "ssh".equals(protocol)
+			? OsCommandConfiguration.builder().build()
+			: SshConfiguration.sshConfigurationBuilder().build();
+		final OsCommandExtension extension = configureLocalCommandChecks(Map.of());
+
+		final ProtocolCheckResponse response = service.checkWithInlineConfiguration(
+			"localhost",
+			protocol,
+			Map.of(siblingProtocol, configuration)
+		);
+
+		assertEquals("Invalid protocol configuration", response.getErrorMessage());
+		assertFalse(response.isReachable());
+		verify(extension, never()).checkProtocol(any());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "SSH", "oscommand" })
+	void testLocalChecksUseTheRequestedConfigurationAndKeepLocalExecution(final String protocol) throws Exception {
+		try (
+			MockedConstruction<OsCommandService> construction = mockConstruction(
+				OsCommandService.class,
+				(commandService, context) ->
+					when(commandService.runLocalCommand(anyString(), anyLong(), any())).thenReturn("test")
+			)
+		) {
+			final OsCommandExtension extension = configureLocalCommandChecks(
+				Map.of(
+					SshConfiguration.class,
+					SshConfiguration.sshConfigurationBuilder().build(),
+					OsCommandConfiguration.class,
+					OsCommandConfiguration.builder().timeout(5L).build()
+				)
+			);
+
+			assertTrue(service.checkFromAgentContext("localhost", protocol, 5L, extension).isReachable());
+			verify(extension).checkProtocol(
+				argThat(telemetryManager ->
+					telemetryManager
+						.getHostConfiguration()
+						.getConfigurations()
+						.values()
+						.stream()
+						.allMatch(configuration -> configuration.isCorrespondingProtocol(protocol))
+				)
+			);
+
+			final OsCommandService commandService = construction.constructed().getFirst();
+			verify(commandService).runLocalCommand(eq("echo test"), anyLong(), any());
+			when(commandService.runLocalCommand(anyString(), anyLong(), any())).thenReturn(null);
+			assertFalse(service.checkFromAgentContext("localhost", protocol, 5L, extension).isReachable());
+			verify(commandService, never()).runSshCommand(anyString(), anyString(), any(), anyLong(), any(), any(), any());
+		}
+	}
+
+	@Test
+	void testOsCommandCollectionReportsObservedWithOsCommandLabel() throws Exception {
+		try (
+			MockedConstruction<OsCommandService> construction = mockConstruction(
+				OsCommandService.class,
+				(commandService, context) ->
+					when(commandService.runLocalCommand(anyString(), anyLong(), any())).thenReturn("test")
+			)
+		) {
+			final Monitor monitor = Monitor.builder().type("host").isEndpoint(true).build();
+			final TelemetryManager telemetryManager = TelemetryManager.builder()
+				.hostConfiguration(
+					HostConfiguration.builder()
+						.hostname("localhost")
+						.configurations(Map.of(OsCommandConfiguration.class, OsCommandConfiguration.builder().timeout(5L).build()))
+						.build()
+				)
+				.hostProperties(HostProperties.builder().isLocalhost(true).mustCheckSshStatus(true).build())
+				.monitors(new HashMap<>(Map.of("host", new HashMap<>(Map.of("localhost", monitor)))))
+				.strategyTime(1L)
+				.build();
+			final ExtensionManager extensionManager = ExtensionManager.builder()
+				.withProtocolExtensions(List.of(new OsCommandExtension()))
+				.build();
+
+			new ProtocolHealthCheckStrategy(telemetryManager, 1L, mock(ClientsExecutor.class), extensionManager).run();
+
+			assertEquals(1.0, monitor.getMetric("metricshub.host.up{protocol=\"oscommand\"}", NumberMetric.class).getValue());
+			assertEquals(1.0, monitor.getMetric("metricshub.host.observed", NumberMetric.class).getValue());
+			assertNull(monitor.getMetric("metricshub.host.up{protocol=\"ssh\"}", NumberMetric.class));
+			verify(construction.constructed().getFirst()).runLocalCommand("echo test", 5L, null);
+		}
+	}
+
+	private OsCommandExtension configureLocalCommandChecks(
+		final Map<Class<? extends IConfiguration>, IConfiguration> configurations
+	) {
+		final OsCommandExtension extension = spy(new OsCommandExtension());
+		when(agentContextHolder.getAgentContext().getExtensionManager()).thenReturn(
+			ExtensionManager.builder().withProtocolExtensions(List.of(extension)).build()
+		);
+		when(agentContextHolder.getAgentContext().getTelemetryManagers()).thenReturn(
+			Map.of(
+				"resourceGroup",
+				Map.of(
+					"localhost",
+					TelemetryManager.builder()
+						.hostConfiguration(HostConfiguration.builder().hostname("localhost").configurations(configurations).build())
+						.build()
+				)
+			)
+		);
+		return extension;
 	}
 }

--- a/metricshub-engine/src/main/java/org/metricshub/engine/extension/IProtocolExtension.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/extension/IProtocolExtension.java
@@ -158,6 +158,20 @@ public interface IProtocolExtension {
 	String getIdentifier();
 
 	/**
+	 * Returns the identifier of the protocol actually exercised by {@link #checkProtocol(TelemetryManager)}
+	 * for the given host.
+	 * <p>
+	 * Extensions handling several protocols override this method so that health metrics are labelled with
+	 * the protocol that was really checked. The default implementation returns {@link #getIdentifier()}.
+	 *
+	 * @param telemetryManager The telemetry manager holding the host configuration and properties.
+	 * @return The protocol identifier as a string.
+	 */
+	default String getIdentifier(TelemetryManager telemetryManager) {
+		return getIdentifier();
+	}
+
+	/**
 	 * Executes a query based on the provided configuration and query parameters.
 	 *
 	 * @param configuration the IConfiguration object containing the configuration details.

--- a/metricshub-engine/src/main/java/org/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategy.java
@@ -119,6 +119,9 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 					telemetryManager.getHostname(),
 					telemetryManager.getConnectorStore()
 				);
+				// The protocol that was really checked: an extension handling several protocols
+				// reports the one it exercised for this host
+				final String identifier = protocolExtension.getIdentifier(telemetryManager);
 
 				Double up = DOWN;
 				if (Boolean.TRUE.equals(isUp)) {
@@ -126,7 +129,7 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 					// Collect protocol check response time metric if response up is true
 					metricFactory.collectNumberMetric(
 						endpointHostMonitor,
-						RESPONSE_TIME_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
+						RESPONSE_TIME_METRIC_FORMAT.formatted(identifier),
 						responseTime,
 						strategyTime
 					);
@@ -135,7 +138,7 @@ public class ProtocolHealthCheckStrategy extends AbstractStrategy {
 				// Collect protocol check metric
 				metricFactory.collectNumberMetric(
 					endpointHostMonitor,
-					UP_METRIC_FORMAT.formatted(protocolExtension.getIdentifier()),
+					UP_METRIC_FORMAT.formatted(identifier),
 					up,
 					strategyTime
 				);

--- a/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/HostProperties.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/HostProperties.java
@@ -58,6 +58,13 @@ public class HostProperties {
 	private boolean osCommandExecutesRemotely;
 	private boolean mustCheckSshStatus;
 
+	/**
+	 * Whether the local shell must be tested for a host configured with an OS Command configuration
+	 * and no SSH configuration. Only set by on-demand protocol checks: the collect strategy leaves it
+	 * {@code false} so that a local shell test is never published as an SSH health metric.
+	 */
+	private boolean mustCheckOsCommandStatus;
+
 	@Default
 	private Map<String, ConnectorNamespace> connectorNamespaces = new ConcurrentHashMap<>();
 

--- a/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/HostProperties.java
+++ b/metricshub-engine/src/main/java/org/metricshub/engine/telemetry/HostProperties.java
@@ -58,13 +58,6 @@ public class HostProperties {
 	private boolean osCommandExecutesRemotely;
 	private boolean mustCheckSshStatus;
 
-	/**
-	 * Whether the local shell must be tested for a host configured with an OS Command configuration
-	 * and no SSH configuration. Only set by on-demand protocol checks: the collect strategy leaves it
-	 * {@code false} so that a local shell test is never published as an SSH health metric.
-	 */
-	private boolean mustCheckOsCommandStatus;
-
 	@Default
 	private Map<String, ConnectorNamespace> connectorNamespaces = new ConcurrentHashMap<>();
 

--- a/metricshub-engine/src/test/java/org/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategyTest.java
+++ b/metricshub-engine/src/test/java/org/metricshub/engine/strategy/collect/ProtocolHealthCheckStrategyTest.java
@@ -89,7 +89,7 @@ class ProtocolHealthCheckStrategyTest {
 
 		final String protocol = "snmp";
 
-		doReturn(protocol).when(protocolExtensionMock).getIdentifier();
+		doReturn(protocol).when(protocolExtensionMock).getIdentifier(any(TelemetryManager.class));
 
 		doReturn(Optional.of(true)).when(protocolExtensionMock).checkProtocol(any(TelemetryManager.class));
 
@@ -132,7 +132,7 @@ class ProtocolHealthCheckStrategyTest {
 			.isValidConfiguration(telemetryManager.getHostConfiguration().getConfigurations().get(TestConfiguration.class));
 
 		final String protocol = "ssh";
-		doReturn(protocol).when(protocolExtensionMock).getIdentifier();
+		doReturn(protocol).when(protocolExtensionMock).getIdentifier(any(TelemetryManager.class));
 		doReturn(Optional.of(false)).when(protocolExtensionMock).checkProtocol(any(TelemetryManager.class));
 
 		final ProtocolHealthCheckStrategy healthCheckStrategy = new ProtocolHealthCheckStrategy(
@@ -170,8 +170,8 @@ class ProtocolHealthCheckStrategyTest {
 			.when(additionalProtocolExtensionMock)
 			.isValidConfiguration(telemetryManager.getHostConfiguration().getConfigurations().get(TestConfiguration.class));
 
-		doReturn("snmp").when(protocolExtensionMock).getIdentifier();
-		doReturn("ssh").when(additionalProtocolExtensionMock).getIdentifier();
+		doReturn("snmp").when(protocolExtensionMock).getIdentifier(any(TelemetryManager.class));
+		doReturn("ssh").when(additionalProtocolExtensionMock).getIdentifier(any(TelemetryManager.class));
 		doReturn(Optional.of(false)).when(protocolExtensionMock).checkProtocol(any(TelemetryManager.class));
 		doReturn(Optional.of(true)).when(additionalProtocolExtensionMock).checkProtocol(any(TelemetryManager.class));
 

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
@@ -44,7 +44,6 @@ import org.metricshub.engine.connector.model.monitor.task.source.Source;
 import org.metricshub.engine.extension.IProtocolExtension;
 import org.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.metricshub.engine.strategy.source.SourceTable;
-import org.metricshub.engine.telemetry.HostProperties;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.extension.oscommand.file.FileSourceProcessor;
 
@@ -93,6 +92,16 @@ public class OsCommandExtension implements IProtocolExtension {
 	 * SSH test command to execute
 	 */
 	public static final String SSH_TEST_COMMAND = "echo test";
+
+	/**
+	 * Identifier reported for the SSH protocol health check
+	 */
+	public static final String SSH_IDENTIFIER = "ssh";
+
+	/**
+	 * Identifier reported for the OS Command protocol health check
+	 */
+	public static final String OS_COMMAND_IDENTIFIER = "oscommand";
 
 	@Override
 	public boolean isValidConfiguration(IConfiguration configuration) {
@@ -253,9 +262,8 @@ public class OsCommandExtension implements IProtocolExtension {
 	 * <p>
 	 * Such a configuration only executes commands on the local machine
 	 * (see {@code OsCommandService.runOsCommand}), so the check is a local command test and is
-	 * skipped for remote hosts. It is also skipped unless the caller explicitly asked for it through
-	 * {@link org.metricshub.engine.telemetry.HostProperties#isMustCheckOsCommandStatus()}: the collect
-	 * strategy labels health metrics with {@link #getIdentifier()}, and a local shell test is not SSH.
+	 * skipped for remote hosts. The result is reported as {@value #OS_COMMAND_IDENTIFIER}, not as SSH:
+	 * see {@link #getIdentifier(TelemetryManager)}.
 	 *
 	 * @param telemetryManager The telemetry manager holding the host configuration and properties
 	 * @return {@code true} or {@code false} when the local shell could be tested, empty otherwise
@@ -266,14 +274,8 @@ public class OsCommandExtension implements IProtocolExtension {
 			.getConfigurations()
 			.get(OsCommandConfiguration.class);
 
-		final HostProperties hostProperties = telemetryManager.getHostProperties();
-
-		if (osCommandConfiguration == null || !hostProperties.isMustCheckOsCommandStatus()) {
-			return Optional.empty();
-		}
-
 		// OS Command without SSH cannot reach a remote host, there is nothing to check there
-		if (!hostProperties.isLocalhost()) {
+		if (osCommandConfiguration == null || !telemetryManager.getHostProperties().isLocalhost()) {
 			return Optional.empty();
 		}
 
@@ -387,7 +389,15 @@ public class OsCommandExtension implements IProtocolExtension {
 
 	@Override
 	public String getIdentifier() {
-		return "ssh";
+		return SSH_IDENTIFIER;
+	}
+
+	@Override
+	public String getIdentifier(final TelemetryManager telemetryManager) {
+		// Mirror checkProtocol: without an SSH configuration, the check is a local OS command test
+		return telemetryManager.getHostConfiguration().getConfigurations().containsKey(SshConfiguration.class)
+			? SSH_IDENTIFIER
+			: OS_COMMAND_IDENTIFIER;
 	}
 
 	/**

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
@@ -124,8 +124,13 @@ public class OsCommandExtension implements IProtocolExtension {
 			.getConfigurations()
 			.get(SshConfiguration.class);
 
-		// Stop the SSH health check if there is not any SSH configuration
-		if (sshConfiguration == null || !telemetryManager.getHostProperties().isMustCheckSshStatus()) {
+		// Without an SSH configuration, OS commands can only run locally: check the local shell instead.
+		if (sshConfiguration == null) {
+			return checkLocalOsCommand(telemetryManager);
+		}
+
+		// Stop the SSH health check when the SSH status doesn't have to be checked
+		if (!telemetryManager.getHostProperties().isMustCheckSshStatus()) {
 			return Optional.empty();
 		}
 
@@ -240,6 +245,33 @@ public class OsCommandExtension implements IProtocolExtension {
 		log.error(errorMessage);
 		log.debug(errorMessage);
 		throw new InvalidConfigurationException(errorMessage);
+	}
+
+	/**
+	 * Checks a host configured with an {@link OsCommandConfiguration} but no {@link SshConfiguration}.
+	 * <p>
+	 * Such a configuration only executes commands on the local machine
+	 * (see {@code OsCommandService.runOsCommand}), so the check is a local command test and is
+	 * skipped for remote hosts.
+	 *
+	 * @param telemetryManager The telemetry manager holding the host configuration and properties
+	 * @return {@code true} or {@code false} when the local shell could be tested, empty otherwise
+	 */
+	private Optional<Boolean> checkLocalOsCommand(final TelemetryManager telemetryManager) {
+		final IConfiguration osCommandConfiguration = telemetryManager
+			.getHostConfiguration()
+			.getConfigurations()
+			.get(OsCommandConfiguration.class);
+
+		if (osCommandConfiguration == null || !telemetryManager.getHostProperties().isLocalhost()) {
+			return Optional.empty();
+		}
+
+		final String hostname = telemetryManager.getHostname(List.of(OsCommandConfiguration.class));
+
+		log.info("Hostname {} - Checking OS Command protocol status. Running a local 'echo test' command.", hostname);
+
+		return Optional.of(UP.equals(localSshTest(hostname)));
 	}
 
 	/**

--- a/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
+++ b/metricshub-oscommand-extension/src/main/java/org/metricshub/extension/oscommand/OsCommandExtension.java
@@ -44,6 +44,7 @@ import org.metricshub.engine.connector.model.monitor.task.source.Source;
 import org.metricshub.engine.extension.IProtocolExtension;
 import org.metricshub.engine.strategy.detection.CriterionTestResult;
 import org.metricshub.engine.strategy.source.SourceTable;
+import org.metricshub.engine.telemetry.HostProperties;
 import org.metricshub.engine.telemetry.TelemetryManager;
 import org.metricshub.extension.oscommand.file.FileSourceProcessor;
 
@@ -145,7 +146,7 @@ public class OsCommandExtension implements IProtocolExtension {
 
 		// Execute Local test
 		if (telemetryManager.getHostProperties().isOsCommandExecutesLocally()) {
-			sshResult = localSshTest(hostname);
+			sshResult = localSshTest(hostname, OsCommandConfiguration.DEFAULT_TIMEOUT);
 		}
 
 		if (telemetryManager.getHostProperties().isOsCommandExecutesRemotely()) {
@@ -252,18 +253,27 @@ public class OsCommandExtension implements IProtocolExtension {
 	 * <p>
 	 * Such a configuration only executes commands on the local machine
 	 * (see {@code OsCommandService.runOsCommand}), so the check is a local command test and is
-	 * skipped for remote hosts.
+	 * skipped for remote hosts. It is also skipped unless the caller explicitly asked for it through
+	 * {@link org.metricshub.engine.telemetry.HostProperties#isMustCheckOsCommandStatus()}: the collect
+	 * strategy labels health metrics with {@link #getIdentifier()}, and a local shell test is not SSH.
 	 *
 	 * @param telemetryManager The telemetry manager holding the host configuration and properties
 	 * @return {@code true} or {@code false} when the local shell could be tested, empty otherwise
 	 */
 	private Optional<Boolean> checkLocalOsCommand(final TelemetryManager telemetryManager) {
-		final IConfiguration osCommandConfiguration = telemetryManager
+		final OsCommandConfiguration osCommandConfiguration = (OsCommandConfiguration) telemetryManager
 			.getHostConfiguration()
 			.getConfigurations()
 			.get(OsCommandConfiguration.class);
 
-		if (osCommandConfiguration == null || !telemetryManager.getHostProperties().isLocalhost()) {
+		final HostProperties hostProperties = telemetryManager.getHostProperties();
+
+		if (osCommandConfiguration == null || !hostProperties.isMustCheckOsCommandStatus()) {
+			return Optional.empty();
+		}
+
+		// OS Command without SSH cannot reach a remote host, there is nothing to check there
+		if (!hostProperties.isLocalhost()) {
 			return Optional.empty();
 		}
 
@@ -271,18 +281,31 @@ public class OsCommandExtension implements IProtocolExtension {
 
 		log.info("Hostname {} - Checking OS Command protocol status. Running a local 'echo test' command.", hostname);
 
-		return Optional.of(UP.equals(localSshTest(hostname)));
+		return Optional.of(UP.equals(localSshTest(hostname, resolveTimeout(osCommandConfiguration))));
+	}
+
+	/**
+	 * Returns the timeout configured for the OS commands, or {@link OsCommandConfiguration#DEFAULT_TIMEOUT}
+	 * when it is not set to a positive value.
+	 *
+	 * @param osCommandConfiguration The OS Command configuration to read the timeout from
+	 * @return The timeout in seconds
+	 */
+	private static long resolveTimeout(final OsCommandConfiguration osCommandConfiguration) {
+		final Long timeout = osCommandConfiguration.getTimeout();
+		return timeout != null && timeout > 0 ? timeout : OsCommandConfiguration.DEFAULT_TIMEOUT;
 	}
 
 	/**
 	 * Performs a local Os Command test to determine whether the SSH protocol is UP.
 	 *
 	 * @param hostname  The hostname on which we perform health check
+	 * @param timeout   The timeout, in seconds, granted to the test command
 	 * @return The SSH health check result after performing the tests
 	 */
-	private Double localSshTest(String hostname) {
+	private Double localSshTest(String hostname, long timeout) {
 		try {
-			if (osCommandService.runLocalCommand(SSH_TEST_COMMAND, OsCommandConfiguration.DEFAULT_TIMEOUT, null) == null) {
+			if (osCommandService.runLocalCommand(SSH_TEST_COMMAND, timeout, null) == null) {
 				log.debug(
 					"Hostname {} - Checking SSH protocol status. Local OS command has not returned any results.",
 					hostname

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -431,6 +431,39 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
+	void testCheckOsCommandHealthLocally() throws Exception {
+		final OsCommandService osCommandService = mock(OsCommandService.class);
+		final OsCommandExtension osCommandExtension = new OsCommandExtension(osCommandService);
+
+		// Create a telemetry manager holding an OS Command configuration only, no SSH.
+		setup();
+		final TelemetryManager telemetryManager = TelemetryManager.builder()
+			.monitors(monitors)
+			.hostConfiguration(
+				HostConfiguration.builder()
+					.hostId(LOCALHOST)
+					.hostname(LOCALHOST)
+					.configurations(Map.of(OsCommandConfiguration.class, OsCommandConfiguration.builder().build()))
+					.build()
+			)
+			.build();
+		telemetryManager.getHostProperties().setLocalhost(true);
+
+		doReturn(SUCCESS_RESPONSE).when(osCommandService).runLocalCommand(anyString(), anyLong(), any());
+
+		assertTrue(osCommandExtension.checkProtocol(telemetryManager).get());
+
+		doReturn(null).when(osCommandService).runLocalCommand(anyString(), anyLong(), any());
+
+		assertFalse(osCommandExtension.checkProtocol(telemetryManager).get());
+
+		// OS Command alone never reaches a remote host: nothing to check.
+		telemetryManager.getHostProperties().setLocalhost(false);
+
+		assertEquals(Optional.empty(), osCommandExtension.checkProtocol(telemetryManager));
+	}
+
+	@Test
 	void testCheckSshNoHealthWhenNoConfiguration() {
 		// Create a telemetry manager without configuration.
 		final TelemetryManager telemetryManager = createTelemetryManagerWithoutConfig();

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -449,7 +449,9 @@ class OsCommandExtensionTest {
 			)
 			.build();
 		telemetryManager.getHostProperties().setLocalhost(true);
-		telemetryManager.getHostProperties().setMustCheckOsCommandStatus(true);
+
+		// The check is reported as OS Command, never as SSH
+		assertEquals(OsCommandExtension.OS_COMMAND_IDENTIFIER, osCommandExtension.getIdentifier(telemetryManager));
 
 		doReturn(SUCCESS_RESPONSE).when(osCommandService).runLocalCommand(anyString(), anyLong(), any());
 
@@ -469,8 +471,14 @@ class OsCommandExtensionTest {
 	}
 
 	@Test
-	void testCheckOsCommandNoHealthWhenNotExplicitlyRequested() {
-		// Create a telemetry manager holding an OS Command configuration only, no SSH.
+	void testGetIdentifierFollowsTheCheckedProtocol() {
+		// An SSH configuration means checkProtocol runs the SSH check
+		assertEquals(
+			OsCommandExtension.SSH_IDENTIFIER,
+			osCommandExtension.getIdentifier(createTelemetryManagerWithSshConfig())
+		);
+
+		// Without it, checkProtocol runs the local OS command check
 		setup();
 		final TelemetryManager telemetryManager = TelemetryManager.builder()
 			.monitors(monitors)
@@ -482,11 +490,8 @@ class OsCommandExtensionTest {
 					.build()
 			)
 			.build();
-		telemetryManager.getHostProperties().setLocalhost(true);
-		telemetryManager.getHostProperties().setMustCheckSshStatus(true);
 
-		// The collect strategy never asks for the OS Command check: its metric would be labelled as SSH
-		assertEquals(Optional.empty(), osCommandExtension.checkProtocol(telemetryManager));
+		assertEquals(OsCommandExtension.OS_COMMAND_IDENTIFIER, osCommandExtension.getIdentifier(telemetryManager));
 	}
 
 	@Test

--- a/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
+++ b/metricshub-oscommand-extension/src/test/java/org/metricshub/extension/oscommand/OsCommandExtensionTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
@@ -443,15 +444,19 @@ class OsCommandExtensionTest {
 				HostConfiguration.builder()
 					.hostId(LOCALHOST)
 					.hostname(LOCALHOST)
-					.configurations(Map.of(OsCommandConfiguration.class, OsCommandConfiguration.builder().build()))
+					.configurations(Map.of(OsCommandConfiguration.class, OsCommandConfiguration.builder().timeout(5L).build()))
 					.build()
 			)
 			.build();
 		telemetryManager.getHostProperties().setLocalhost(true);
+		telemetryManager.getHostProperties().setMustCheckOsCommandStatus(true);
 
 		doReturn(SUCCESS_RESPONSE).when(osCommandService).runLocalCommand(anyString(), anyLong(), any());
 
 		assertTrue(osCommandExtension.checkProtocol(telemetryManager).get());
+
+		// The configured timeout is granted to the test command, not the default one
+		verify(osCommandService).runLocalCommand(OsCommandExtension.SSH_TEST_COMMAND, 5L, null);
 
 		doReturn(null).when(osCommandService).runLocalCommand(anyString(), anyLong(), any());
 
@@ -460,6 +465,27 @@ class OsCommandExtensionTest {
 		// OS Command alone never reaches a remote host: nothing to check.
 		telemetryManager.getHostProperties().setLocalhost(false);
 
+		assertEquals(Optional.empty(), osCommandExtension.checkProtocol(telemetryManager));
+	}
+
+	@Test
+	void testCheckOsCommandNoHealthWhenNotExplicitlyRequested() {
+		// Create a telemetry manager holding an OS Command configuration only, no SSH.
+		setup();
+		final TelemetryManager telemetryManager = TelemetryManager.builder()
+			.monitors(monitors)
+			.hostConfiguration(
+				HostConfiguration.builder()
+					.hostId(LOCALHOST)
+					.hostname(LOCALHOST)
+					.configurations(Map.of(OsCommandConfiguration.class, OsCommandConfiguration.builder().build()))
+					.build()
+			)
+			.build();
+		telemetryManager.getHostProperties().setLocalhost(true);
+		telemetryManager.getHostProperties().setMustCheckSshStatus(true);
+
+		// The collect strategy never asks for the OS Command check: its metric would be labelled as SSH
 		assertEquals(Optional.empty(), osCommandExtension.checkProtocol(telemetryManager));
 	}
 


### PR DESCRIPTION
Closes #1344

A localhost resource configured only with OS Command previously failed the guided configuration connection test because the shared SSH/OS Command extension returned no health result. This PR tests local command execution using the OS Command timeout and reports the result during collection.

## Behavior

- OS Command-only local resources report `metricshub.host.up{protocol="oscommand"}` and contribute to `metricshub.host.observed=1` when the check succeeds. A local shell test does not establish a remote host's health.
- UI and MCP checks validate that the configuration matches the requested protocol before execution. An OS Command configuration cannot satisfy an SSH request merely because both protocols share an extension; converted candidates are validated too.
- SSH-configured local resources retain the local execution optimization used by collection. Their check does not certify the SSH daemon or credentials.
- The MCP tool and protocol parameter descriptions advertise `oscommand` for checks on the machine running MetricsHub, including `localhost`, loopback addresses, and hostnames/IP addresses resolving to that machine.
- The README's MCP Server and File log capture details move to `TECHNICAL_NOTES.md`, alongside OS Command/SSH health-check behavior, metrics, and timeout semantics. The README links to the notes after License.

## Validation

- Agent: `mvn prettier:write`, `mvn license:check-file-header`, `mvn checkstyle:check`, and `mvn verify`.
- 23 focused protocol tests passed; the full agent suite runs 756 tests with zero failures/errors and three skips.
- Regression coverage includes mismatched UI/MCP configurations, matching selection with both protocols configured, preserved localhost SSH execution, local command failures, and OS Command collection labels/observed metrics.
- The full reactor package build passed. Agent verification includes coverage checks and was rerun after the final MCP description edits.
- No frontend source changes; the reactor build also passed frontend formatting, lint, build, and tests.

## Before 
<img width="2164" height="1073" alt="image" src="https://github.com/user-attachments/assets/b2080eda-1852-495c-8974-55dee8687c6d" />
<img width="1988" height="891" alt="image" src="https://github.com/user-attachments/assets/3616d8ce-2f94-4d49-899d-b5690eebb823" />

## Now
<img width="2195" height="953" alt="image" src="https://github.com/user-attachments/assets/b6446774-fe28-4e45-a8f6-8d87c394eeb2" />
<img width="1871" height="977" alt="image" src="https://github.com/user-attachments/assets/a753ce33-75d8-4cfd-ae23-411bc41b911f" />

